### PR TITLE
Remove cli containers after completing a task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,7 +46,7 @@ tasks:
   dev:cli:
     summary: Performs command inside container. Expects parameter(s).
     cmds:
-      - docker compose {{ .DOCKER_COMPOSE_FILES }} run cli sh -c "{{.CLI_ARGS}}"
+      - docker compose {{ .DOCKER_COMPOSE_FILES }} run --rm cli sh -c "{{.CLI_ARGS}}"
 
   dev:start:
     summary: Run docker compose


### PR DESCRIPTION
#### What does this PR do?

Remove cli containers after completing a task

There is no reason for us to have these lingering until someone runs
dev:stop.

#### Should this be tested by the reviewer and how?

- Run `task dev:cli -- drush status` (or some other CLI tool with a no-op` - preferably multiple times
- Run `task dev:reset`
- See that only a single cli container is removed