### PR TITLE
Add SimpleTest database configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,7 @@
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
     <env name="SIMPLETEST_BASE_URL" value=""/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
-    <env name="SIMPLETEST_DB" value=""/>
+    <env name="SIMPLETEST_DB" value="sqlite://tmp/test.sqlite"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
     <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
     <!-- To have browsertest output use an alternative base URL. For example if


### PR DESCRIPTION
#### What does this PR do?

Add SimpleTest database configuration

This makes it possible to run Drupal kernel tests which need a
database.

Using a SQLite database in the /tmp directory is a simple solution
which does not require any additional setup. 

#### Should this be tested by the reviewer and how?

I found it helpful when running kernel tests from a contrib module e.g.

`vendor/bin/phpunit  web/modules/contrib/config_ignore/tests/src/Kernel/IgnoreKernelTest.php`
