### PR TITLE
Feature/integrate search result app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
             "type": "package",
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-react",
-                "version": "0.2.0",
+                "version": "0.2.1",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/0.2.0-rc.1/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-feature%2Fsearch-result-app/dist.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -50,7 +50,7 @@
         "composer/installers": "1.11.0",
         "cweagans/composer-patches": "1.7.0",
         "danskernesdigitalebibliotek/dpl-design-system": "^1.1",
-        "danskernesdigitalebibliotek/dpl-react": "^0.2.0",
+        "danskernesdigitalebibliotek/dpl-react": "^0.2.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "drupal/config_ignore": "^2.3",
         "drupal/core-project-message": "^9.2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "330c78fdb39c766a04a79f1d8b5752f4",
+    "content-hash": "914d697d420bd14505b2ba589cc5ce56",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1086,10 +1086,10 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-react",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/0.2.0-rc.1/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-feature%2Fsearch-result-app/dist.zip"
             },
             "require": {
                 "composer/installers": "^1.2.0"

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -7,6 +7,7 @@ module:
   dpl_login: 0
   dpl_mapp: 0
   dpl_react: 0
+  dpl_search: 0
   dynamic_page_cache: 0
   field: 0
   file: 0

--- a/config/sync/language/da/system.action.node_make_sticky_action.yml
+++ b/config/sync/language/da/system.action.node_make_sticky_action.yml
@@ -1,0 +1,1 @@
+label: 'Gør indhold klæbrigt'

--- a/config/sync/language/da/user.role.authenticated.yml
+++ b/config/sync/language/da/user.role.authenticated.yml
@@ -1,0 +1,1 @@
+label: 'Godkendt bruger'

--- a/web/modules/custom/dpl_react/dpl_react.libraries.yml
+++ b/web/modules/custom/dpl_react/dpl_react.libraries.yml
@@ -2,7 +2,7 @@
 hello-world:
   remote: https://github.com/danskernesdigitalebibliotek/dpl-react
   license:
-    name: GNU GPL
+    name: GNU AFFERO
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
@@ -14,7 +14,7 @@ hello-world:
 search-header:
   remote: https://github.com/danskernesdigitalebibliotek/dpl-react
   license:
-    name: GNU GPL
+    name: GNU AFFERO
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
@@ -26,7 +26,7 @@ search-header:
 search-result:
   remote: https://github.com/danskernesdigitalebibliotek/dpl-react
   license:
-    name: GNU GPL
+    name: GNU AFFERO
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
@@ -38,7 +38,7 @@ search-result:
 base:
   remote: https://github.com/danskernesdigitalebibliotek/dpl-react
   license:
-    name: GNU GPL
+    name: GNU AFFERO
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:

--- a/web/modules/custom/dpl_react/dpl_react.libraries.yml
+++ b/web/modules/custom/dpl_react/dpl_react.libraries.yml
@@ -23,6 +23,18 @@ search-header:
     - dpl_react/base
     - dpl_react/handler
 
+search-result:
+  remote: https://github.com/danskernesdigitalebibliotek/dpl-react
+  license:
+    name: GNU GPL
+    url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
+    gpl-compatible: true
+  js:
+    /libraries/dpl-react/search-result.js: {}
+  dependencies:
+    - dpl_react/base
+    - dpl_react/handler
+
 base:
   remote: https://github.com/danskernesdigitalebibliotek/dpl-react
   license:

--- a/web/modules/custom/dpl_search/dpl_search.info.yml
+++ b/web/modules/custom/dpl_search/dpl_search.info.yml
@@ -1,0 +1,8 @@
+name: DPL Search
+description: For material search functionality on the site.
+package: DPL
+dependencies:
+  - dpl_react:dpl_react
+
+type: module
+core_version_requirement: ^9

--- a/web/modules/custom/dpl_search/dpl_search.module
+++ b/web/modules/custom/dpl_search/dpl_search.module
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @file
+ * Dpl_react_demo drupal module file.
+ *
+ * Demonstrates how to use the dpl_react module
+ * and render components.
+ */

--- a/web/modules/custom/dpl_search/dpl_search.module
+++ b/web/modules/custom/dpl_search/dpl_search.module
@@ -2,8 +2,32 @@
 
 /**
  * @file
- * Dpl_react_demo drupal module file.
+ * Dpl_search drupal module file.
  *
- * Demonstrates how to use the dpl_react module
- * and render components.
+ * Is providing theme variables
+ * in order to integrate the DPL react apps in the site
+ * and various other tasks eg. providing rides and controllers for rendering.
  */
+
+use Drupal\Core\Url;
+
+/**
+ * Implements template_preprocess_page().
+ *
+ * @param mixed[] $variables
+ *   Theme variables.
+ */
+function dpl_search_preprocess_page(array &$variables): void {
+  $search_result_url = Url::fromRoute('dpl_search.result')->toString();
+  $data = [
+    'search-header' => [
+      'search-header-url' => $search_result_url,
+      'alt-text' => t('Search field', [], ['context' => 'Search Header']),
+      'input-placeholder' => t('Start typing in order to search', [], ['context' => 'Search Header']),
+    ],
+  ];
+
+  $variables['search'] = [
+    'header' => dpl_react_render('search-header', $data['search-header']),
+  ];
+}

--- a/web/modules/custom/dpl_search/dpl_search.routing.yml
+++ b/web/modules/custom/dpl_search/dpl_search.routing.yml
@@ -2,6 +2,5 @@ dpl_search.result:
   path: '/search'
   defaults:
     _controller: '\Drupal\dpl_search\Controller\DplSearchResultController::index'
-    _title: 'DPL Search'
   requirements:
     _permission: 'access content'

--- a/web/modules/custom/dpl_search/dpl_search.routing.yml
+++ b/web/modules/custom/dpl_search/dpl_search.routing.yml
@@ -1,0 +1,7 @@
+dpl_search.result:
+  path: '/search'
+  defaults:
+    _controller: '\Drupal\dpl_search\Controller\DplSearchResultController::index'
+    _title: 'DPL Search'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/dpl_search/src/Controller/DplSearchResultController.php
+++ b/web/modules/custom/dpl_search/src/Controller/DplSearchResultController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\dpl_search\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * This is used for demoing the react components.
+ */
+class DplSearchResultController extends ControllerBase {
+
+  /**
+   * Demo react rendering.
+   *
+   * @return mixed[]
+   *   Render array.
+   */
+  public function index(): array {
+
+    return [
+      'search-result' => dpl_react_render('search-result'),
+    ];
+  }
+
+}

--- a/web/modules/custom/dpl_search/src/Controller/DplSearchResultController.php
+++ b/web/modules/custom/dpl_search/src/Controller/DplSearchResultController.php
@@ -10,7 +10,7 @@ use Drupal\Core\Controller\ControllerBase;
 class DplSearchResultController extends ControllerBase {
 
   /**
-   * Demo react rendering.
+   * Render search result app.
    *
    * @return mixed[]
    *   Render array.

--- a/web/modules/custom/dpl_search/src/Controller/DplSearchResultController.php
+++ b/web/modules/custom/dpl_search/src/Controller/DplSearchResultController.php
@@ -5,7 +5,7 @@ namespace Drupal\dpl_search\Controller;
 use Drupal\Core\Controller\ControllerBase;
 
 /**
- * This is used for demoing the react components.
+ * Controller for handling search related routes.
  */
 class DplSearchResultController extends ControllerBase {
 
@@ -16,7 +16,6 @@ class DplSearchResultController extends ControllerBase {
    *   Render array.
    */
   public function index(): array {
-
     return [
       'search-result' => dpl_react_render('search-result'),
     ];

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -5,6 +5,8 @@
  * Novel Theme.
  */
 
+use Drupal\Core\Url;
+
 /**
  * Implements template_preprocess_page().
  *
@@ -12,14 +14,16 @@
  *   Theme variables.
  */
 function novel_preprocess_page(array &$variables): void {
+  $search_result_url = Url::fromRoute('dpl_search.result')->toString();
   $data = [
-    // @todo Something Insert the right search result page url when it is ready.
-    'search-header-url' => '/search',
-    'alt-text' => t('Search field', [], ['context' => 'Search Header']),
-    'input-placeholder' => t('Start typing in order to search', [], ['context' => 'Search Header']),
+    'search-header' => [
+      'search-header-url' => $search_result_url,
+      'alt-text' => t('Search field', [], ['context' => 'Search Header']),
+      'input-placeholder' => t('Start typing in order to search', [], ['context' => 'Search Header']),
+    ],
   ];
 
   $variables['search'] = [
-    'header' => dpl_react_render('search-header', $data),
+    'header' => dpl_react_render('search-header', $data['search-header']),
   ];
 }

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -4,26 +4,3 @@
  * @file
  * Novel Theme.
  */
-
-use Drupal\Core\Url;
-
-/**
- * Implements template_preprocess_page().
- *
- * @param mixed[] $variables
- *   Theme variables.
- */
-function novel_preprocess_page(array &$variables): void {
-  $search_result_url = Url::fromRoute('dpl_search.result')->toString();
-  $data = [
-    'search-header' => [
-      'search-header-url' => $search_result_url,
-      'alt-text' => t('Search field', [], ['context' => 'Search Header']),
-      'input-placeholder' => t('Start typing in order to search', [], ['context' => 'Search Header']),
-    ],
-  ];
-
-  $variables['search'] = [
-    'header' => dpl_react_render('search-header', $data['search-header']),
-  ];
-}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-129

#### Description

This PR:
- Integrates the Search Result app from dpl-react
- Introduces a new custom module for managing material search on: dpl_search

dpl_search contains a route and controller that allows the search page to be accessed at: `/ search`.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Screenshots
<img width="922" alt="image" src="https://user-images.githubusercontent.com/998889/173364133-bb3da0b5-4b33-48cb-b4f9-91139e6d8edf.png">

#### Additional comments or questions

If you decide to test the integration you need to:
- Log into the administration
- Goto: /admin/config/services/openid-connect
- Type in the client id / client secret / agency id
- Run `drush cron` at the command line
- Go to /search?q=harry at the site