### PR TITLE
Have the php-service depend on a healthy mariadb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,9 @@ services:
 
   php:
     image: uselagoon/php-7.4-fpm:latest
+    depends_on:
+      mariadb:
+        condition: service_healthy
     volumes:
       - 'projectroot:/app'
     environment:
@@ -53,6 +56,11 @@ services:
     image: uselagoon/mariadb-drupal:latest
     labels:
       lagoon.type: mariadb
+    # Do a periodic healthcheck. This is mainly used to block the php service
+    # from starting up before we have a healthy database.
+    healthcheck:
+      test: "/usr/share/container-scripts/mysql/readiness-probe.sh"
+      interval: 10s
     ports:
       - "3306" # exposes the port 3306 with a random local port, find it with `docker-compose port mariadb 3306`
 


### PR DESCRIPTION
#### What does this PR do?
By adding a healthcheck to the mariadb docker-compose service and a
depends_on we can ensure a docker-compose up does not allow the php-
service to start before the database is ready.

This protects us from situations where we boot quickly enough to have
a drupal site-install hit a not fully booted mariadb.

#### Should this be tested by the reviewer and how?
Do a `task dev:reset` have eg. a `watch -n 1 docker compose ps` running alongside it. Watch carefully and check whether the php service is allowed to start up before mariadb is marked as healthy.

