### PR TITLE
Add Safe to manage native functions returning false for errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
         "drupal/redis": "^1.5",
         "drupal/varnish_purge": "^2.1",
         "drush/drush": "10.4.3",
+        "thecodingmachine/safe": "^1.3",
         "zaporylie/composer-drupal-optimizations": "1.2.0"
     },
     "require-dev": {
@@ -74,6 +75,7 @@
         "friends-of-behat/mink-debug-extension": "^2.0",
         "mglaman/phpstan-drupal": "^0.12.15",
         "phpstan/extension-installer": "^1.1",
+        "thecodingmachine/phpstan-safe-rule": "^1.0",
         "vpx/behat-wiremock-extension": "dev-master"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16da8f89d07e4699cb6c16366dfd6521",
+    "content-hash": "9d28e18dc746e44168d2c9b266dc32bc",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -7515,6 +7515,145 @@
             "time": "2021-05-26T17:39:37+00:00"
         },
         {
+            "name": "thecodingmachine/safe",
+            "version": "v1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
+                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12",
+                "squizlabs/php_codesniffer": "^3.2",
+                "thecodingmachine/phpstan-strict-rules": "^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Safe\\": [
+                        "lib/",
+                        "deprecated/",
+                        "generated/"
+                    ]
+                },
+                "files": [
+                    "deprecated/apc.php",
+                    "deprecated/libevent.php",
+                    "deprecated/mssql.php",
+                    "deprecated/stats.php",
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/ingres-ii.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/msql.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/mysqlndMs.php",
+                    "generated/mysqlndQc.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/password.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pdf.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/simplexml.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v1.3.3"
+            },
+            "time": "2020-10-28T17:51:34+00:00"
+        },
+        {
             "name": "twig/twig",
             "version": "v2.14.6",
             "source": {
@@ -12223,6 +12362,63 @@
                 "source": "https://github.com/Textalk/websocket-php/tree/1.5.5"
             },
             "time": "2021-08-07T10:21:40+00:00"
+        },
+        {
+            "name": "thecodingmachine/phpstan-safe-rule",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/phpstan-safe-rule.git",
+                "reference": "1a1ae26c29011d2d48636353ecadf7fc40997401"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/phpstan-safe-rule/zipball/1a1ae26c29011d2d48636353ecadf7fc40997401",
+                "reference": "1a1ae26c29011d2d48636353ecadf7fc40997401",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": "^0.10 | ^0.11 | ^0.12",
+                "thecodingmachine/safe": "^1.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^7.5.2",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "phpstan-safe-rule.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TheCodingMachine\\Safe\\PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Négrier",
+                    "email": "d.negrier@thecodingmachine.com"
+                }
+            ],
+            "description": "A PHPStan rule to detect safety issues. Must be used in conjunction with thecodingmachine/safe",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/phpstan-safe-rule/issues",
+                "source": "https://github.com/thecodingmachine/phpstan-safe-rule/tree/v1.0.1"
+            },
+            "time": "2020-08-30T11:41:12+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/behat/context/AdgangsplatformenContext.php
+++ b/tests/behat/context/AdgangsplatformenContext.php
@@ -7,6 +7,8 @@ use Drupal\DrupalExtension\MinkAwareTrait;
 use VPX\WiremockExtension\Context\WiremockAware;
 use VPX\WiremockExtension\Context\WiremockAwareInterface;
 use WireMock\Client\WireMock;
+use function Safe\json_encode as json_encode;
+use function Safe\preg_match as preg_match;
 
 // Ignore short comment requirement. @Given and @Then should provide the same.
 // phpcs:disable Drupal.Commenting.DocComment.MissingShort
@@ -68,7 +70,7 @@ class AdgangsplatformenContext implements MinkAwareContext, WiremockAwareInterfa
             "access_token" => $access_token,
             "token_type" => "Bearer",
             "expires_in" => 2591999,
-          ]) ?: "")
+          ]))
         )
     );
 
@@ -84,7 +86,7 @@ class AdgangsplatformenContext implements MinkAwareContext, WiremockAwareInterfa
             'attributes' => [
               'uniqueId' => $user_guid,
             ],
-          ]) ?: "")
+          ]))
         )
     );
 

--- a/web/modules/custom/ddb_react/ddb_react.module
+++ b/web/modules/custom/ddb_react/ddb_react.module
@@ -10,6 +10,8 @@
 
 use Drupal\Component\Serialization\Json;
 use Drupal\ddb_react\DdbReactInterface;
+use function Safe\file_get_contents as file_get_contents;
+use function Safe\sprintf as sprintf;
 
 /**
  * Implements hook_library_info_alter().

--- a/web/modules/custom/ddb_react/src/Controller/DdbReactController.php
+++ b/web/modules/custom/ddb_react/src/Controller/DdbReactController.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Drupal\dpl_library_token\LibraryTokenHandler;
 use Drupal\dpl_login\UserTokensProvider;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use function Safe\sprintf as sprintf;
 
 /**
  * DDB React Controller.

--- a/web/modules/custom/dpl_library_token/src/LibraryToken.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryToken.php
@@ -3,6 +3,7 @@
 namespace Drupal\dpl_library_token;
 
 use Drupal\dpl_library_token\Exception\LibraryTokenResponseException;
+use function Safe\json_decode as json_decode;
 
 /**
  * Library Token.
@@ -34,8 +35,11 @@ class LibraryToken {
    */
   public static function createFromResponseBody(string $response_body): self {
     // Get token data by decoding json.
-    if (!$token_data = json_decode($response_body, TRUE)) {
-      throw new LibraryTokenResponseException('Could not decode library token response');
+    try {
+      $token_data = json_decode($response_body, TRUE);
+    }
+    catch (\JsonException $e) {
+      throw new LibraryTokenResponseException('Could not decode library token response', $e);
     }
     if (empty($token_data['access_token'])) {
       throw new LibraryTokenResponseException('Access token is missing');

--- a/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
@@ -9,6 +9,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
 use Drupal\dpl_library_token\Exception\MissingConfigurationException;
+use function Safe\sprintf as sprintf;
 
 /**
  * Library Token Handler Service.

--- a/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
+++ b/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
@@ -93,7 +93,7 @@ class LibraryTokenHandlerTest extends UnitTestCase {
       '@message. Details: @error_message',
       [
         '@message' => 'Could not retrieve library token',
-        '@error_message' => 'Could not decode library token response',
+        '@error_message' => 'Syntax error',
       ]
     )->shouldBeCalledTimes(1);
     $logger_factory = $this->prophesize(LoggerChannelFactoryInterface::class);

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -12,6 +12,7 @@ use Drupal\dpl_login\AccessToken;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\dpl_login\DplLoginInterface;
 use Drupal\user\UserInterface;
+use function Safe\sprintf as sprintf;
 
 /**
  * Implements hook_openid_connect_userinfo_alter().


### PR DESCRIPTION
#### What does this PR do?

Safe implementations throw exceptions instead. Exceptions will 
normally bubble up and result in an error page we prefer this 
compared to juggling types at every corner.

In most situations these functions will never return false. If there
are situations where they might e.g. when decoding JSON from an
external source exceptions are a neat way to handle this.  

This means that we can import Safe functions where needed. In some
situations this also allows us to simplify our code a bit.

To ease Safe adoption we add the corresponding PHPStan rule.