### PR TITLE
Adding ddb-react assets to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,21 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "danskernesdigitalebibliotek/ddb-react",
+                "version": "2.4.0",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://github.com/danskernesdigitalebibliotek/ddb-react/releases/download/2.4.0/dist.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "^1.2.0"
+                }
+            }
         }
     ],
     "require": {
@@ -22,7 +37,8 @@
         "drupal/core-project-message": "9.1.7",
         "drupal/core-recommended": "9.1.7",
         "drush/drush": "10.4.3",
-        "zaporylie/composer-drupal-optimizations": "1.2.0"
+        "zaporylie/composer-drupal-optimizations": "1.2.0",
+        "danskernesdigitalebibliotek/ddb-react": "2.4.0"
     },
     "require-dev": {
         "drupal/core-dev-pinned": "9.1.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0a5f1eb8d61556f4f25f229e1e2ae89",
+    "content-hash": "4702480cf5bf01e1b65687607f30d3ed",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -380,16 +380,16 @@
         },
         {
             "name": "consolidation/annotated-command",
-            "version": "4.2.4",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "ec297e05cb86557671c2d6cbb1bebba6c7ae2c60"
+                "reference": "386d2c9253675bbb4b7f04c6bc52f8e74c0d4cc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/ec297e05cb86557671c2d6cbb1bebba6c7ae2c60",
-                "reference": "ec297e05cb86557671c2d6cbb1bebba6c7ae2c60",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/386d2c9253675bbb4b7f04c6bc52f8e74c0d4cc6",
+                "reference": "386d2c9253675bbb4b7f04c6bc52f8e74c0d4cc6",
                 "shasum": ""
             },
             "require": {
@@ -401,7 +401,7 @@
                 "symfony/finder": "^4.4.8|^5"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=7.5.20",
+                "phpunit/phpunit": "^7.5.20 || ^8 || ^9",
                 "squizlabs/php_codesniffer": "^3",
                 "yoast/phpunit-polyfills": "^0.2.0"
             },
@@ -427,7 +427,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2020-12-10T16:56:39+00:00"
+            "time": "2021-08-30T03:50:47+00:00"
         },
         {
             "name": "consolidation/config",
@@ -1010,6 +1010,18 @@
             ],
             "description": "Provides a way to patch Composer packages.",
             "time": "2020-09-30T17:56:20+00:00"
+        },
+        {
+            "name": "danskernesdigitalebibliotek/ddb-react",
+            "version": "2.4.0",
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/danskernesdigitalebibliotek/ddb-react/releases/download/2.4.0/dist.zip"
+            },
+            "require": {
+                "composer/installers": "^1.2.0"
+            },
+            "type": "drupal-library"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",


### PR DESCRIPTION
This shows how we can pull ddb-react.
Right now it is saved into:
```
web
├── libraries
│   └── ddb-react
```

An example of how it is integrated in Drupal will follow.
And it could be that the path to ddb-react changes as we get wiser.

Issue:
https://reload.atlassian.com/browse/DDFDPDEL-83