### PR TITLE
Search and material app updates

### DIFF
--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -19,11 +19,18 @@ use Drupal\Core\Url;
  */
 function dpl_react_apps_preprocess_page(array &$variables): void {
   $search_result_url = Url::fromRoute('dpl_react_apps.search_result')->toString();
+
+  $options = ['context' => 'Search Header'];
+
   $data = [
     'search-header' => [
       'search-header-url' => $search_result_url,
-      'alt-text' => t('Search field', [], ['context' => 'Search Header']),
-      'input-placeholder' => t('Start typing in order to search', [], ['context' => 'Search Header']),
+      'alt-text' => t('Search field', [], $options),
+      'input-placeholder-text' => t('Start typing in order to search', [],
+        $options),
+      'string-suggestion-author-text' => t('Author', [], $options),
+      'string-suggestion-topic-text' => t('Topic', [], $options),
+      'string-suggestion-work-text' => t('Work', [], $options),
     ],
   ];
 

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -9,7 +9,6 @@
  * and various other tasks eg. providing rides and controllers for rendering.
  */
 
-use Drupal\Core\Url;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 
 /**
@@ -19,13 +18,11 @@ use Drupal\dpl_react_apps\Controller\DplReactAppsController;
  *   Theme variables.
  */
 function dpl_react_apps_preprocess_page(array &$variables): void {
-  $search_result_url = Url::fromRoute('dpl_react_apps.search_result')->toString();
-
   $options = ['context' => 'Search Header'];
 
   $data = [
     'search-header' => [
-      'search-url' => $search_result_url,
+      'search-url' => DplReactAppsController::searchResultUrl(),
       'material-url' => DplReactAppsController::materialUrl(),
       'alt-text' => t('Search field', [], $options),
       'input-placeholder-text' => t('Start typing in order to search', [],

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -24,7 +24,7 @@ function dpl_react_apps_preprocess_page(array &$variables): void {
 
   $data = [
     'search-header' => [
-      'search-header-url' => $search_result_url,
+      'search-url' => $search_result_url,
       'alt-text' => t('Search field', [], $options),
       'input-placeholder-text' => t('Start typing in order to search', [],
         $options),

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -10,6 +10,7 @@
  */
 
 use Drupal\Core\Url;
+use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 
 /**
  * Implements template_preprocess_page().
@@ -25,6 +26,7 @@ function dpl_react_apps_preprocess_page(array &$variables): void {
   $data = [
     'search-header' => [
       'search-url' => $search_result_url,
+      'material-url' => DplReactAppsController::materialUrl(),
       'alt-text' => t('Search field', [], $options),
       'input-placeholder-text' => t('Start typing in order to search', [],
         $options),

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.routing.yml
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.routing.yml
@@ -5,10 +5,9 @@ dpl_react_apps.search_result:
   requirements:
     _permission: "access content"
 
-dpl_react_apps.material_page:
-  path: "/material/{pid}"
+dpl_react_apps.work:
+  path: "/work/{wid}"
   defaults:
-    _controller: '\Drupal\dpl_react_apps\Controller\DplReactAppsController::material'
+    _controller: '\Drupal\dpl_react_apps\Controller\DplReactAppsController::work'
   requirements:
     _permission: "access content"
-    pid: "[0-9]+-[a-z]+:[0-9]+"

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -24,16 +24,16 @@ class DplReactAppsController extends ControllerBase {
       'search-result' => dpl_react_render('search-result', [
         'search-url' => self::searchResultUrl(),
         'material-url' => self::materialUrl(),
-        'et-al-text' => t('et. al.', [], $options),
-        'by-author-text' => t('By', [], $options),
-        'show-more-text' => t('Show more', [], $options),
-        'showing-text' => t('Showing', [], $options),
-        'out-of-text' => t('out of', [], $options),
-        'results-text' => t('results', [], $options),
-        'number-description-text' => t('Nr.', [], $options),
-        'in-series-text' => t('In series', [], $options),
-        'available-text' => t('Available', [], $options),
-        'unavailable-text' => t('Unavailable', [], $options)
+        'et-al-text' => $this->t('et. al.', [], $options),
+        'by-author-text' => $this->t('By', [], $options),
+        'show-more-text' => $this->t('Show more', [], $options),
+        'showing-text' => $this->t('Showing', [], $options),
+        'out-of-text' => $this->t('out of', [], $options),
+        'results-text' => $this->t('results', [], $options),
+        'number-description-text' => $this->t('Nr.', [], $options),
+        'in-series-text' => $this->t('In series', [], $options),
+        'available-text' => $this->t('Available', [], $options),
+        'unavailable-text' => $this->t('Unavailable', [], $options),
       ]),
     ];
   }
@@ -93,8 +93,7 @@ class DplReactAppsController extends ControllerBase {
   /**
    * Builds an url for the local search result route.
    */
-  public static function searchResultUrl(): string
-  {
+  public static function searchResultUrl(): string {
     $url = Url::fromRoute('dpl_react_apps.search_result')
       ->toString();
     if ($url instanceof GeneratedUrl) {
@@ -106,8 +105,7 @@ class DplReactAppsController extends ControllerBase {
   /**
    * Builds an url for the material/work route.
    */
-  public static function materialUrl(): string
-  {
+  public static function materialUrl(): string {
     // React applications support variable replacement where variables are
     // prefixed with :. Specify the variable :workid as a parameter to let the
     // route build the url. Unfortunatly : will be encoded as %3A so we have to

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -24,9 +24,7 @@ class DplReactAppsController extends ControllerBase {
     return [
       'search-result' => dpl_react_render('search-result', [
         'search-url' => $search_result_url,
-        // TODO Consider if we can get this value from the routing instead of
-        // hardcoding it.
-        'material-url' => 'work/:workid',
+        'material-url' => self::materialUrl(),
         'et-al-text' => t('et. al.', [], $options),
         'by-author-text' => t('By', [], $options),
         'show-more-text' => t('Show more', [], $options),
@@ -60,9 +58,7 @@ class DplReactAppsController extends ControllerBase {
       'material' => dpl_react_render('material', [
         'wid' => $wid,
         'search-url' => $search_result_url,
-        // TODO Consider if we can get this value from the routing instead of
-        // hardcoding it.
-        'material-url' => '/work/:workid',
+        'material-url' => self::materialUrl(),
         'material-header-author-by-text' => $this->t('By', [], $c),
         'periodikum-select-year-text' => $this->t('Year', [], $c),
         'periodikum-select-week-text' => $this->t('Week', [], $c),
@@ -95,6 +91,21 @@ class DplReactAppsController extends ControllerBase {
         'unavailable-text' => $this->t('Unavailable', [], $c),
       ]),
     ];
+  }
+
+  /**
+   * Builds an url for the material/work route.
+   */
+  public static function materialUrl(): string
+  {
+    // React applications support variable replacement where variables are
+    // prefixed with :. Specify the variable :workid as a parameter to let the
+    // route build the url. Unfortunatly : will be encoded as %3A so we have to
+    // decode the url again to make replacement work.
+    $url = Url::fromRoute('dpl_react_apps.work')
+      ->setRouteParameter('wid', ':workid')
+      ->toString();
+    return urldecode($url);
   }
 
 }

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -17,13 +17,11 @@ class DplReactAppsController extends ControllerBase {
    *   Render array.
    */
   public function search(): array {
-    $search_result_url = Url::fromRoute('dpl_react_apps.search_result')->toString();
-
     $options = ['context' => 'Search Result'];
 
     return [
       'search-result' => dpl_react_render('search-result', [
-        'search-url' => $search_result_url,
+        'search-url' => self::searchResultUrl(),
         'material-url' => self::materialUrl(),
         'et-al-text' => t('et. al.', [], $options),
         'by-author-text' => t('By', [], $options),
@@ -49,15 +47,13 @@ class DplReactAppsController extends ControllerBase {
    *   Render array.
    */
   public function work(string $wid): array {
-    $search_result_url = Url::fromRoute('dpl_react_apps.search_result')->toString();
-
     // Translation context.
     $c = ['context' => 'Work Page'];
 
     return [
       'material' => dpl_react_render('material', [
         'wid' => $wid,
-        'search-url' => $search_result_url,
+        'search-url' => self::searchResultUrl(),
         'material-url' => self::materialUrl(),
         'material-header-author-by-text' => $this->t('By', [], $c),
         'periodikum-select-year-text' => $this->t('Year', [], $c),
@@ -91,6 +87,14 @@ class DplReactAppsController extends ControllerBase {
         'unavailable-text' => $this->t('Unavailable', [], $c),
       ]),
     ];
+  }
+
+  /**
+   * Builds an url for the local search result route.
+   */
+  public static function searchResultUrl(): string
+  {
+    return Url::fromRoute('dpl_react_apps.search_result')->toString();
   }
 
   /**

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -3,6 +3,7 @@
 namespace Drupal\dpl_react_apps\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
 
 /**
  * Controller for rendering full page DPL React apps.
@@ -16,8 +17,27 @@ class DplReactAppsController extends ControllerBase {
    *   Render array.
    */
   public function search(): array {
+    $search_result_url = Url::fromRoute('dpl_react_apps.search_result')->toString();
+
+    $options = ['context' => 'Search Result'];
+
     return [
-      'search-result' => dpl_react_render('search-result'),
+      'search-result' => dpl_react_render('search-result', [
+        'search-url' => $search_result_url,
+        // TODO Consider if we can get this value from the routing instead of
+        // hardcoding it.
+        'material-url' => 'work/:workid',
+        'et-al-text' => t('et. al.', [], $options),
+        'by-author-text' => t('By', [], $options),
+        'show-more-text' => t('Show more', [], $options),
+        'showing-text' => t('Showing', [], $options),
+        'out-of-text' => t('out of', [], $options),
+        'results-text' => t('results', [], $options),
+        'number-description-text' => t('Nr.', [], $options),
+        'in-series-text' => t('In series', [], $options),
+        'available-text' => t('Available', [], $options),
+        'unavailable-text' => t('Unavailable', [], $options)
+      ]),
     ];
   }
 

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -51,20 +51,48 @@ class DplReactAppsController extends ControllerBase {
    *   Render array.
    */
   public function work(string $wid): array {
+    $search_result_url = Url::fromRoute('dpl_react_apps.search_result')->toString();
+
     // Translation context.
     $c = ['context' => 'Work Page'];
 
     return [
       'material' => dpl_react_render('material', [
         'wid' => $wid,
+        'search-url' => $search_result_url,
+        // TODO Consider if we can get this value from the routing instead of
+        // hardcoding it.
+        'material-url' => '/work/:workid',
         'material-header-author-by-text' => $this->t('By', [], $c),
         'periodikum-select-year-text' => $this->t('Year', [], $c),
         'periodikum-select-week-text' => $this->t('Week', [], $c),
         'reserve-book-text' => $this->t('Reserve book', [], $c),
-        'fine-on-bookshelf-text' => $this->t('Find at book Shelf', [], $c),
-        'in-the-same-series-text' => $this->t('In the same series', [], $c),
-        'subjects-text' => $this->t('Subjects', [], $c),
-        'number-in-series-text' => $this->t('in series', [], $c),
+        'find-on-bookshelf-text' => $this->t('Find on book shelf', [], $c),
+        'description-headline-text' => $this->t('Description', [], $c),
+        'identifier-text' => $this->t('Identifiers', [], $c),
+        'in-same-series-text' => $this->t('In the same series', [], $c),
+        'number-description-text' => $this->t('Nr.', [], $c),
+        'in-series-text' => $this->t('in the series', [], $c),
+        'login-to-see-review-text' => $this->t('Log in to read the review', [], $c),
+        'cannot-see-review-text' => $this->t('The review is not accessible', [], $c),
+        'rating-text' => $this->t('out of', [], $c),
+        'hearts-icon-text' => $this->t('hearts', [], $c),
+        'details-of-the-material-text' => $this->t('Details of the material', [], $c),
+        'editions-text' => $this->t('Editions', [], $c),
+        'fiction-nonfiction-text' => $this->t('Fiction/nonfiction', [], $c),
+        'details-text' => $this->t('Details', [], $c),
+        'type-text' => $this->t('Type', [], $c),
+        'language-text' => $this->t('Language', [], $c),
+        'contributors-text' => $this->t('Contributors', [], $c),
+        'original-title-text' => $this->t('Original title', [], $c),
+        'isbn-text' => $this->t('ISBN', [], $c),
+        'edition-text' => $this->t('Edition', [], $c),
+        'scope-text' => $this->t('Scope', [], $c),
+        'publisher-text' => $this->t('Publisher', [], $c),
+        'audience-text' => $this->t('Audience', [], $c),
+        'reserve-text' => $this->t('Reserve', [], $c),
+        'available-text' => $this->t('Available', [], $c),
+        'unavailable-text' => $this->t('Unavailable', [], $c),
       ]),
     ];
   }

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -42,25 +42,21 @@ class DplReactAppsController extends ControllerBase {
   }
 
   /**
-   * Render material page.
-   */
-
-  /**
-   * Render material page.
+   * Render work page.
    *
-   * @param string $pid
-   *   A material post id.
+   * @param string $wid
+   *   A work id.
    *
    * @return mixed[]
    *   Render array.
    */
-  public function material(string $pid): array {
+  public function work(string $wid): array {
     // Translation context.
-    $c = ['context' => 'Material Page'];
+    $c = ['context' => 'Work Page'];
 
     return [
       'material' => dpl_react_render('material', [
-        'pid' => $pid,
+        'wid' => $wid,
         'material-header-author-by-text' => $this->t('By', [], $c),
         'periodikum-select-year-text' => $this->t('Year', [], $c),
         'periodikum-select-week-text' => $this->t('Week', [], $c),

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -3,6 +3,7 @@
 namespace Drupal\dpl_react_apps\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\GeneratedUrl;
 use Drupal\Core\Url;
 
 /**
@@ -94,7 +95,12 @@ class DplReactAppsController extends ControllerBase {
    */
   public static function searchResultUrl(): string
   {
-    return Url::fromRoute('dpl_react_apps.search_result')->toString();
+    $url = Url::fromRoute('dpl_react_apps.search_result')
+      ->toString();
+    if ($url instanceof GeneratedUrl) {
+      $url = $url->getGeneratedUrl();
+    }
+    return $url;
   }
 
   /**
@@ -109,6 +115,9 @@ class DplReactAppsController extends ControllerBase {
     $url = Url::fromRoute('dpl_react_apps.work')
       ->setRouteParameter('wid', ':workid')
       ->toString();
+    if ($url instanceof GeneratedUrl) {
+      $url = $url->getGeneratedUrl();
+    }
     return urldecode($url);
   }
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-176

#### Description

This PR updates the configuration of the search and material apps inserted into the CMS. This is primarily in the way of props being passed to the apps in regard to UI texts and routes.

The route to works/materials is also renamed to `/work/:workid` because what we show is actually works - not materials.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.