### PR TITLE
Use release/1 build of dpl-react

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
             "type": "package",
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-react",
-                "version": "0.1.0",
+                "version": "0.1.1",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/0.1.0/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F1/dist.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -49,7 +49,7 @@
         "amazeeio/drupal_integrations": "0.3.5",
         "composer/installers": "1.11.0",
         "cweagans/composer-patches": "1.7.0",
-        "danskernesdigitalebibliotek/dpl-react": "0.1.0",
+        "danskernesdigitalebibliotek/dpl-react": "0.1.1",
         "danskernesdigitalebibliotek/dpl-design-system": "^1.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "drupal/config_ignore": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
             "type": "package",
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-react",
-                "version": "0.1.1",
+                "version": "0.1.0",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F1/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-fix%2Fsearch-bar/dist.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -33,9 +33,9 @@
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-design-system",
                 "type": "drupal-library",
-                "version": "v1.0.2",
+                "version": "v1.0.3",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/v1.0.2/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-release%2F1/dist.zip",
                     "type": "zip"
                 }
             }
@@ -49,8 +49,8 @@
         "amazeeio/drupal_integrations": "0.3.5",
         "composer/installers": "1.11.0",
         "cweagans/composer-patches": "1.7.0",
-        "danskernesdigitalebibliotek/dpl-react": "0.1.1",
         "danskernesdigitalebibliotek/dpl-design-system": "^1.0",
+        "danskernesdigitalebibliotek/dpl-react": "^0.1.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "drupal/config_ignore": "^2.3",
         "drupal/core-project-message": "^9.2.7",

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
             "type": "package",
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-react",
-                "version": "0.1.0",
+                "version": "0.2.0",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F1/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/0.2.0-rc.1/dist.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -33,9 +33,9 @@
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-design-system",
                 "type": "drupal-library",
-                "version": "v1.0.3",
+                "version": "v1.1.0",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-release%2F1/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/v1.1.0-rc.1/dist.zip",
                     "type": "zip"
                 }
             }
@@ -49,8 +49,8 @@
         "amazeeio/drupal_integrations": "0.3.5",
         "composer/installers": "1.11.0",
         "cweagans/composer-patches": "1.7.0",
-        "danskernesdigitalebibliotek/dpl-design-system": "^1.0",
-        "danskernesdigitalebibliotek/dpl-react": "^0.1.0",
+        "danskernesdigitalebibliotek/dpl-design-system": "^1.1",
+        "danskernesdigitalebibliotek/dpl-react": "^0.2.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "drupal/config_ignore": "^2.3",
         "drupal/core-project-message": "^9.2.7",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
                 "version": "0.1.0",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-fix%2Fsearch-bar/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F1/dist.zip",
                     "type": "zip"
                 },
                 "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2f9280e9b98e4af17e4606f6622318d",
