### PR TITLE
Implement deployment status for Lagoon environments

### DIFF
--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -13,20 +13,26 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' }}
     steps:
+      - name: Generate environment data
+        id: environment
+        run: |
+          echo ::set-output name=id::pr-${{github.event.number}}
+          echo ::set-output name=url::'https://varnish.pr-${{github.event.number}}.${{ env.LAGOON_PROJECT }}.${{ env.LAGOON_HOST }}/'
+          echo ::set-output name=logs::'https://ui.lagoon.${{ env.LAGOON_HOST }}/projects/${{ env.LAGOON_PROJECT }}/${{ env.LAGOON_PROJECT }}-pr-${{github.event.number}}/deployments'
       - name: Start deployment
         uses: bobheadxi/deployments@v0.6.1
         id: deployment
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: "pr-${{github.event.number}}"
+          env: ${{ steps.environment.outputs.id }}
           ref: ${{ github.head_ref }}
-          logs: "https://ui.lagoon.${{ env.LAGOON_HOST }}/projects/${{ env.LAGOON_PROJECT }}/${{ env.LAGOON_PROJECT }}-pr-${{github.event.number}}/deployments"
+          logs: ${{ steps.environment.outputs.logs }}
           log_args: true
       - name: Wait for environment to become available
         uses: nev7n/wait_for_response@v1
         with:
-          url: 'https://varnish.pr-${{github.event.number}}.${{ env.LAGOON_PROJECT }}.${{ env.LAGOON_HOST }}/'
+          url: ${{ steps.environment.outputs.url }}
           responseCode: 200
           # Time in ms. Wait for 15 mins for deployment to complete. We have
           # seen deployments taking up to 12 mins.
@@ -44,8 +50,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: 'https://varnish.pr-${{github.event.number}}.${{ env.LAGOON_PROJECT }}.${{ env.LAGOON_HOST }}/'
-          logs: "https://ui.lagoon.${{ env.LAGOON_HOST }}/projects/${{ env.LAGOON_PROJECT }}/${{ env.LAGOON_PROJECT }}-pr-${{github.event.number}}/deployments"
+          env_url: ${{ steps.environment.outputs.url }}
+          logs: ${{ steps.environment.outputs.logs }}
           log_args: true
 
   CloseEnvironment:
@@ -53,10 +59,14 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.action == 'closed' }}
     steps:
+      - name: Generate environment data
+        id: environment
+        run: |
+          echo ::set-output name=id::pr-${{github.event.number}}
       - name: Close environment
         uses: bobheadxi/deployments@v0.6.1
         with:
           step: deactivate-env
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: "pr-${{github.event.number}}"
+          env: ${{ steps.environment.outputs.id }}
           log_args: true


### PR DESCRIPTION
#### What does this PR do?

Lagoon does not have native integration which will show the url for
a PR environment in GitHub. However this is quite useful for
development and testing.

Implement a GitHub Actions workflow to create a primitive
integration.

When a pull request is created or updated we know what the url for
the corresponding environment will be and start a deployment on 
GitHub linked to the head of the pull request branch. Then we can 
poll the HTTP status for the site url. When it is 200 we assume that
the deployment is complete and we can finalize the deployment.

When the pull request is closed Lagoon will shut down the
corresponding environment and we can close the deployment
correspondingly.

The workflow is stringed together by two actions. Both were chosen
based on the fact that they had the most stars within their domain.

#### Should this be tested by the reviewer and how?

1. See that this PR has created a deployment which is visible on the PR page.
2. The deployment should link to the corresponding environment on Lagoon.
3. See that [closing a PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/64) with the same changes will mark the corresponding deployment as inactive