### PR TITLE
Wait for page to be loaded before checking Hello World component

### DIFF
--- a/tests/behat/context/ReactContext.php
+++ b/tests/behat/context/ReactContext.php
@@ -43,4 +43,14 @@ class ReactContext implements MinkAwareContext {
     }
   }
 
+  /**
+   * @Then I wait for components to render
+   */
+  public function waitForComponentsToRender(): void {
+    // This is a rather simplistic way to ensure that React componets have
+    // had a chance to load and render but it should work for simple situations
+    // which is what we need at the moment.
+    $this->getMink()->getSession()->wait(1000);
+  }
+
 }

--- a/tests/behat/features/30-react-components.feature
+++ b/tests/behat/features/30-react-components.feature
@@ -15,4 +15,5 @@ Feature: React components
   Scenario: Hello World is shown
     Given I enable modules "dpl_react, dpl_react_demo"
     And I go to "/react-dpl-demo"
-    And I should see "Hello World"
+    And I wait for components to render
+    Then I should see "Hello World"


### PR DESCRIPTION
On GitHub Actions the text from the Hello World component is not
available when checking for it. This causes the test to fail.
The logs show that the text is not available in the DOM but the
screenshot actually contain the text. The tests also pass locally.

The error may be caused by timing issues so try to wait for the page
to settle before testing.