+    "content-hash": "2d067c78c0e20f45261019ac9f05a38e",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1086,10 +1086,10 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-react",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/0.1.0/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F1/dist.zip"
             },
             "require": {
                 "composer/installers": "^1.2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d067c78c0e20f45261019ac9f05a38e",
+    "content-hash": "b424eab76c9875e9bdf401433c01c3d4",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1077,19 +1077,19 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-design-system",
-            "version": "v1.0.2",
+            "version": "v1.0.3",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/v1.0.2/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-release%2F1/dist.zip"
             },
             "type": "drupal-library"
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-react",
-            "version": "0.1.1",
+            "version": "0.1.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F1/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-fix%2Fsearch-bar/dist.zip"
             },
             "require": {
                 "composer/installers": "^1.2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70123ec560ddbf39834ea8fa564f2601",
+    "content-hash": "330c78fdb39c766a04a79f1d8b5752f4",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1077,19 +1077,19 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-design-system",
-            "version": "v1.0.3",
+            "version": "v1.1.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-release%2F1/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/v1.1.0-rc.1/dist.zip"
             },
             "type": "drupal-library"
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-react",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F1/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/0.2.0-rc.1/dist.zip"
             },
             "require": {
                 "composer/installers": "^1.2.0"
@@ -13019,5 +13019,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b424eab76c9875e9bdf401433c01c3d4",
+    "content-hash": "70123ec560ddbf39834ea8fa564f2601",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1089,7 +1089,7 @@
             "version": "0.1.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-fix%2Fsearch-bar/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F1/dist.zip"
             },
             "require": {
                 "composer/installers": "^1.2.0"

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -6,6 +6,7 @@ module:
   dpl_library_token: 0
   dpl_login: 0
   dpl_mapp: 0
+  dpl_react: 0
   dynamic_page_cache: 0
   field: 0
   file: 0

--- a/web/modules/custom/dpl_react/dpl_react.libraries.yml
+++ b/web/modules/custom/dpl_react/dpl_react.libraries.yml
@@ -11,6 +11,18 @@ hello-world:
     - dpl_react/base
     - dpl_react/handler
 
+search-header:
+  remote: https://github.com/danskernesdigitalebibliotek/dpl-react
+  license:
+    name: GNU GPL
+    url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
+    gpl-compatible: true
+  js:
+    /libraries/dpl-react/search-header.js: {}
+  dependencies:
+    - dpl_react/base
+    - dpl_react/handler
+
 base:
   remote: https://github.com/danskernesdigitalebibliotek/dpl-react
   license:

--- a/web/themes/custom/novel/novel.info.yml
+++ b/web/themes/custom/novel/novel.info.yml
@@ -3,6 +3,8 @@ type: theme
 base theme: stable9
 description: 'Custom theme for the Danish Public Libraries'
 core_version_requirement: ^8 || ^9
+dependencies:
+  - dpl_react:dpl_react
 
 libraries:
   - novel/base

--- a/web/themes/custom/novel/novel.info.yml
+++ b/web/themes/custom/novel/novel.info.yml
@@ -3,8 +3,17 @@ type: theme
 base theme: stable9
 description: 'Custom theme for the Danish Public Libraries'
 core_version_requirement: ^8 || ^9
-dependencies:
-  - dpl_react:dpl_react
+
+# We want to add dpl_react as a module dependency
+# but we get an error upon theme install.
+# Apparently others are getting same error since there is
+# an issue about it:
+# https://www.drupal.org/project/drupal/is-sues/3176625
+# But no seemingly stable patch is created at this point.
+# When a proper fix has been created we can uncomment the
+# "dependencies" block.
+# dependencies:
+#   - dpl_react:dpl_react
 
 libraries:
   - novel/base

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -20,3 +20,21 @@ function novel_preprocess_page(array &$variables): void {
 
   $variables['search_header'] = dpl_react_render('search-header', $data);
 }
+
+/**
+ * Implements hook_page_attachments()
+ *
+ * @param mixed[] $page
+ *   Drupal render array.
+ */
+function novel_page_attachments(array &$page): void {
+  $metatag = [
+    '#tag' => 'meta',
+    '#attributes' => [
+      'name' => 'description',
+      'content' => t('This is the meta description of the DPL CMS site'),
+    ],
+  ];
+
+  $page['#attached']['html_head'][] = [$metatag, 'description'];
+}

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Novel Theme.
+ */
+
+/**
+ * Implements template_preprocess_page().
+ *
+ * @param mixed[] $variables
+ *   Theme variables.
+ */
+function novel_preprocess_page(array &$variables): void {
+  $data = [
+    'search-header-url' => '/search',
+    'alt-text' => t('Search field'),
+    'input-placeholder' => t('Start typing in order to search'),
+  ];
+
+  $variables['search_header'] = dpl_react_render('search-header', $data);
+}

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -13,28 +13,13 @@
  */
 function novel_preprocess_page(array &$variables): void {
   $data = [
+    // @todo Something Insert the right search result page url when it is ready.
     'search-header-url' => '/search',
-    'alt-text' => t('Search field'),
-    'input-placeholder' => t('Start typing in order to search'),
+    'alt-text' => t('Search field', [], ['context' => 'Search Header']),
+    'input-placeholder' => t('Start typing in order to search', [], ['context' => 'Search Header']),
   ];
 
-  $variables['search_header'] = dpl_react_render('search-header', $data);
-}
-
-/**
- * Implements hook_page_attachments()
- *
- * @param mixed[] $page
- *   Drupal render array.
- */
-function novel_page_attachments(array &$page): void {
-  $metatag = [
-    '#tag' => 'meta',
-    '#attributes' => [
-      'name' => 'description',
-      'content' => t('This is the meta description of the DPL CMS site'),
-    ],
+  $variables['search'] = [
+    'header' => dpl_react_render('search-header', $data),
   ];
-
-  $page['#attached']['html_head'][] = [$metatag, 'description'];
 }

--- a/web/themes/custom/novel/templates/layout/footer.html.twig
+++ b/web/themes/custom/novel/templates/layout/footer.html.twig
@@ -1,35 +1,35 @@
 <footer class="footer">
   <h2 class="hide-visually">Globale links</h2>
-  <div class="footer--mobile">
-    <div class="pagefold-parent-small internal-pagefold-parent">
-      <div class="pagefold-triangle-small pagefold-inherit-parent"></div>
+  <div class="footer__mobile">
+    <div class="pagefold-parent--small internal-pagefold-parent">
+      <div class="pagefold-triangle--small pagefold-inherit-parent"></div>
       <div>
         <h3 class="text-header-h4 mb-16">Åbningstider</h3>
         <p class="text-body-medium-regular mb-24">
           Bibliotekerne lorem ipsum consectetur, adipisci velit, sed quia non
           numquam eius modi tempora incidunt ut labore.
         </p>
-        <div class="footer-column--link mb-48">
+        <div class="footer__column-link mb-48">
           <a href="/" class="link-tag">Se bibliotekernes åbningstider</a>
         </div>
       </div>
       <ul class="accordion">
-        <li class="accordion-row">
-          <h3 class="accordion-header text-header-h4">
+        <li class="accordion__row">
+          <h3 class="accordion__header text-header-h4">
             <button
-              class="accordion-button px-48"
+              class="accordion__button px-48"
               aria-expanded="false"
               data-accordion-trigger="true"
             >
               Om Bibliotekerne
               <img
-                class="accordion-button--arrow"
-                src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
+                class="accordion__button-arrow"
+                src="icons/basic/icon-triangle.svg"
                 alt=""
               />
             </button>
           </h3>
-          <div hidden="" class="accordion-body pt-16 pb-32">
+          <div hidden="" class="accordion__body pt-16 pb-32">
             <a href="/">Brug bibliotekerne</a>
             <a href="/">Erstatninger og gebyrer</a>
             <a href="/">Opret bruger</a>
@@ -40,22 +40,22 @@
             <a href="/">Nyhedsbrev</a>
           </div>
         </li>
-        <li class="accordion-row">
-          <h3 class="accordion-header text-header-h4">
+        <li class="accordion__row">
+          <h3 class="accordion__header text-header-h4">
             <button
-              class="accordion-button px-48"
+              class="accordion__button px-48"
               aria-expanded="false"
               data-accordion-trigger="true"
             >
               Online tilbud
               <img
-                class="accordion-button--arrow"
+                class="accordion__button-arrow"
                 src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
                 alt=""
               />
             </button>
           </h3>
-          <div hidden="" class="accordion-body pt-16 pb-32">
+          <div hidden="" class="accordion__body pt-16 pb-32">
             <a href="/">Brug bibliotekerne</a>
             <a href="/">Erstatninger og gebyrer</a>
             <a href="/">Opret bruger</a>
@@ -66,22 +66,22 @@
             <a href="/">Nyhedsbrev</a>
           </div>
         </li>
-        <li class="accordion-row">
-          <h3 class="accordion-header text-header-h4">
+        <li class="accordion__row">
+          <h3 class="accordion__header text-header-h4">
             <button
-              class="accordion-button px-48"
+              class="accordion__button px-48"
               aria-expanded="false"
               data-accordion-trigger="true"
             >
               Kontakt
               <img
-                class="accordion-button--arrow"
+                class="accordion__button-arrow"
                 src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
                 alt=""
               />
             </button>
           </h3>
-          <div hidden="" class="accordion-body pt-16 pb-32">
+          <div hidden="" class="accordion__body pt-16 pb-32">
             <a href="/">Brug bibliotekerne</a>
             <a href="/">Erstatninger og gebyrer</a>
             <a href="/">Opret bruger</a>
@@ -93,24 +93,26 @@
           </div>
         </li>
       </ul>
-      <div class="footer-widgets mt-48">
+      <div class="footer__widgets mt-48">
         <div class="dropdown">
-          <select class="dropdown-select" aria-label="dropdown">
-            <option class="dropdown-option" value="DK">DK</option>
-            <option class="dropdown-option" value="SEK">SEK</option>
-            <option class="dropdown-option" value="ENG">ENG</option>
+          <select class="dropdown__select" aria-label="dropdown">
+            <option class="dropdown__option" value="DK">DK</option>
+            <option class="dropdown__option" value="SEK">SEK</option>
+            <option class="dropdown__option" value="ENG">ENG</option>
           </select>
-          <div class="dropdown-arrows">
-            <img
-              class="dropdown-arrow--top"
-              src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
-              alt=""
-            />
-            <img
-              class="dropdown-arrow--bottom"
-              src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
-              alt=""
-            />
+          <div class="dropdown__arrows">
+            <span>
+              <img
+                class="dropdown__arrow"
+                src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
+                alt=""
+              />
+              <img
+                class="dropdown__arrow dropdown__arrow--bottom"
+                src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
+                alt=""
+              />
+            </span>
           </div>
         </div>
         <div>
@@ -121,25 +123,25 @@
           />
         </div>
       </div>
-      <div class="footer-separator mt-24"></div>
-      <div class="footer-site-info mt-24">
-        <div class="footer-site-info--links">
+      <div class="footer__separator mt-24"></div>
+      <div class="footer__site-info mt-24">
+        <div class="footer__site-info-links">
           <ul>
             <li>
-              <a href="/" class="footer-site-info--link">
+              <a href="" class="footer__site-info-link">
                 Behandling af persondata
               </a>
             </li>
             <li>
-              <a href="/" class="footer-site-info--link">Servicedeklaration</a>
+              <a href="/" class="footer__site-info-link">Servicedeklaration</a>
             </li>
-            <li><a href="/" class="footer-site-info--link">Relement</a></li>
+            <li><a href="/" class="footer__site-info-link">Relement</a></li>
             <li>
-              <a href="/" class="footer-site-info--link">Tilgængelighed</a>
+              <a href="/" class="footer__site-info-link">Tilgængelighed</a>
             </li>
           </ul>
         </div>
-        <div class="footer-site-info--icons mt-32">
+        <div class="footer__site-info-icons mt-32">
           <a href="/">
             <img
               src="/themes/custom/novel/assets/dpl-design-system/icons/social/icon-social-facebook.svg"
@@ -168,18 +170,18 @@
       </div>
     </div>
   </div>
-  <div class="footer--desktop">
-    <div class="pagefold-parent-medium internal-pagefold-parent">
-      <div class="pagefold-triangle-medium pagefold-inherit-parent"></div>
-      <div class="footer-column-wrapper">
-        <div class="footer-column">
+  <div class="footer__desktop">
+    <div class="pagefold-parent--medium internal-pagefold-parent">
+      <div class="pagefold-triangle--medium pagefold-inherit-parent"></div>
+      <div class="footer__column-wrapper">
+        <div class="footer__column">
           <h3 class="text-header-h4 mb-16">Åbningstider</h3>
-          <div class="footer-column">
+          <div class="footer__column">
             <p class="text-body-medium-regular">
               Bibliotekerne lorem ipsum consectetur, adipisci velit, sed quia
               non numquam eius modi tempora incidunt ut labore.
             </p>
-            <div class="footer-column--link">
+            <div class="footer__column-link">
               <a href="/" class="link-tag">Se bibliotekernes åbningstider</a>
             </div>
           </div>
@@ -230,7 +232,7 @@
             </li>
           </ul>
         </div>
-        <div class="footer-column">
+        <div class="footer__column">
           <h3 class="text-header-h4 mb-16">Kontakt</h3>
           <p class="text-body-medium-regular">
             Lyngby-Taarbæk Bibliotekerne
@@ -240,14 +242,14 @@
             2800 Kgs. Lyngby
             <br />
             <br />
-            <a class="footer-column--phone" href="tel:4545973700">
+            <a class="footer__column-phone" href="tel:4545973700">
               +45 45 97 37 00
             </a>
             <br />
             Man - fre / Kl. 10-16
             <br />
           </p>
-          <div class="footer-column--link">
+          <div class="footer__column-link">
             <a href="/" class="link-tag">info@ltk.dk</a>
           </div>
         </div>
@@ -303,24 +305,26 @@
           </ul>
         </div>
       </div>
-      <div class="footer-widgets mt-80">
+      <div class="footer__widgets mt-80">
         <div class="dropdown">
-          <select class="dropdown-select" aria-label="dropdown">
-            <option class="dropdown-option" value="DK">DK</option>
-            <option class="dropdown-option" value="SEK">SEK</option>
-            <option class="dropdown-option" value="ENG">ENG</option>
+          <select class="dropdown__select" aria-label="dropdown">
+            <option class="dropdown__option" value="DK">DK</option>
+            <option class="dropdown__option" value="SEK">SEK</option>
+            <option class="dropdown__option" value="ENG">ENG</option>
           </select>
-          <div class="dropdown-arrows">
-            <img
-              class="dropdown-arrow--top"
-              src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
-              alt=""
-            />
-            <img
-              class="dropdown-arrow--bottom"
-              src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
-              alt=""
-            />
+          <div class="dropdown__arrows">
+            <span>
+              <img
+                class="dropdown__arrow"
+                src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
+                alt=""
+              />
+              <img
+                class="dropdown__arrow dropdown__arrow--bottom"
+                src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
+                alt=""
+              />
+            </span>
           </div>
         </div>
         <div>
@@ -331,9 +335,9 @@
           />
         </div>
       </div>
-      <div class="footer-separator"></div>
-      <div class="footer-site-info">
-        <div class="footer-site-info--icons">
+      <div class="footer__separator"></div>
+      <div class="footer__site-info">
+        <div class="footer__site-info-icons">
           <a href="/">
             <img
               src="/themes/custom/novel/assets/dpl-design-system/icons/social/icon-social-facebook.svg"
@@ -359,13 +363,13 @@
             />
           </a>
         </div>
-        <div class="footer-site-info--links">
-          <a href="/" class="footer-site-info--link">
+        <div class="footer__site-info-links color-secondary-gray">
+          <a href="/" class="footer__site-info-link">
             Behandling af persondata
           </a>
-          <a href="/" class="footer-site-info--link">Servicedeklaration</a>
-          <a href="/" class="footer-site-info--link">Relement</a>
-          <a href="/" class="footer-site-info--link">Tilgængelighed</a>
+          <a href="/" class="footer__site-info-link">Servicedeklaration</a>
+          <a href="/" class="footer__site-info-link">Relement</a>
+          <a href="/" class="footer__site-info-link">Tilgængelighed</a>
         </div>
       </div>
     </div>

--- a/web/themes/custom/novel/templates/layout/footer.html.twig
+++ b/web/themes/custom/novel/templates/layout/footer.html.twig
@@ -24,7 +24,7 @@
               Om Bibliotekerne
               <img
                 class="accordion__button-arrow"
-                src="icons/basic/icon-triangle.svg"
+                src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg"
                 alt=""
               />
             </button>
@@ -128,7 +128,7 @@
         <div class="footer__site-info-links">
           <ul>
             <li>
-              <a href="" class="footer__site-info-link">
+              <a href="/" class="footer__site-info-link">
                 Behandling af persondata
               </a>
             </li>

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -1,150 +1,108 @@
-
-  <header class="header">
-    <div class="header__logo-desktop">
-      <a class="header__logo-desktop-link" href="/">
-        <div>
-          <img
-            class="logo"
-            src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAAgCAYAAAB6vRjLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAABRSSURBVHgB7VwLeFTVtV5r73POTCYJIQmBJJPwEBABkwBBRIEU6LXWZ20Rbq312U9vvbZWW7X1ai3tbdVWW+3Vttx+1Yp6tYK12l61eG1BRQEhkISHIGgSMpOEVzJhksnMeex91z7DxMwY8uBpSv/vO9+cs85+77XXXo99BoKs5GDXpZW+BMcIa2HizUll09XIS66EE4gGVvozVW+Anfn11Hf1vGRhvF2TH03QAlhSGdTKWgM5c4vgOIPq3lrPzmxYCqeNhFMcmgTITDwgYBocI+yFmF4EWmZ3mgOODicWHtU/h35TX2gguASWKZP7HKX0NoJAOO7AmAnS2gQRBqc4TvkB6A5DeheALqf6W95q6CvtznEXeOAo4Ah+sS6cWQ/DGQE4xaHBP9EFK9t7NaIxrHXEZfdl170UUrRaGO3VtKxbUcrLpJTDAbGGaez/ZF3wa80Z534+v/3dvYH8z8wjuXahw7R3WFt4snSc2SjZs78rsl65oSPrLqbpdXbbwVZwnMuJvqVIVN+rZfuujUrDe5f86GFog9bGvFlzpC0uRUdWyc7OGcSln5cITcC0J/yzsp7FVavsRDt3jhvn8XyUdjNDXARSDkXGXhZDfI1MQpEwxdPFHetqYBDhn0zYDTIUug45Gx8BrvTE0EqYqxnYskIKUaHe0x4tadLHSMv5AiK8vn9kKATbiN4Wni5j1u0M5b+BxExUCdFZFwq0DJGM3+4gxEjVEZQ7jeg+VZZoa7tRAGRFhfkEPbbCvrZpkuHtpA6Y9GzEGwSng2NVBNe0nkNPN7kkKbHRM3WJBOdaeognE+JObOvopHdpVPd7RBpUTHhKbMeaxC+TIfBY90sAXttXvtM9LRdIlBXEU7uNNO9U/70LNGTcNd5o+qdkBbIykjJINICzq1HIkbpgD378AjXg/BEh5DiScF/prU4EeVDTtfP8f/i+BoYxH5F1gC2vaTbKS9T7QFpphbSdKyjlPmboFf6//ZfOvWkXU4OiMEhxSkhC2tZm0s/M7jSU/bA9mF6hBJPweB4c3rG+KnC/eTEI+VlguJ1+J9iRcCmlWtVVpqE97Y9uejrxfCvk58UbIGv9Zta9CB9vqYdtK+Af82Ob3oBFi9TjyoBnyu/Acm6VjllOz5tRMyaCaXokk48XRje+DfPmqXSvBLTSN0DAQhiE6JEJa0fP9Xrq9o+xPcZ8zrBIGpouO6MH0YGNVmb26jGhVSE4CryfOSM307LLEOVZYOi5gvYltM1G0Wm9s7fcWzW9stKCYwiSWs8hir92p6Hk5bS33tJrvpjlSjq9YPiBuubyAohaj9J4POQgjiXT4ozUwZPC2dNjQZq2F82+GdBtl9qakwrFdvVj61wn9wKwSNQr3A2MdSalEzICgxRJ40iToge0su9g4MD1gsEZzLKYq3WQMyEhN/RwS4hW51KaxCV+s3I7DASSFwd46a8hElUKdW68bLurbEZKVUGVWRfQyx6NWvJ/xkHNXjgGIGVs3Shn61PdaUE+mTwk7JZ+5WeC66a1hOZ+h8jTHoL9zm/gJEFwTvwv4R8JyTqhkHNAiIekgEm0JnvWF8kao+3hW2BbbzV4p9wgSXmHfoKG727Kf5NiwJ5TkGyUMIb0pl94GawI6uXT4CQCde5KL7u+6TY1NjrXvuFvqoxQ+7PhZMHQ45KS4ekJkjsHiBNgkCKV0frNUCQ189B0fhs02n7Q/zwwAN+anEJ60NuNWukcOFmwnXfVD3PENMG1O4bHNu6ihTeX9t3PE7mFLILdcIKBHeFXiOH2o+1c2WCUvbAbJt/TyA+8RAvjbBikOHrr2LbvCepTbobjA58j5LKgp/SkrHLNK/5OP3GrU9qPBbSSRlp4K2k1aaDxJfmxDR/BCYYfPthPAuAaWtDNaIsFjLH/FBLPJZVmHwxS9CL5MIQcnyFrrVJoWoy24EIk3xS5H85MTUn+qcV1vokvjo683wT9hGSskibyfx0hdhq0FmgjLnFscSNJmaStjgY3n5TzR+j2AhggkGE9VbRG4zRBZkr9yEnfZGtQitrD5bfQmKw2YypnBTHexZQrQzLYyhEfLzh36KNddjHTguQGXEMVJkVaJkB6BJCvoa1zcw+NW0/qSeb0tAwbyMQQBjaCo9I6QVJiu0B68m5BZTAWZ7Lm0qvSAdo3OPtDc+We1lIBTgZyUSkd9h2aiKsxM82CozIbTzwwwEo+oeVKZCssTX7rtFjNjiQ6OUoD+pTvohA/osfkOLDBf18Urbo+8fhnOO3WaSz94R7qFILhd41c+E3+npqO7i/qfOUFmuU8QpGFRalN4oZ3XkF0/ZtwHEFjsZOiD2NgSNaYROguCOU+P1RG5MKFfM9bbd4RzSsiSCsGThICGdMvR9NeSh6mlf5zhl6mIinbh03ITA953lUCQni9M0ZG1q+HQYRPbseIf8/yaV9NZcD4K5TFdvUDFAW4J/UdRRGuOJBz9hDoCxo+UGxV/zyVARVGRyqbtJzh1xMjrE6tWljmVXAcEeQlb1G0oZgWWlTYVlfbFAO6DVi+3Mnf83rHyWRABY/fswJssZd2pouCq1tWB3nZExkhzwrFgLRr7dybJbbCIEMyEyLakhl3DQlX7u8tkyfb/DWFt7YlZZXg7WyLVkCvtbGd/lj1Pb1NpJpoqXvupDBXkh+M9KB5e/PmZsBxAlnlc+hSesHDxQfXtMCnFHk73gmDV19AC/UDstjPllJcR7/n0JiuAZ1dNL2pctD5C5OYkPwjzVErVN1XpuH7trV3SueVVLqQsrS3fCRpVvRHkvgj69ZKzusguW2j7fCeXDhOoMjuxKgPi4rs6u/Dpxz+SOXGwmfvnkT66VyBcB16+OwP5uRUFMeqdsIgRLKzmrMPxotdsf5k9AwZshNC4SQaBzGm10ycVUE/YiGKUcmp3Ui3E7vaRguG543IhIb34XjAD5u3QzsMGuCiRRQ/gTfdS+0Zq2DQIokJSUb1K7TkZjQ000mhSRWo7wWOFXOgn5Bk0qKV3BzUvANyKTVAyQ3Ez584MEBu+GaStH8qMquXfZx24oWI/A4hxdKRsO1JWV6uB6usx8mMKvaLzfMPJ8GVwRJ8ccfvVboiucUN5Mply3jj1fc/RWG/AqLNhxOIepg0myO5bRBfGCk2/woGAf6xDzAwVO6kualk9wSULf61QSubRobW99ykjI+lRTQXkb3pukg6T0OQO+aRWO79qP/kyYgv7viMRBwJH7MppzpU3nwYoBnzkXfqKEPjNzJbvF8Y3fgMDBCMwyhyb8ylvld1d/V8mnFKHOUSgPcJDUvUZXMsR037gTrfx6S4mfybBSpNTMAyh1vTpbB+C0eLhQstEOYFVN5ZMEB4opYfIrH/cCzrcjhFcGoc5QKxd5S5ZUs30saAVqaOZZ21zwQlLZs8eTmFpC+o7fRdaIHG7vmb8uZMI1fItbRV+1DXtmKMLUm4bnrE8uWMDcubyWNmBpVVmSBXQ2l6to6LKAyojpUZqPH6iCl+Nx5q3CP+ewsqKmJtkUUYjZEgw4nBnHNuV/TCW87/BS5e7Mq15rSzZ5pWdCETIod0+HYSfa8UxSpXIBze4AuWX+yTtS03cVWpV1uW23jIB+o76xIRMz9HDvsM2gpauYHPFUSqunyMTbnnzBASKpgBb9l726eQ034SZqQvxSi2SJ9cCI5sgE6TgkmWOgVu0fvVfqvmaffwb/fxM86abIvYNeRGyhMoO4F7Xh9pVnZ9VHdCmVAzvEOhs5+JbduXQpFWuOWYHNxU34dgXaOhRqpAHxJ2NeEDLbNpO36QXEE/BMWI3SBa21bTsHpQBXBITyWr9Jp9ObNm5+1/J3yYKrhooZi6ZefT/c8VIZRVkt3RAS9Jxz2l7U6StB30crilQZ/ypeJo1Sor1HEhxkw3BCqFPB1C7e7B2F05Oeqkdyygld5lxyL3qe0L3e/GBKfr3wOsVB06+V7q5CvUQ0m2rKpfTm8+62j8/tyWqgYJi1mj/sdHZDT6TTxUlhSCOzG8JcjK7vaL6p/G+x2uUGPiMIqeAQylRasiXe+KaGsdmvxByhgj3cZwP5GjhFTKDUFeerm0q7+Q0KEDaeULhRl9FqXLazaTZDfY5k2U7tnWCfZ1Z27bZp7Q7VhYziX9SXcg7WzSw+T4JCLigWg0ekQBKS7xvCAr+Z66dmsl9/h2Ny+nQS+jAd3a3GlX9lkA4koyZj5nI1xEbibFoKXRtvb7YABo74CbibEqyL+6gyyjS5HxOcD5L2lyssk7+4D6boQk1Z9oLhe7VZK0pnqvVde4lhZru29qITHBD4lO0g/vlhxnU1nXS3Bt+tuC2tSZqXXuzZuUoWnsOcWAVOAz/pEFaoFBs/HKROnAN+h2jyqDc5xFbHQzucEk6Si3NI/43PCkgoT0okEqDIPzMn0Zb3TRJUlzxMcoeDGfJPflkuFOYspL9vjK3YhX69C5Q8k4e4D0Y06G5kPU57mosS9T/+upqq9k7/IsUOlO7HYsxPw9aVPOHdFZ9W5vyUzLvA4lDutOozh25dhw1T7lbBwwiHlosi5St0woKeNa3Q4ZIb+aDn0foLUN/WsqmqPum4ypdY5tb2UgZ8IAQAw/k8KdIHR2W3Fk02uKRhGmzZ2hyMW0TU3nu/T8fKhcF4QzOU3mYvL/NRQ7NUvdzItroDljeoUNtk5W71+K7ZrEAlgb1EonE3N/B9GZRM9rEvUxCh6YLdoT1Nnzadt/mWeLr+Ou12LxjjvnqVGh7fMpv1X9+0NZ1jXwEtWWC5z9zapvf06UZSI+cVp004/ch8Bm8iRMivcJcKN/Ts63Ex9hNelT0x2wl9qmeSE9Ph8JhSYzJkYLZO8VxTbd2SUdjSljaff5iUQ5mx6fO25M6GNaj1KWvDTP12XNqBjd9l6PBwcCetlVtrDv/gSrIf/bkYbMWLrvZRjiW+c+2ALF/tZSGsEF0rF/3Owt/Wt+tKa2t/yjOjY0J5i/3QzvS2NpIB3Zd4iyOyyRpsQb+oc1wSGXcs6BtWHqb5AkzViE3r83EF7PUDJYVBHzKE+X9CYGzI/fsBRHvlxEfcw59PBk9zAp83mHiTaLhBZeSWV9tiuLI1xPgAAnSRJ6pOzxE1iG4kD3rwBty9pNjK12bU+8HFtHdYwEYGzQmLKB6nLTkcT1qYkkF5yb7oiZ0OqIhFK5jFbGLKWDGLQJ2J32FYdxTxRp4eh7tIJ/yrxZSwva33ZPhzRlzJkkOg/eQT34KsgU/yViszdd/2/olxu9p7Z2rBwVXvfL7rSAd+p9aNp3OTbeSI93wQAhQR6BSAbQbZY0Kj3pcb2CoYcZuj+FukciiyQ524kBqexaKtw9JNxQdM6K4sCazkNlxNvOMZPpGk/KRWU5Dkahm0f3cJ6ew9FT+YJqy8CUNlMD1KcQbdBxFEwoHPkeBVrJQpS+jwuW4zWODU5MKJnlO3xuOYwU6QedSOtPg54p+6g3aU4k1LNkoXi2w+HbuS3rDsIxBDoyGLcOnGF9Jl60XI2rOy0+b1aaNE0aaGbCQMDRUiKCVA1vgrQK5/HxmjsHfTIi6bDWod8/FHZs+FqCHoTyYVHopLGOtqVk2ZJelFXR0dz+OBlAX2SN4ceI5uZDS8SXMxP3U1n3JzIEMmfkxsLt6WNh2zE5rEvhBvX5kGLWV4s7NixI0D+E07IAvFmJNh+xYTLqzkto9cnXU+mkcKbTyvP1rxRk0nJGSMc57NbGGD5abH7peTgK0JaQGcqanZ24PvSUnS5s55vqndDY5r7yB1/6yQ3qd8ukSQZZ7VfEC8VPxGn3TTy/4LBtQIgfgN3TesUGisao2zO08ByaoWn0soFlDUtiIlrguersYPNV6vwgTWi4Y8uhvszf7Skfq+6bM84dLrj1gofxDw2edW73/ILhG0N3r25FE2+jXGQR46IGXvZF911Hp3s+gJjxou3DZrl/1aKO0WGkc4uHa9uCvulT4VjAq9XTLhYiPXN+0Cg/Q5F2wrghBs9Y6rZZy7wp3tcjhOu30vQ7aFBq+06MAdoCVJxzIFuPzZl2b8t4i1wPi4/K908McE+4va0ucRm22EK0CRLYtkzvkKf7zC/EowF25gdD3+ebpXDud10aBvuZ+27xYltI6Vrt5s6mHbWHBrsHPAVqQhznWyOqzO0NWLLBkSYp/zKNoi3PjWpb7X47YhkZrcr1QYt5tr1tc529bHPtlmXLjBFWTiUy9g6t8tFoWzVBLF3tRMKbSb/6DLWn2pdlvNNTpYWwqV7omlpEaVTXz3dllA4vdGa8SpraVtIJZ2W2HKwNYsl6LWbVkBWbT0bEq4UzMvpcmP1BYZTqBlBG2FDpmOupz2t83FdDbVZ/HrAfdelGhEhpxLrERVpO40AqKY5t3EUx2C+qDh0uDa2EWsa0y/yzc/6FrL7vkvDrxzF03MINfl6+tfHHyo8ERwimYQQ530MhuRBdne7FNVIhWIDp/GGpa5cOPTT51A/TTatrrmbldkjjLYpGDuEnqSPFxBzkNmL1QtMX+SMb1ybqkRrcC8oXzXgHo7UT7wI7QJGZrk9Ai6yatdJjXEmivYpUldE0CeWUxgSd3d52unVvIt0oc+12bhh307tdlMZBEVe91DfLuse4nNqxFNUfN6GcRcybIxh7ydA9VybUFQ3i/eAa71JfRsY2riAn+28ZY740oX8DFrYKoeP5lP9VmvN0uqaDy6T4a91LrpqEsUFjFR8TI0kVYrpuxen6/uTx1ty6Qde7jsK1TbCvZRyXqL5Sf2aSFCqgNCttzTOrqDPupD8m/z6lnL+++uYbSb+6jFZSOapNWcpqYuy/aLlySXfLTJ1UFrr9VdKPyGfEzyKNr4AmxqH0tZTvTeTaawWxS18/Wul3rCFXriTdbbSG88YctcNcbtigQziXH2lZ6oQ7VDamQXlhlBb5UY0TlcWoLC+V1Xk8D+y6bV6zxguxmIXz5iWdTPl/+jv2xktbiOwAAAAASUVORK5CYII="
-            alt="Logo image of libary"
-          />
-        </div>
-      </a>
-    </div>
-    <div class="header__menu">
-      <nav class="header__menu-first">
-        <div>
-          <div class="header__menu-navigation-mobile">
-            <div
-              class="pagefold-parent--small header__menu-navigation-button header__button"
-              id="header__menu--open"
-            >
-              <div class="pagefold-triangle--small"></div>
-              <img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-menu.svg" alt="List of bookmarks" />
-            </div>
-            <div class="header__menu-navigation-logo">
-              <div class="logo-fallback">
-                <p class="logo-fallback__text-name">Lyngby-Taarbæk</p>
-                <p class="logo-fallback__text-libraries">Bibliotekerne</p>
-              </div>
-            </div>
-          </div>
-          <ul class="header__menu-navigation">
-            <li class="header__menu-navigation-item">
-              <a
-                href="/"
-                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
-              >
-                Det sker
-              </a>
-            </li>
-            <li class="header__menu-navigation-item">
-              <a
-                href="/"
-                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
-              >
-                Biblioteker &amp; åbningstider
-              </a>
-            </li>
-            <li class="header__menu-navigation-item">
-              <a
-                href="/"
-                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
-              >
-                Digitale tilbud
-              </a>
-            </li>
-            <li class="header__menu-navigation-item">
-              <a
-                href="/"
-                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
-              >
-                Litteratur
-              </a>
-            </li>
-            <li class="header__menu-navigation-item">
-              <a
-                href="/"
-                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
-              >
-                Børn &amp; forældre
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div class="header__menu-profile header__button">
-          <a href="/" class="hide-linkstyle">
-            <img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-profile.svg" alt="Profile" />
-          </a>
-        </div>
-        <div class="header__menu-bookmarked header__button">
-          <a href="/">
-            <img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt="List of bookmarks" />
-          </a>
-        </div>
-      </nav>
-      {{ search_header }}
-    </div>
-    <div class="header__clock">
-      <div class="pagefold-parent--medium">
-        <div class="pagefold-triangle--medium"></div>
-      </div>
-      <div class="header__clock-items">
-        <img
-          src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg"
-          class="mb-8"
-          alt="clock icon"
-        />
-        <span class="text-small-caption">Fredag</span>
-        <span class="text-small-caption">28 Maj</span>
-      </div>
-    </div>
-  </header>
-  <div id="header__overlay">
-    <div class="header__overlay-main">
-      <img id="header__menu--close" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-cross-medium.svg" />
-      <ul class="header__overlay-menu">
-        <li class="header__overlay-menu-item">
-          <a
-            href="/"
-            class="header__overlay-menu-link text-body-large hide-linkstyle"
-          >
-            Det sker
-          </a>
-        </li>
-        <li class="header__overlay-menu-item">
-          <a
-            href="/"
-            class="header__overlay-menu-link text-body-large hide-linkstyle"
-          >
-            Biblioteker &amp; åbningstider
-          </a>
-        </li>
-        <li class="header__overlay-menu-item">
-          <a
-            href="/"
-            class="header__overlay-menu-link text-body-large hide-linkstyle"
-          >
-            Digitale tilbud
-          </a>
-        </li>
-        <li class="header__overlay-menu-item">
-          <a
-            href="/"
-            class="header__overlay-menu-link text-body-large hide-linkstyle"
-          >
-            Litteratur
-          </a>
-        </li>
-        <li class="header__overlay-menu-item">
-          <a
-            href="/"
-            class="header__overlay-menu-link text-body-large hide-linkstyle"
-          >
-            Børn &amp; forældre
-          </a>
-        </li>
-      </ul>
-    </div>
-    <div class="header__overlay-backdrop"></div>
-  </div>
+<header class="header">
+	<div class="header__logo-desktop">
+		<a class="header__logo-desktop-link" href="/">
+			<div>
+				<img class="logo" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAAgCAYAAAB6vRjLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAABRSSURBVHgB7VwLeFTVtV5r73POTCYJIQmBJJPwEBABkwBBRIEU6LXWZ20Rbq312U9vvbZWW7X1ai3tbdVWW+3Vttx+1Yp6tYK12l61eG1BRQEhkISHIGgSMpOEVzJhksnMeex91z7DxMwY8uBpSv/vO9+cs85+77XXXo99BoKs5GDXpZW+BMcIa2HizUll09XIS66EE4gGVvozVW+Anfn11Hf1vGRhvF2TH03QAlhSGdTKWgM5c4vgOIPq3lrPzmxYCqeNhFMcmgTITDwgYBocI+yFmF4EWmZ3mgOODicWHtU/h35TX2gguASWKZP7HKX0NoJAOO7AmAnS2gQRBqc4TvkB6A5DeheALqf6W95q6CvtznEXeOAo4Ah+sS6cWQ/DGQE4xaHBP9EFK9t7NaIxrHXEZfdl170UUrRaGO3VtKxbUcrLpJTDAbGGaez/ZF3wa80Z534+v/3dvYH8z8wjuXahw7R3WFt4snSc2SjZs78rsl65oSPrLqbpdXbbwVZwnMuJvqVIVN+rZfuujUrDe5f86GFog9bGvFlzpC0uRUdWyc7OGcSln5cITcC0J/yzsp7FVavsRDt3jhvn8XyUdjNDXARSDkXGXhZDfI1MQpEwxdPFHetqYBDhn0zYDTIUug45Gx8BrvTE0EqYqxnYskIKUaHe0x4tadLHSMv5AiK8vn9kKATbiN4Wni5j1u0M5b+BxExUCdFZFwq0DJGM3+4gxEjVEZQ7jeg+VZZoa7tRAGRFhfkEPbbCvrZpkuHtpA6Y9GzEGwSng2NVBNe0nkNPN7kkKbHRM3WJBOdaeognE+JObOvopHdpVPd7RBpUTHhKbMeaxC+TIfBY90sAXttXvtM9LRdIlBXEU7uNNO9U/70LNGTcNd5o+qdkBbIykjJINICzq1HIkbpgD378AjXg/BEh5DiScF/prU4EeVDTtfP8f/i+BoYxH5F1gC2vaTbKS9T7QFpphbSdKyjlPmboFf6//ZfOvWkXU4OiMEhxSkhC2tZm0s/M7jSU/bA9mF6hBJPweB4c3rG+KnC/eTEI+VlguJ1+J9iRcCmlWtVVpqE97Y9uejrxfCvk58UbIGv9Zta9CB9vqYdtK+Af82Ob3oBFi9TjyoBnyu/Acm6VjllOz5tRMyaCaXokk48XRje+DfPmqXSvBLTSN0DAQhiE6JEJa0fP9Xrq9o+xPcZ8zrBIGpouO6MH0YGNVmb26jGhVSE4CryfOSM307LLEOVZYOi5gvYltM1G0Wm9s7fcWzW9stKCYwiSWs8hir92p6Hk5bS33tJrvpjlSjq9YPiBuubyAohaj9J4POQgjiXT4ozUwZPC2dNjQZq2F82+GdBtl9qakwrFdvVj61wn9wKwSNQr3A2MdSalEzICgxRJ40iToge0su9g4MD1gsEZzLKYq3WQMyEhN/RwS4hW51KaxCV+s3I7DASSFwd46a8hElUKdW68bLurbEZKVUGVWRfQyx6NWvJ/xkHNXjgGIGVs3Shn61PdaUE+mTwk7JZ+5WeC66a1hOZ+h8jTHoL9zm/gJEFwTvwv4R8JyTqhkHNAiIekgEm0JnvWF8kao+3hW2BbbzV4p9wgSXmHfoKG727Kf5NiwJ5TkGyUMIb0pl94GawI6uXT4CQCde5KL7u+6TY1NjrXvuFvqoxQ+7PhZMHQ45KS4ekJkjsHiBNgkCKV0frNUCQ189B0fhs02n7Q/zwwAN+anEJ60NuNWukcOFmwnXfVD3PENMG1O4bHNu6ihTeX9t3PE7mFLILdcIKBHeFXiOH2o+1c2WCUvbAbJt/TyA+8RAvjbBikOHrr2LbvCepTbobjA58j5LKgp/SkrHLNK/5OP3GrU9qPBbSSRlp4K2k1aaDxJfmxDR/BCYYfPthPAuAaWtDNaIsFjLH/FBLPJZVmHwxS9CL5MIQcnyFrrVJoWoy24EIk3xS5H85MTUn+qcV1vokvjo683wT9hGSskibyfx0hdhq0FmgjLnFscSNJmaStjgY3n5TzR+j2AhggkGE9VbRG4zRBZkr9yEnfZGtQitrD5bfQmKw2YypnBTHexZQrQzLYyhEfLzh36KNddjHTguQGXEMVJkVaJkB6BJCvoa1zcw+NW0/qSeb0tAwbyMQQBjaCo9I6QVJiu0B68m5BZTAWZ7Lm0qvSAdo3OPtDc+We1lIBTgZyUSkd9h2aiKsxM82CozIbTzwwwEo+oeVKZCssTX7rtFjNjiQ6OUoD+pTvohA/osfkOLDBf18Urbo+8fhnOO3WaSz94R7qFILhd41c+E3+npqO7i/qfOUFmuU8QpGFRalN4oZ3XkF0/ZtwHEFjsZOiD2NgSNaYROguCOU+P1RG5MKFfM9bbd4RzSsiSCsGThICGdMvR9NeSh6mlf5zhl6mIinbh03ITA953lUCQni9M0ZG1q+HQYRPbseIf8/yaV9NZcD4K5TFdvUDFAW4J/UdRRGuOJBz9hDoCxo+UGxV/zyVARVGRyqbtJzh1xMjrE6tWljmVXAcEeQlb1G0oZgWWlTYVlfbFAO6DVi+3Mnf83rHyWRABY/fswJssZd2pouCq1tWB3nZExkhzwrFgLRr7dybJbbCIEMyEyLakhl3DQlX7u8tkyfb/DWFt7YlZZXg7WyLVkCvtbGd/lj1Pb1NpJpoqXvupDBXkh+M9KB5e/PmZsBxAlnlc+hSesHDxQfXtMCnFHk73gmDV19AC/UDstjPllJcR7/n0JiuAZ1dNL2pctD5C5OYkPwjzVErVN1XpuH7trV3SueVVLqQsrS3fCRpVvRHkvgj69ZKzusguW2j7fCeXDhOoMjuxKgPi4rs6u/Dpxz+SOXGwmfvnkT66VyBcB16+OwP5uRUFMeqdsIgRLKzmrMPxotdsf5k9AwZshNC4SQaBzGm10ycVUE/YiGKUcmp3Ui3E7vaRguG543IhIb34XjAD5u3QzsMGuCiRRQ/gTfdS+0Zq2DQIokJSUb1K7TkZjQ000mhSRWo7wWOFXOgn5Bk0qKV3BzUvANyKTVAyQ3Ez584MEBu+GaStH8qMquXfZx24oWI/A4hxdKRsO1JWV6uB6usx8mMKvaLzfMPJ8GVwRJ8ccfvVboiucUN5Mply3jj1fc/RWG/AqLNhxOIepg0myO5bRBfGCk2/woGAf6xDzAwVO6kualk9wSULf61QSubRobW99ykjI+lRTQXkb3pukg6T0OQO+aRWO79qP/kyYgv7viMRBwJH7MppzpU3nwYoBnzkXfqKEPjNzJbvF8Y3fgMDBCMwyhyb8ylvld1d/V8mnFKHOUSgPcJDUvUZXMsR037gTrfx6S4mfybBSpNTMAyh1vTpbB+C0eLhQstEOYFVN5ZMEB4opYfIrH/cCzrcjhFcGoc5QKxd5S5ZUs30saAVqaOZZ21zwQlLZs8eTmFpC+o7fRdaIHG7vmb8uZMI1fItbRV+1DXtmKMLUm4bnrE8uWMDcubyWNmBpVVmSBXQ2l6to6LKAyojpUZqPH6iCl+Nx5q3CP+ewsqKmJtkUUYjZEgw4nBnHNuV/TCW87/BS5e7Mq15rSzZ5pWdCETIod0+HYSfa8UxSpXIBze4AuWX+yTtS03cVWpV1uW23jIB+o76xIRMz9HDvsM2gpauYHPFUSqunyMTbnnzBASKpgBb9l726eQ034SZqQvxSi2SJ9cCI5sgE6TgkmWOgVu0fvVfqvmaffwb/fxM86abIvYNeRGyhMoO4F7Xh9pVnZ9VHdCmVAzvEOhs5+JbduXQpFWuOWYHNxU34dgXaOhRqpAHxJ2NeEDLbNpO36QXEE/BMWI3SBa21bTsHpQBXBITyWr9Jp9ObNm5+1/J3yYKrhooZi6ZefT/c8VIZRVkt3RAS9Jxz2l7U6StB30crilQZ/ypeJo1Sor1HEhxkw3BCqFPB1C7e7B2F05Oeqkdyygld5lxyL3qe0L3e/GBKfr3wOsVB06+V7q5CvUQ0m2rKpfTm8+62j8/tyWqgYJi1mj/sdHZDT6TTxUlhSCOzG8JcjK7vaL6p/G+x2uUGPiMIqeAQylRasiXe+KaGsdmvxByhgj3cZwP5GjhFTKDUFeerm0q7+Q0KEDaeULhRl9FqXLazaTZDfY5k2U7tnWCfZ1Z27bZp7Q7VhYziX9SXcg7WzSw+T4JCLigWg0ekQBKS7xvCAr+Z66dmsl9/h2Ny+nQS+jAd3a3GlX9lkA4koyZj5nI1xEbibFoKXRtvb7YABo74CbibEqyL+6gyyjS5HxOcD5L2lyssk7+4D6boQk1Z9oLhe7VZK0pnqvVde4lhZru29qITHBD4lO0g/vlhxnU1nXS3Bt+tuC2tSZqXXuzZuUoWnsOcWAVOAz/pEFaoFBs/HKROnAN+h2jyqDc5xFbHQzucEk6Si3NI/43PCkgoT0okEqDIPzMn0Zb3TRJUlzxMcoeDGfJPflkuFOYspL9vjK3YhX69C5Q8k4e4D0Y06G5kPU57mosS9T/+upqq9k7/IsUOlO7HYsxPw9aVPOHdFZ9W5vyUzLvA4lDutOozh25dhw1T7lbBwwiHlosi5St0woKeNa3Q4ZIb+aDn0foLUN/WsqmqPum4ypdY5tb2UgZ8IAQAw/k8KdIHR2W3Fk02uKRhGmzZ2hyMW0TU3nu/T8fKhcF4QzOU3mYvL/NRQ7NUvdzItroDljeoUNtk5W71+K7ZrEAlgb1EonE3N/B9GZRM9rEvUxCh6YLdoT1Nnzadt/mWeLr+Ou12LxjjvnqVGh7fMpv1X9+0NZ1jXwEtWWC5z9zapvf06UZSI+cVp004/ch8Bm8iRMivcJcKN/Ts63Ex9hNelT0x2wl9qmeSE9Ph8JhSYzJkYLZO8VxTbd2SUdjSljaff5iUQ5mx6fO25M6GNaj1KWvDTP12XNqBjd9l6PBwcCetlVtrDv/gSrIf/bkYbMWLrvZRjiW+c+2ALF/tZSGsEF0rF/3Owt/Wt+tKa2t/yjOjY0J5i/3QzvS2NpIB3Zd4iyOyyRpsQb+oc1wSGXcs6BtWHqb5AkzViE3r83EF7PUDJYVBHzKE+X9CYGzI/fsBRHvlxEfcw59PBk9zAp83mHiTaLhBZeSWV9tiuLI1xPgAAnSRJ6pOzxE1iG4kD3rwBty9pNjK12bU+8HFtHdYwEYGzQmLKB6nLTkcT1qYkkF5yb7oiZ0OqIhFK5jFbGLKWDGLQJ2J32FYdxTxRp4eh7tIJ/yrxZSwva33ZPhzRlzJkkOg/eQT34KsgU/yViszdd/2/olxu9p7Z2rBwVXvfL7rSAd+p9aNp3OTbeSI93wQAhQR6BSAbQbZY0Kj3pcb2CoYcZuj+FukciiyQ524kBqexaKtw9JNxQdM6K4sCazkNlxNvOMZPpGk/KRWU5Dkahm0f3cJ6ew9FT+YJqy8CUNlMD1KcQbdBxFEwoHPkeBVrJQpS+jwuW4zWODU5MKJnlO3xuOYwU6QedSOtPg54p+6g3aU4k1LNkoXi2w+HbuS3rDsIxBDoyGLcOnGF9Jl60XI2rOy0+b1aaNE0aaGbCQMDRUiKCVA1vgrQK5/HxmjsHfTIi6bDWod8/FHZs+FqCHoTyYVHopLGOtqVk2ZJelFXR0dz+OBlAX2SN4ceI5uZDS8SXMxP3U1n3JzIEMmfkxsLt6WNh2zE5rEvhBvX5kGLWV4s7NixI0D+E07IAvFmJNh+xYTLqzkto9cnXU+mkcKbTyvP1rxRk0nJGSMc57NbGGD5abH7peTgK0JaQGcqanZ24PvSUnS5s55vqndDY5r7yB1/6yQ3qd8ukSQZZ7VfEC8VPxGn3TTy/4LBtQIgfgN3TesUGisao2zO08ByaoWn0soFlDUtiIlrguersYPNV6vwgTWi4Y8uhvszf7Skfq+6bM84dLrj1gofxDw2edW73/ILhG0N3r25FE2+jXGQR46IGXvZF911Hp3s+gJjxou3DZrl/1aKO0WGkc4uHa9uCvulT4VjAq9XTLhYiPXN+0Cg/Q5F2wrghBs9Y6rZZy7wp3tcjhOu30vQ7aFBq+06MAdoCVJxzIFuPzZl2b8t4i1wPi4/K908McE+4va0ucRm22EK0CRLYtkzvkKf7zC/EowF25gdD3+ebpXDud10aBvuZ+27xYltI6Vrt5s6mHbWHBrsHPAVqQhznWyOqzO0NWLLBkSYp/zKNoi3PjWpb7X47YhkZrcr1QYt5tr1tc529bHPtlmXLjBFWTiUy9g6t8tFoWzVBLF3tRMKbSb/6DLWn2pdlvNNTpYWwqV7omlpEaVTXz3dllA4vdGa8SpraVtIJZ2W2HKwNYsl6LWbVkBWbT0bEq4UzMvpcmP1BYZTqBlBG2FDpmOupz2t83FdDbVZ/HrAfdelGhEhpxLrERVpO40AqKY5t3EUx2C+qDh0uDa2EWsa0y/yzc/6FrL7vkvDrxzF03MINfl6+tfHHyo8ERwimYQQ530MhuRBdne7FNVIhWIDp/GGpa5cOPTT51A/TTatrrmbldkjjLYpGDuEnqSPFxBzkNmL1QtMX+SMb1ybqkRrcC8oXzXgHo7UT7wI7QJGZrk9Ai6yatdJjXEmivYpUldE0CeWUxgSd3d52unVvIt0oc+12bhh307tdlMZBEVe91DfLuse4nNqxFNUfN6GcRcybIxh7ydA9VybUFQ3i/eAa71JfRsY2riAn+28ZY740oX8DFrYKoeP5lP9VmvN0uqaDy6T4a91LrpqEsUFjFR8TI0kVYrpuxen6/uTx1ty6Qde7jsK1TbCvZRyXqL5Sf2aSFCqgNCttzTOrqDPupD8m/z6lnL+++uYbSb+6jFZSOapNWcpqYuy/aLlySXfLTJ1UFrr9VdKPyGfEzyKNr4AmxqH0tZTvTeTaawWxS18/Wul3rCFXriTdbbSG88YctcNcbtigQziXH2lZ6oQ7VDamQXlhlBb5UY0TlcWoLC+V1Xk8D+y6bV6zxguxmIXz5iWdTPl/+jv2xktbiOwAAAAASUVORK5CYII=" alt="Logo image of libary"/>
+			</div>
+		</a>
+	</div>
+	<div class="header__menu">
+		<nav class="header__menu-first">
+			<div>
+				<div class="header__menu-navigation-mobile">
+					<div class="pagefold-parent--small header__menu-navigation-button header__button" id="header__menu--open">
+						<div class="pagefold-triangle--small"></div>
+						<img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-menu.svg" alt="List of bookmarks"/>
+					</div>
+					<div class="header__menu-navigation-logo">
+						<div class="logo-fallback">
+							<p class="logo-fallback__text-name">Lyngby-Taarbæk</p>
+							<p class="logo-fallback__text-libraries">Bibliotekerne</p>
+						</div>
+					</div>
+				</div>
+				<ul class="header__menu-navigation">
+					<li class="header__menu-navigation-item">
+						<a href="/" class="header__menu-navigation-link text-body-medium-regular hide-linkstyle">
+							Det sker
+						</a>
+					</li>
+					<li class="header__menu-navigation-item">
+						<a href="/" class="header__menu-navigation-link text-body-medium-regular hide-linkstyle">
+							Biblioteker &amp; åbningstider
+						</a>
+					</li>
+					<li class="header__menu-navigation-item">
+						<a href="/" class="header__menu-navigation-link text-body-medium-regular hide-linkstyle">
+							Digitale tilbud
+						</a>
+					</li>
+					<li class="header__menu-navigation-item">
+						<a href="/" class="header__menu-navigation-link text-body-medium-regular hide-linkstyle">
+							Litteratur
+						</a>
+					</li>
+					<li class="header__menu-navigation-item">
+						<a href="/" class="header__menu-navigation-link text-body-medium-regular hide-linkstyle">
+							Børn &amp; forældre
+						</a>
+					</li>
+				</ul>
+			</div>
+			<div class="header__menu-profile header__button">
+				<a href="/" class="hide-linkstyle">
+					<img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-profile.svg" alt="Profile"/>
+				</a>
+			</div>
+			<div class="header__menu-bookmarked header__button">
+				<a href="/">
+					<img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt="List of bookmarks"/>
+				</a>
+			</div>
+		</nav>
+		{{ search_header }}
+	</div>
+	<div class="header__clock">
+		<div class="pagefold-parent--medium">
+			<div class="pagefold-triangle--medium"></div>
+		</div>
+		<div class="header__clock-items">
+			<img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" class="mb-8" alt="clock icon"/>
+			<span class="text-small-caption">Fredag</span>
+			<span class="text-small-caption">28 Maj</span>
+		</div>
+	</div>
+</header>
+<div id="header__overlay">
+	<div class="header__overlay-main">
+		<img id="header__menu--close" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-cross-medium.svg"/>
+		<ul class="header__overlay-menu">
+			<li class="header__overlay-menu-item">
+				<a href="/" class="header__overlay-menu-link text-body-large hide-linkstyle">
+					Det sker
+				</a>
+			</li>
+			<li class="header__overlay-menu-item">
+				<a href="/" class="header__overlay-menu-link text-body-large hide-linkstyle">
+					Biblioteker &amp; åbningstider
+				</a>
+			</li>
+			<li class="header__overlay-menu-item">
+				<a href="/" class="header__overlay-menu-link text-body-large hide-linkstyle">
+					Digitale tilbud
+				</a>
+			</li>
+			<li class="header__overlay-menu-item">
+				<a href="/" class="header__overlay-menu-link text-body-large hide-linkstyle">
+					Litteratur
+				</a>
+			</li>
+			<li class="header__overlay-menu-item">
+				<a href="/" class="header__overlay-menu-link text-body-large hide-linkstyle">
+					Børn &amp; forældre
+				</a>
+			</li>
+		</ul>
+	</div>
+	<div class="header__overlay-backdrop"></div>
+</div>

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -1,162 +1,150 @@
-<header class="header">
-  <div class="header-logo--desktop">
-    <a class="header-logo--desktop--link" href="/">
-      <div>
-        <img
-          class="logo"
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAAgCAYAAAB6vRjLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAABRSSURBVHgB7VwLeFTVtV5r73POTCYJIQmBJJPwEBABkwBBRIEU6LXWZ20Rbq312U9vvbZWW7X1ai3tbdVWW+3Vttx+1Yp6tYK12l61eG1BRQEhkISHIGgSMpOEVzJhksnMeex91z7DxMwY8uBpSv/vO9+cs85+77XXXo99BoKs5GDXpZW+BMcIa2HizUll09XIS66EE4gGVvozVW+Anfn11Hf1vGRhvF2TH03QAlhSGdTKWgM5c4vgOIPq3lrPzmxYCqeNhFMcmgTITDwgYBocI+yFmF4EWmZ3mgOODicWHtU/h35TX2gguASWKZP7HKX0NoJAOO7AmAnS2gQRBqc4TvkB6A5DeheALqf6W95q6CvtznEXeOAo4Ah+sS6cWQ/DGQE4xaHBP9EFK9t7NaIxrHXEZfdl170UUrRaGO3VtKxbUcrLpJTDAbGGaez/ZF3wa80Z534+v/3dvYH8z8wjuXahw7R3WFt4snSc2SjZs78rsl65oSPrLqbpdXbbwVZwnMuJvqVIVN+rZfuujUrDe5f86GFog9bGvFlzpC0uRUdWyc7OGcSln5cITcC0J/yzsp7FVavsRDt3jhvn8XyUdjNDXARSDkXGXhZDfI1MQpEwxdPFHetqYBDhn0zYDTIUug45Gx8BrvTE0EqYqxnYskIKUaHe0x4tadLHSMv5AiK8vn9kKATbiN4Wni5j1u0M5b+BxExUCdFZFwq0DJGM3+4gxEjVEZQ7jeg+VZZoa7tRAGRFhfkEPbbCvrZpkuHtpA6Y9GzEGwSng2NVBNe0nkNPN7kkKbHRM3WJBOdaeognE+JObOvopHdpVPd7RBpUTHhKbMeaxC+TIfBY90sAXttXvtM9LRdIlBXEU7uNNO9U/70LNGTcNd5o+qdkBbIykjJINICzq1HIkbpgD378AjXg/BEh5DiScF/prU4EeVDTtfP8f/i+BoYxH5F1gC2vaTbKS9T7QFpphbSdKyjlPmboFf6//ZfOvWkXU4OiMEhxSkhC2tZm0s/M7jSU/bA9mF6hBJPweB4c3rG+KnC/eTEI+VlguJ1+J9iRcCmlWtVVpqE97Y9uejrxfCvk58UbIGv9Zta9CB9vqYdtK+Af82Ob3oBFi9TjyoBnyu/Acm6VjllOz5tRMyaCaXokk48XRje+DfPmqXSvBLTSN0DAQhiE6JEJa0fP9Xrq9o+xPcZ8zrBIGpouO6MH0YGNVmb26jGhVSE4CryfOSM307LLEOVZYOi5gvYltM1G0Wm9s7fcWzW9stKCYwiSWs8hir92p6Hk5bS33tJrvpjlSjq9YPiBuubyAohaj9J4POQgjiXT4ozUwZPC2dNjQZq2F82+GdBtl9qakwrFdvVj61wn9wKwSNQr3A2MdSalEzICgxRJ40iToge0su9g4MD1gsEZzLKYq3WQMyEhN/RwS4hW51KaxCV+s3I7DASSFwd46a8hElUKdW68bLurbEZKVUGVWRfQyx6NWvJ/xkHNXjgGIGVs3Shn61PdaUE+mTwk7JZ+5WeC66a1hOZ+h8jTHoL9zm/gJEFwTvwv4R8JyTqhkHNAiIekgEm0JnvWF8kao+3hW2BbbzV4p9wgSXmHfoKG727Kf5NiwJ5TkGyUMIb0pl94GawI6uXT4CQCde5KL7u+6TY1NjrXvuFvqoxQ+7PhZMHQ45KS4ekJkjsHiBNgkCKV0frNUCQ189B0fhs02n7Q/zwwAN+anEJ60NuNWukcOFmwnXfVD3PENMG1O4bHNu6ihTeX9t3PE7mFLILdcIKBHeFXiOH2o+1c2WCUvbAbJt/TyA+8RAvjbBikOHrr2LbvCepTbobjA58j5LKgp/SkrHLNK/5OP3GrU9qPBbSSRlp4K2k1aaDxJfmxDR/BCYYfPthPAuAaWtDNaIsFjLH/FBLPJZVmHwxS9CL5MIQcnyFrrVJoWoy24EIk3xS5H85MTUn+qcV1vokvjo683wT9hGSskibyfx0hdhq0FmgjLnFscSNJmaStjgY3n5TzR+j2AhggkGE9VbRG4zRBZkr9yEnfZGtQitrD5bfQmKw2YypnBTHexZQrQzLYyhEfLzh36KNddjHTguQGXEMVJkVaJkB6BJCvoa1zcw+NW0/qSeb0tAwbyMQQBjaCo9I6QVJiu0B68m5BZTAWZ7Lm0qvSAdo3OPtDc+We1lIBTgZyUSkd9h2aiKsxM82CozIbTzwwwEo+oeVKZCssTX7rtFjNjiQ6OUoD+pTvohA/osfkOLDBf18Urbo+8fhnOO3WaSz94R7qFILhd41c+E3+npqO7i/qfOUFmuU8QpGFRalN4oZ3XkF0/ZtwHEFjsZOiD2NgSNaYROguCOU+P1RG5MKFfM9bbd4RzSsiSCsGThICGdMvR9NeSh6mlf5zhl6mIinbh03ITA953lUCQni9M0ZG1q+HQYRPbseIf8/yaV9NZcD4K5TFdvUDFAW4J/UdRRGuOJBz9hDoCxo+UGxV/zyVARVGRyqbtJzh1xMjrE6tWljmVXAcEeQlb1G0oZgWWlTYVlfbFAO6DVi+3Mnf83rHyWRABY/fswJssZd2pouCq1tWB3nZExkhzwrFgLRr7dybJbbCIEMyEyLakhl3DQlX7u8tkyfb/DWFt7YlZZXg7WyLVkCvtbGd/lj1Pb1NpJpoqXvupDBXkh+M9KB5e/PmZsBxAlnlc+hSesHDxQfXtMCnFHk73gmDV19AC/UDstjPllJcR7/n0JiuAZ1dNL2pctD5C5OYkPwjzVErVN1XpuH7trV3SueVVLqQsrS3fCRpVvRHkvgj69ZKzusguW2j7fCeXDhOoMjuxKgPi4rs6u/Dpxz+SOXGwmfvnkT66VyBcB16+OwP5uRUFMeqdsIgRLKzmrMPxotdsf5k9AwZshNC4SQaBzGm10ycVUE/YiGKUcmp3Ui3E7vaRguG543IhIb34XjAD5u3QzsMGuCiRRQ/gTfdS+0Zq2DQIokJSUb1K7TkZjQ000mhSRWo7wWOFXOgn5Bk0qKV3BzUvANyKTVAyQ3Ez584MEBu+GaStH8qMquXfZx24oWI/A4hxdKRsO1JWV6uB6usx8mMKvaLzfMPJ8GVwRJ8ccfvVboiucUN5Mply3jj1fc/RWG/AqLNhxOIepg0myO5bRBfGCk2/woGAf6xDzAwVO6kualk9wSULf61QSubRobW99ykjI+lRTQXkb3pukg6T0OQO+aRWO79qP/kyYgv7viMRBwJH7MppzpU3nwYoBnzkXfqKEPjNzJbvF8Y3fgMDBCMwyhyb8ylvld1d/V8mnFKHOUSgPcJDUvUZXMsR037gTrfx6S4mfybBSpNTMAyh1vTpbB+C0eLhQstEOYFVN5ZMEB4opYfIrH/cCzrcjhFcGoc5QKxd5S5ZUs30saAVqaOZZ21zwQlLZs8eTmFpC+o7fRdaIHG7vmb8uZMI1fItbRV+1DXtmKMLUm4bnrE8uWMDcubyWNmBpVVmSBXQ2l6to6LKAyojpUZqPH6iCl+Nx5q3CP+ewsqKmJtkUUYjZEgw4nBnHNuV/TCW87/BS5e7Mq15rSzZ5pWdCETIod0+HYSfa8UxSpXIBze4AuWX+yTtS03cVWpV1uW23jIB+o76xIRMz9HDvsM2gpauYHPFUSqunyMTbnnzBASKpgBb9l726eQ034SZqQvxSi2SJ9cCI5sgE6TgkmWOgVu0fvVfqvmaffwb/fxM86abIvYNeRGyhMoO4F7Xh9pVnZ9VHdCmVAzvEOhs5+JbduXQpFWuOWYHNxU34dgXaOhRqpAHxJ2NeEDLbNpO36QXEE/BMWI3SBa21bTsHpQBXBITyWr9Jp9ObNm5+1/J3yYKrhooZi6ZefT/c8VIZRVkt3RAS9Jxz2l7U6StB30crilQZ/ypeJo1Sor1HEhxkw3BCqFPB1C7e7B2F05Oeqkdyygld5lxyL3qe0L3e/GBKfr3wOsVB06+V7q5CvUQ0m2rKpfTm8+62j8/tyWqgYJi1mj/sdHZDT6TTxUlhSCOzG8JcjK7vaL6p/G+x2uUGPiMIqeAQylRasiXe+KaGsdmvxByhgj3cZwP5GjhFTKDUFeerm0q7+Q0KEDaeULhRl9FqXLazaTZDfY5k2U7tnWCfZ1Z27bZp7Q7VhYziX9SXcg7WzSw+T4JCLigWg0ekQBKS7xvCAr+Z66dmsl9/h2Ny+nQS+jAd3a3GlX9lkA4koyZj5nI1xEbibFoKXRtvb7YABo74CbibEqyL+6gyyjS5HxOcD5L2lyssk7+4D6boQk1Z9oLhe7VZK0pnqvVde4lhZru29qITHBD4lO0g/vlhxnU1nXS3Bt+tuC2tSZqXXuzZuUoWnsOcWAVOAz/pEFaoFBs/HKROnAN+h2jyqDc5xFbHQzucEk6Si3NI/43PCkgoT0okEqDIPzMn0Zb3TRJUlzxMcoeDGfJPflkuFOYspL9vjK3YhX69C5Q8k4e4D0Y06G5kPU57mosS9T/+upqq9k7/IsUOlO7HYsxPw9aVPOHdFZ9W5vyUzLvA4lDutOozh25dhw1T7lbBwwiHlosi5St0woKeNa3Q4ZIb+aDn0foLUN/WsqmqPum4ypdY5tb2UgZ8IAQAw/k8KdIHR2W3Fk02uKRhGmzZ2hyMW0TU3nu/T8fKhcF4QzOU3mYvL/NRQ7NUvdzItroDljeoUNtk5W71+K7ZrEAlgb1EonE3N/B9GZRM9rEvUxCh6YLdoT1Nnzadt/mWeLr+Ou12LxjjvnqVGh7fMpv1X9+0NZ1jXwEtWWC5z9zapvf06UZSI+cVp004/ch8Bm8iRMivcJcKN/Ts63Ex9hNelT0x2wl9qmeSE9Ph8JhSYzJkYLZO8VxTbd2SUdjSljaff5iUQ5mx6fO25M6GNaj1KWvDTP12XNqBjd9l6PBwcCetlVtrDv/gSrIf/bkYbMWLrvZRjiW+c+2ALF/tZSGsEF0rF/3Owt/Wt+tKa2t/yjOjY0J5i/3QzvS2NpIB3Zd4iyOyyRpsQb+oc1wSGXcs6BtWHqb5AkzViE3r83EF7PUDJYVBHzKE+X9CYGzI/fsBRHvlxEfcw59PBk9zAp83mHiTaLhBZeSWV9tiuLI1xPgAAnSRJ6pOzxE1iG4kD3rwBty9pNjK12bU+8HFtHdYwEYGzQmLKB6nLTkcT1qYkkF5yb7oiZ0OqIhFK5jFbGLKWDGLQJ2J32FYdxTxRp4eh7tIJ/yrxZSwva33ZPhzRlzJkkOg/eQT34KsgU/yViszdd/2/olxu9p7Z2rBwVXvfL7rSAd+p9aNp3OTbeSI93wQAhQR6BSAbQbZY0Kj3pcb2CoYcZuj+FukciiyQ524kBqexaKtw9JNxQdM6K4sCazkNlxNvOMZPpGk/KRWU5Dkahm0f3cJ6ew9FT+YJqy8CUNlMD1KcQbdBxFEwoHPkeBVrJQpS+jwuW4zWODU5MKJnlO3xuOYwU6QedSOtPg54p+6g3aU4k1LNkoXi2w+HbuS3rDsIxBDoyGLcOnGF9Jl60XI2rOy0+b1aaNE0aaGbCQMDRUiKCVA1vgrQK5/HxmjsHfTIi6bDWod8/FHZs+FqCHoTyYVHopLGOtqVk2ZJelFXR0dz+OBlAX2SN4ceI5uZDS8SXMxP3U1n3JzIEMmfkxsLt6WNh2zE5rEvhBvX5kGLWV4s7NixI0D+E07IAvFmJNh+xYTLqzkto9cnXU+mkcKbTyvP1rxRk0nJGSMc57NbGGD5abH7peTgK0JaQGcqanZ24PvSUnS5s55vqndDY5r7yB1/6yQ3qd8ukSQZZ7VfEC8VPxGn3TTy/4LBtQIgfgN3TesUGisao2zO08ByaoWn0soFlDUtiIlrguersYPNV6vwgTWi4Y8uhvszf7Skfq+6bM84dLrj1gofxDw2edW73/ILhG0N3r25FE2+jXGQR46IGXvZF911Hp3s+gJjxou3DZrl/1aKO0WGkc4uHa9uCvulT4VjAq9XTLhYiPXN+0Cg/Q5F2wrghBs9Y6rZZy7wp3tcjhOu30vQ7aFBq+06MAdoCVJxzIFuPzZl2b8t4i1wPi4/K908McE+4va0ucRm22EK0CRLYtkzvkKf7zC/EowF25gdD3+ebpXDud10aBvuZ+27xYltI6Vrt5s6mHbWHBrsHPAVqQhznWyOqzO0NWLLBkSYp/zKNoi3PjWpb7X47YhkZrcr1QYt5tr1tc529bHPtlmXLjBFWTiUy9g6t8tFoWzVBLF3tRMKbSb/6DLWn2pdlvNNTpYWwqV7omlpEaVTXz3dllA4vdGa8SpraVtIJZ2W2HKwNYsl6LWbVkBWbT0bEq4UzMvpcmP1BYZTqBlBG2FDpmOupz2t83FdDbVZ/HrAfdelGhEhpxLrERVpO40AqKY5t3EUx2C+qDh0uDa2EWsa0y/yzc/6FrL7vkvDrxzF03MINfl6+tfHHyo8ERwimYQQ530MhuRBdne7FNVIhWIDp/GGpa5cOPTT51A/TTatrrmbldkjjLYpGDuEnqSPFxBzkNmL1QtMX+SMb1ybqkRrcC8oXzXgHo7UT7wI7QJGZrk9Ai6yatdJjXEmivYpUldE0CeWUxgSd3d52unVvIt0oc+12bhh307tdlMZBEVe91DfLuse4nNqxFNUfN6GcRcybIxh7ydA9VybUFQ3i/eAa71JfRsY2riAn+28ZY740oX8DFrYKoeP5lP9VmvN0uqaDy6T4a91LrpqEsUFjFR8TI0kVYrpuxen6/uTx1ty6Qde7jsK1TbCvZRyXqL5Sf2aSFCqgNCttzTOrqDPupD8m/z6lnL+++uYbSb+6jFZSOapNWcpqYuy/aLlySXfLTJ1UFrr9VdKPyGfEzyKNr4AmxqH0tZTvTeTaawWxS18/Wul3rCFXriTdbbSG88YctcNcbtigQziXH2lZ6oQ7VDamQXlhlBb5UY0TlcWoLC+V1Xk8D+y6bV6zxguxmIXz5iWdTPl/+jv2xktbiOwAAAAASUVORK5CYII="
-          alt="Logo image of libary"
-        />
-      </div>
-    </a>
-  </div>
-  <div class="header-menu">
-    <nav class="header-menu--first">
-      <div>
-        <div class="header-menu--navigation--mobile">
-          <div
-            class="pagefold-parent-small header-menu--navigation--button header-button"
-            id="header-menu--open"
-          >
-            <div class="pagefold-triangle-small"></div>
-            <img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-menu.svg" alt="List of bookmarks" />
-          </div>
-          <div class="header-menu--navigation--logo">
-            <div class="logo-fallback-text">
-              <p class="logo-fallback-text--name">Lyngby-Taarbæk</p>
-              <p class="logo-fallback-text--libraries">Bibliotekerne</p>
+
+  <header class="header">
+    <div class="header__logo-desktop">
+      <a class="header__logo-desktop-link" href="/">
+        <div>
+          <img
+            class="logo"
+            src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAAgCAYAAAB6vRjLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAABRSSURBVHgB7VwLeFTVtV5r73POTCYJIQmBJJPwEBABkwBBRIEU6LXWZ20Rbq312U9vvbZWW7X1ai3tbdVWW+3Vttx+1Yp6tYK12l61eG1BRQEhkISHIGgSMpOEVzJhksnMeex91z7DxMwY8uBpSv/vO9+cs85+77XXXo99BoKs5GDXpZW+BMcIa2HizUll09XIS66EE4gGVvozVW+Anfn11Hf1vGRhvF2TH03QAlhSGdTKWgM5c4vgOIPq3lrPzmxYCqeNhFMcmgTITDwgYBocI+yFmF4EWmZ3mgOODicWHtU/h35TX2gguASWKZP7HKX0NoJAOO7AmAnS2gQRBqc4TvkB6A5DeheALqf6W95q6CvtznEXeOAo4Ah+sS6cWQ/DGQE4xaHBP9EFK9t7NaIxrHXEZfdl170UUrRaGO3VtKxbUcrLpJTDAbGGaez/ZF3wa80Z534+v/3dvYH8z8wjuXahw7R3WFt4snSc2SjZs78rsl65oSPrLqbpdXbbwVZwnMuJvqVIVN+rZfuujUrDe5f86GFog9bGvFlzpC0uRUdWyc7OGcSln5cITcC0J/yzsp7FVavsRDt3jhvn8XyUdjNDXARSDkXGXhZDfI1MQpEwxdPFHetqYBDhn0zYDTIUug45Gx8BrvTE0EqYqxnYskIKUaHe0x4tadLHSMv5AiK8vn9kKATbiN4Wni5j1u0M5b+BxExUCdFZFwq0DJGM3+4gxEjVEZQ7jeg+VZZoa7tRAGRFhfkEPbbCvrZpkuHtpA6Y9GzEGwSng2NVBNe0nkNPN7kkKbHRM3WJBOdaeognE+JObOvopHdpVPd7RBpUTHhKbMeaxC+TIfBY90sAXttXvtM9LRdIlBXEU7uNNO9U/70LNGTcNd5o+qdkBbIykjJINICzq1HIkbpgD378AjXg/BEh5DiScF/prU4EeVDTtfP8f/i+BoYxH5F1gC2vaTbKS9T7QFpphbSdKyjlPmboFf6//ZfOvWkXU4OiMEhxSkhC2tZm0s/M7jSU/bA9mF6hBJPweB4c3rG+KnC/eTEI+VlguJ1+J9iRcCmlWtVVpqE97Y9uejrxfCvk58UbIGv9Zta9CB9vqYdtK+Af82Ob3oBFi9TjyoBnyu/Acm6VjllOz5tRMyaCaXokk48XRje+DfPmqXSvBLTSN0DAQhiE6JEJa0fP9Xrq9o+xPcZ8zrBIGpouO6MH0YGNVmb26jGhVSE4CryfOSM307LLEOVZYOi5gvYltM1G0Wm9s7fcWzW9stKCYwiSWs8hir92p6Hk5bS33tJrvpjlSjq9YPiBuubyAohaj9J4POQgjiXT4ozUwZPC2dNjQZq2F82+GdBtl9qakwrFdvVj61wn9wKwSNQr3A2MdSalEzICgxRJ40iToge0su9g4MD1gsEZzLKYq3WQMyEhN/RwS4hW51KaxCV+s3I7DASSFwd46a8hElUKdW68bLurbEZKVUGVWRfQyx6NWvJ/xkHNXjgGIGVs3Shn61PdaUE+mTwk7JZ+5WeC66a1hOZ+h8jTHoL9zm/gJEFwTvwv4R8JyTqhkHNAiIekgEm0JnvWF8kao+3hW2BbbzV4p9wgSXmHfoKG727Kf5NiwJ5TkGyUMIb0pl94GawI6uXT4CQCde5KL7u+6TY1NjrXvuFvqoxQ+7PhZMHQ45KS4ekJkjsHiBNgkCKV0frNUCQ189B0fhs02n7Q/zwwAN+anEJ60NuNWukcOFmwnXfVD3PENMG1O4bHNu6ihTeX9t3PE7mFLILdcIKBHeFXiOH2o+1c2WCUvbAbJt/TyA+8RAvjbBikOHrr2LbvCepTbobjA58j5LKgp/SkrHLNK/5OP3GrU9qPBbSSRlp4K2k1aaDxJfmxDR/BCYYfPthPAuAaWtDNaIsFjLH/FBLPJZVmHwxS9CL5MIQcnyFrrVJoWoy24EIk3xS5H85MTUn+qcV1vokvjo683wT9hGSskibyfx0hdhq0FmgjLnFscSNJmaStjgY3n5TzR+j2AhggkGE9VbRG4zRBZkr9yEnfZGtQitrD5bfQmKw2YypnBTHexZQrQzLYyhEfLzh36KNddjHTguQGXEMVJkVaJkB6BJCvoa1zcw+NW0/qSeb0tAwbyMQQBjaCo9I6QVJiu0B68m5BZTAWZ7Lm0qvSAdo3OPtDc+We1lIBTgZyUSkd9h2aiKsxM82CozIbTzwwwEo+oeVKZCssTX7rtFjNjiQ6OUoD+pTvohA/osfkOLDBf18Urbo+8fhnOO3WaSz94R7qFILhd41c+E3+npqO7i/qfOUFmuU8QpGFRalN4oZ3XkF0/ZtwHEFjsZOiD2NgSNaYROguCOU+P1RG5MKFfM9bbd4RzSsiSCsGThICGdMvR9NeSh6mlf5zhl6mIinbh03ITA953lUCQni9M0ZG1q+HQYRPbseIf8/yaV9NZcD4K5TFdvUDFAW4J/UdRRGuOJBz9hDoCxo+UGxV/zyVARVGRyqbtJzh1xMjrE6tWljmVXAcEeQlb1G0oZgWWlTYVlfbFAO6DVi+3Mnf83rHyWRABY/fswJssZd2pouCq1tWB3nZExkhzwrFgLRr7dybJbbCIEMyEyLakhl3DQlX7u8tkyfb/DWFt7YlZZXg7WyLVkCvtbGd/lj1Pb1NpJpoqXvupDBXkh+M9KB5e/PmZsBxAlnlc+hSesHDxQfXtMCnFHk73gmDV19AC/UDstjPllJcR7/n0JiuAZ1dNL2pctD5C5OYkPwjzVErVN1XpuH7trV3SueVVLqQsrS3fCRpVvRHkvgj69ZKzusguW2j7fCeXDhOoMjuxKgPi4rs6u/Dpxz+SOXGwmfvnkT66VyBcB16+OwP5uRUFMeqdsIgRLKzmrMPxotdsf5k9AwZshNC4SQaBzGm10ycVUE/YiGKUcmp3Ui3E7vaRguG543IhIb34XjAD5u3QzsMGuCiRRQ/gTfdS+0Zq2DQIokJSUb1K7TkZjQ000mhSRWo7wWOFXOgn5Bk0qKV3BzUvANyKTVAyQ3Ez584MEBu+GaStH8qMquXfZx24oWI/A4hxdKRsO1JWV6uB6usx8mMKvaLzfMPJ8GVwRJ8ccfvVboiucUN5Mply3jj1fc/RWG/AqLNhxOIepg0myO5bRBfGCk2/woGAf6xDzAwVO6kualk9wSULf61QSubRobW99ykjI+lRTQXkb3pukg6T0OQO+aRWO79qP/kyYgv7viMRBwJH7MppzpU3nwYoBnzkXfqKEPjNzJbvF8Y3fgMDBCMwyhyb8ylvld1d/V8mnFKHOUSgPcJDUvUZXMsR037gTrfx6S4mfybBSpNTMAyh1vTpbB+C0eLhQstEOYFVN5ZMEB4opYfIrH/cCzrcjhFcGoc5QKxd5S5ZUs30saAVqaOZZ21zwQlLZs8eTmFpC+o7fRdaIHG7vmb8uZMI1fItbRV+1DXtmKMLUm4bnrE8uWMDcubyWNmBpVVmSBXQ2l6to6LKAyojpUZqPH6iCl+Nx5q3CP+ewsqKmJtkUUYjZEgw4nBnHNuV/TCW87/BS5e7Mq15rSzZ5pWdCETIod0+HYSfa8UxSpXIBze4AuWX+yTtS03cVWpV1uW23jIB+o76xIRMz9HDvsM2gpauYHPFUSqunyMTbnnzBASKpgBb9l726eQ034SZqQvxSi2SJ9cCI5sgE6TgkmWOgVu0fvVfqvmaffwb/fxM86abIvYNeRGyhMoO4F7Xh9pVnZ9VHdCmVAzvEOhs5+JbduXQpFWuOWYHNxU34dgXaOhRqpAHxJ2NeEDLbNpO36QXEE/BMWI3SBa21bTsHpQBXBITyWr9Jp9ObNm5+1/J3yYKrhooZi6ZefT/c8VIZRVkt3RAS9Jxz2l7U6StB30crilQZ/ypeJo1Sor1HEhxkw3BCqFPB1C7e7B2F05Oeqkdyygld5lxyL3qe0L3e/GBKfr3wOsVB06+V7q5CvUQ0m2rKpfTm8+62j8/tyWqgYJi1mj/sdHZDT6TTxUlhSCOzG8JcjK7vaL6p/G+x2uUGPiMIqeAQylRasiXe+KaGsdmvxByhgj3cZwP5GjhFTKDUFeerm0q7+Q0KEDaeULhRl9FqXLazaTZDfY5k2U7tnWCfZ1Z27bZp7Q7VhYziX9SXcg7WzSw+T4JCLigWg0ekQBKS7xvCAr+Z66dmsl9/h2Ny+nQS+jAd3a3GlX9lkA4koyZj5nI1xEbibFoKXRtvb7YABo74CbibEqyL+6gyyjS5HxOcD5L2lyssk7+4D6boQk1Z9oLhe7VZK0pnqvVde4lhZru29qITHBD4lO0g/vlhxnU1nXS3Bt+tuC2tSZqXXuzZuUoWnsOcWAVOAz/pEFaoFBs/HKROnAN+h2jyqDc5xFbHQzucEk6Si3NI/43PCkgoT0okEqDIPzMn0Zb3TRJUlzxMcoeDGfJPflkuFOYspL9vjK3YhX69C5Q8k4e4D0Y06G5kPU57mosS9T/+upqq9k7/IsUOlO7HYsxPw9aVPOHdFZ9W5vyUzLvA4lDutOozh25dhw1T7lbBwwiHlosi5St0woKeNa3Q4ZIb+aDn0foLUN/WsqmqPum4ypdY5tb2UgZ8IAQAw/k8KdIHR2W3Fk02uKRhGmzZ2hyMW0TU3nu/T8fKhcF4QzOU3mYvL/NRQ7NUvdzItroDljeoUNtk5W71+K7ZrEAlgb1EonE3N/B9GZRM9rEvUxCh6YLdoT1Nnzadt/mWeLr+Ou12LxjjvnqVGh7fMpv1X9+0NZ1jXwEtWWC5z9zapvf06UZSI+cVp004/ch8Bm8iRMivcJcKN/Ts63Ex9hNelT0x2wl9qmeSE9Ph8JhSYzJkYLZO8VxTbd2SUdjSljaff5iUQ5mx6fO25M6GNaj1KWvDTP12XNqBjd9l6PBwcCetlVtrDv/gSrIf/bkYbMWLrvZRjiW+c+2ALF/tZSGsEF0rF/3Owt/Wt+tKa2t/yjOjY0J5i/3QzvS2NpIB3Zd4iyOyyRpsQb+oc1wSGXcs6BtWHqb5AkzViE3r83EF7PUDJYVBHzKE+X9CYGzI/fsBRHvlxEfcw59PBk9zAp83mHiTaLhBZeSWV9tiuLI1xPgAAnSRJ6pOzxE1iG4kD3rwBty9pNjK12bU+8HFtHdYwEYGzQmLKB6nLTkcT1qYkkF5yb7oiZ0OqIhFK5jFbGLKWDGLQJ2J32FYdxTxRp4eh7tIJ/yrxZSwva33ZPhzRlzJkkOg/eQT34KsgU/yViszdd/2/olxu9p7Z2rBwVXvfL7rSAd+p9aNp3OTbeSI93wQAhQR6BSAbQbZY0Kj3pcb2CoYcZuj+FukciiyQ524kBqexaKtw9JNxQdM6K4sCazkNlxNvOMZPpGk/KRWU5Dkahm0f3cJ6ew9FT+YJqy8CUNlMD1KcQbdBxFEwoHPkeBVrJQpS+jwuW4zWODU5MKJnlO3xuOYwU6QedSOtPg54p+6g3aU4k1LNkoXi2w+HbuS3rDsIxBDoyGLcOnGF9Jl60XI2rOy0+b1aaNE0aaGbCQMDRUiKCVA1vgrQK5/HxmjsHfTIi6bDWod8/FHZs+FqCHoTyYVHopLGOtqVk2ZJelFXR0dz+OBlAX2SN4ceI5uZDS8SXMxP3U1n3JzIEMmfkxsLt6WNh2zE5rEvhBvX5kGLWV4s7NixI0D+E07IAvFmJNh+xYTLqzkto9cnXU+mkcKbTyvP1rxRk0nJGSMc57NbGGD5abH7peTgK0JaQGcqanZ24PvSUnS5s55vqndDY5r7yB1/6yQ3qd8ukSQZZ7VfEC8VPxGn3TTy/4LBtQIgfgN3TesUGisao2zO08ByaoWn0soFlDUtiIlrguersYPNV6vwgTWi4Y8uhvszf7Skfq+6bM84dLrj1gofxDw2edW73/ILhG0N3r25FE2+jXGQR46IGXvZF911Hp3s+gJjxou3DZrl/1aKO0WGkc4uHa9uCvulT4VjAq9XTLhYiPXN+0Cg/Q5F2wrghBs9Y6rZZy7wp3tcjhOu30vQ7aFBq+06MAdoCVJxzIFuPzZl2b8t4i1wPi4/K908McE+4va0ucRm22EK0CRLYtkzvkKf7zC/EowF25gdD3+ebpXDud10aBvuZ+27xYltI6Vrt5s6mHbWHBrsHPAVqQhznWyOqzO0NWLLBkSYp/zKNoi3PjWpb7X47YhkZrcr1QYt5tr1tc529bHPtlmXLjBFWTiUy9g6t8tFoWzVBLF3tRMKbSb/6DLWn2pdlvNNTpYWwqV7omlpEaVTXz3dllA4vdGa8SpraVtIJZ2W2HKwNYsl6LWbVkBWbT0bEq4UzMvpcmP1BYZTqBlBG2FDpmOupz2t83FdDbVZ/HrAfdelGhEhpxLrERVpO40AqKY5t3EUx2C+qDh0uDa2EWsa0y/yzc/6FrL7vkvDrxzF03MINfl6+tfHHyo8ERwimYQQ530MhuRBdne7FNVIhWIDp/GGpa5cOPTT51A/TTatrrmbldkjjLYpGDuEnqSPFxBzkNmL1QtMX+SMb1ybqkRrcC8oXzXgHo7UT7wI7QJGZrk9Ai6yatdJjXEmivYpUldE0CeWUxgSd3d52unVvIt0oc+12bhh307tdlMZBEVe91DfLuse4nNqxFNUfN6GcRcybIxh7ydA9VybUFQ3i/eAa71JfRsY2riAn+28ZY740oX8DFrYKoeP5lP9VmvN0uqaDy6T4a91LrpqEsUFjFR8TI0kVYrpuxen6/uTx1ty6Qde7jsK1TbCvZRyXqL5Sf2aSFCqgNCttzTOrqDPupD8m/z6lnL+++uYbSb+6jFZSOapNWcpqYuy/aLlySXfLTJ1UFrr9VdKPyGfEzyKNr4AmxqH0tZTvTeTaawWxS18/Wul3rCFXriTdbbSG88YctcNcbtigQziXH2lZ6oQ7VDamQXlhlBb5UY0TlcWoLC+V1Xk8D+y6bV6zxguxmIXz5iWdTPl/+jv2xktbiOwAAAAASUVORK5CYII="
+            alt="Logo image of libary"
+          />
+        </div>
+      </a>
+    </div>
+    <div class="header__menu">
+      <nav class="header__menu-first">
+        <div>
+          <div class="header__menu-navigation-mobile">
+            <div
+              class="pagefold-parent--small header__menu-navigation-button header__button"
+              id="header__menu--open"
+            >
+              <div class="pagefold-triangle--small"></div>
+              <img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-menu.svg" alt="List of bookmarks" />
+            </div>
+            <div class="header__menu-navigation-logo">
+              <div class="logo-fallback">
+                <p class="logo-fallback__text-name">Lyngby-Taarbæk</p>
+                <p class="logo-fallback__text-libraries">Bibliotekerne</p>
+              </div>
             </div>
           </div>
+          <ul class="header__menu-navigation">
+            <li class="header__menu-navigation-item">
+              <a
+                href="/"
+                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
+              >
+                Det sker
+              </a>
+            </li>
+            <li class="header__menu-navigation-item">
+              <a
+                href="/"
+                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
+              >
+                Biblioteker &amp; åbningstider
+              </a>
+            </li>
+            <li class="header__menu-navigation-item">
+              <a
+                href="/"
+                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
+              >
+                Digitale tilbud
+              </a>
+            </li>
+            <li class="header__menu-navigation-item">
+              <a
+                href="/"
+                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
+              >
+                Litteratur
+              </a>
+            </li>
+            <li class="header__menu-navigation-item">
+              <a
+                href="/"
+                class="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
+              >
+                Børn &amp; forældre
+              </a>
+            </li>
+          </ul>
         </div>
-        <ul class="header-menu--navigation">
-          <li class="header-menu--navigation--item">
-            <a
-              href="/"
-              class="header-menu--navigation--link text-body-medium-regular hide-linkstyle"
-            >
-              Det sker
-            </a>
-          </li>
-          <li class="header-menu--navigation--item">
-            <a
-              href="/"
-              class="header-menu--navigation--link text-body-medium-regular hide-linkstyle"
-            >
-              Biblioteker &amp; åbningstider
-            </a>
-          </li>
-          <li class="header-menu--navigation--item">
-            <a
-              href="/"
-              class="header-menu--navigation--link text-body-medium-regular hide-linkstyle"
-            >
-              Digitale tilbud
-            </a>
-          </li>
-          <li class="header-menu--navigation--item">
-            <a
-              href="/"
-              class="header-menu--navigation--link text-body-medium-regular hide-linkstyle"
-            >
-              Litteratur
-            </a>
-          </li>
-          <li class="header-menu--navigation--item">
-            <a
-              href="/"
-              class="header-menu--navigation--link text-body-medium-regular hide-linkstyle"
-            >
-              Børn &amp; forældre
-            </a>
-          </li>
-        </ul>
+        <div class="header__menu-profile header__button">
+          <a href="/" class="hide-linkstyle">
+            <img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-profile.svg" alt="Profile" />
+          </a>
+        </div>
+        <div class="header__menu-bookmarked header__button">
+          <a href="/">
+            <img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt="List of bookmarks" />
+          </a>
+        </div>
+      </nav>
+      {{ search_header }}
+    </div>
+    <div class="header__clock">
+      <div class="pagefold-parent--medium">
+        <div class="pagefold-triangle--medium"></div>
       </div>
-      <div class="header-menu--profile header-button">
-        <a href="/" class="hide-linkstyle">
-          <img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-profile.svg" alt="Profile" />
-        </a>
-      </div>
-      <div class="header-menu--bookmarked header-button">
-        <a href="/">
-          <img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt="List of bookmarks" />
-        </a>
-      </div>
-    </nav>
-    <div class="header-menu--second">
-      <div class="header-menu--search">
-        <input
-          class="header-menu--search--input text-body-medium-regular"
-          type="text"
-          placeholder="Søg blandt bibliotekets materialer"
-        />
+      <div class="header__clock-items">
         <img
-          class="header-menu--search--icon"
-          src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-search.svg"
-          alt="search icon"
+          src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg"
+          class="mb-8"
+          alt="clock icon"
         />
+        <span class="text-small-caption">Fredag</span>
+        <span class="text-small-caption">28 Maj</span>
       </div>
     </div>
-  </div>
-  <div class="header-clock">
-    <div class="pagefold-parent-medium">
-      <div class="pagefold-triangle-medium"></div>
+  </header>
+  <div id="header__overlay">
+    <div class="header__overlay-main">
+      <img id="header__menu--close" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-cross-medium.svg" />
+      <ul class="header__overlay-menu">
+        <li class="header__overlay-menu-item">
+          <a
+            href="/"
+            class="header__overlay-menu-link text-body-large hide-linkstyle"
+          >
+            Det sker
+          </a>
+        </li>
+        <li class="header__overlay-menu-item">
+          <a
+            href="/"
+            class="header__overlay-menu-link text-body-large hide-linkstyle"
+          >
+            Biblioteker &amp; åbningstider
+          </a>
+        </li>
+        <li class="header__overlay-menu-item">
+          <a
+            href="/"
+            class="header__overlay-menu-link text-body-large hide-linkstyle"
+          >
+            Digitale tilbud
+          </a>
+        </li>
+        <li class="header__overlay-menu-item">
+          <a
+            href="/"
+            class="header__overlay-menu-link text-body-large hide-linkstyle"
+          >
+            Litteratur
+          </a>
+        </li>
+        <li class="header__overlay-menu-item">
+          <a
+            href="/"
+            class="header__overlay-menu-link text-body-large hide-linkstyle"
+          >
+            Børn &amp; forældre
+          </a>
+        </li>
+      </ul>
     </div>
-    <div class="header-clock--items">
-      <img
-        src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg"
-        class="mb-8"
-        alt="clock icon"
-      />
-      <span class="text-small-caption">Fredag</span>
-      <span class="text-small-caption">28 Maj</span>
-    </div>
+    <div class="header__overlay-backdrop"></div>
   </div>
-</header>
-<div id="header-overlay">
-  <div class="header-overlay--main">
-    <img id="header-menu--close" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-cross-medium.svg" />
-    <ul class="header-overlay--menu">
-      <li class="header-overlay--menu--item">
-        <a
-          href="/"
-          class="header-overlay--menu--link text-body-large hide-linkstyle"
-        >
-          Det sker
-        </a>
-      </li>
-      <li class="header-overlay--menu--item">
-        <a
-          href="/"
-          class="header-overlay--menu--link text-body-large hide-linkstyle"
-        >
-          Biblioteker &amp; åbningstider
-        </a>
-      </li>
-      <li class="header-overlay--menu--item">
-        <a
-          href="/"
-          class="header-overlay--menu--link text-body-large hide-linkstyle"
-        >
-          Digitale tilbud
-        </a>
-      </li>
-      <li class="header-overlay--menu--item">
-        <a
-          href="/"
-          class="header-overlay--menu--link text-body-large hide-linkstyle"
-        >
-          Litteratur
-        </a>
-      </li>
-      <li class="header-overlay--menu--item">
-        <a
-          href="/"
-          class="header-overlay--menu--link text-body-large hide-linkstyle"
-        >
-          Børn &amp; forældre
-        </a>
-      </li>
-    </ul>
-  </div>
-  <div class="header-overlay--backdrop"></div>
-</div>

--- a/web/themes/custom/novel/templates/layout/page.html.twig
+++ b/web/themes/custom/novel/templates/layout/page.html.twig
@@ -47,6 +47,7 @@
   {% include '@novel/layout/header.html.twig'
     with {
     'header': page.header,
+    'search_header': search_header
   } only %}
 
   <main id="main-content" role="main">

--- a/web/themes/custom/novel/templates/layout/page.html.twig
+++ b/web/themes/custom/novel/templates/layout/page.html.twig
@@ -47,7 +47,7 @@
   {% include '@novel/layout/header.html.twig'
     with {
     'header': page.header,
-    'search_header': search_header
+    'search_header': search.header
   } only %}
 
   <main id="main-content" role="main">


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-98

#### Description

This PR:
* Enables the dpl_react module so the react apps can be rendered
* Imports the latests heads of the release/1 branch of dpl-react and dpl-design-system
* Adds the search header library
* Implements the search_header library in the header of the Novel theme.
#### Screenshot of the result

![image](https://user-images.githubusercontent.com/998889/171937705-cbd2279e-8140-4658-8686-db95bc862d2c.png)
#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This PR is using deliberately using the release/1 assets of dpl-design-system and dpl-react. The should of course be corrected to latest main in the future.