### PR TITLE
Trying to clean up codeing style in login module

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -11,3 +11,4 @@
 /update.php
 /web.config
 /autoload.php
+/autoload.php

--- a/web/modules/custom/dpl_library_token/src/LibraryToken.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryToken.php
@@ -3,6 +3,7 @@
 namespace Drupal\dpl_library_token;
 
 use Drupal\dpl_library_token\Exception\LibraryTokenResponseException;
+use Safe\Exceptions\JsonException;
 use function Safe\json_decode as json_decode;
 
 /**
@@ -32,14 +33,16 @@ class LibraryToken {
    *
    * @return LibraryToken
    *   Token object created based on a json formed response.
+   *
+   * @throws \Drupal\dpl_library_token\Exception\LibraryTokenResponseException
    */
   public static function createFromResponseBody(string $response_body): self {
     // Get token data by decoding json.
     try {
       $token_data = json_decode($response_body, TRUE);
     }
-    catch (\JsonException $e) {
-      throw new LibraryTokenResponseException('Could not decode library token response', $e);
+    catch (JsonException $e) {
+      throw new LibraryTokenResponseException($e->getMessage(), $e->getCode(), $e);
     }
     if (empty($token_data['access_token'])) {
       throw new LibraryTokenResponseException('Access token is missing');

--- a/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
+++ b/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
@@ -29,6 +29,8 @@ class LibraryTokenHandlerTest extends UnitTestCase {
 
   /**
    * Test behaviour when no token has been stored yet.
+   *
+   * @throws \Safe\Exceptions\JsonException
    */
   public function testIfNoTokenHasBeenStoredaNewOneIsFetched(): void {
     $collection = $this->prophesize(KeyValueStoreExpirableInterface::class);
@@ -154,7 +156,7 @@ class LibraryTokenHandlerTest extends UnitTestCase {
   }
 
   /**
-   * Dataprovider with settings and expected exception messages.
+   * Data provider with settings and expected exception messages.
    *
    * @return array[]
    */

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -17,14 +17,16 @@ use function Safe\sprintf as sprintf;
 /**
  * Implements hook_openid_connect_userinfo_alter().
  *
- * @param mixed[] $userinfo
+ * @param array $userinfo
  *   User info from external service.
- * @param mixed[] $context
+ * @param array $context
  *   Various openid_connect context. Tokens etc.
+ *
+ * @throws \Safe\Exceptions\StringsException
  */
 function dpl_login_openid_connect_userinfo_alter(array &$userinfo, array $context): void {
 
-  // If we cannot resolve uinque id we cannot continue.
+  // If we cannot resolve unique id we cannot continue.
   if (!$id = $userinfo['attributes']['uniqueId'] ?? FALSE) {
     $userinfo = [];
     return;
@@ -35,7 +37,7 @@ function dpl_login_openid_connect_userinfo_alter(array &$userinfo, array $contex
   $name = uniqid();
   // Drupal needs an email. We set a unique one to apply to that rule.
   $userinfo['email'] = sprintf('%s@dpl-cms.invalid', $name);
-  // Drupal needs a user name. We use the unique id to apply to that rule.
+  // Drupal needs a username. We use the unique id to apply to that rule.
   $userinfo['name'] = $name;
   // openid_connect module needs the sub for creating the auth map.
   $userinfo['sub'] = $id_hash;
@@ -46,11 +48,15 @@ function dpl_login_openid_connect_userinfo_alter(array &$userinfo, array $contex
  *
  * @param \Drupal\Core\Session\AccountInterface $account
  *   User account.
- * @param mixed[] $context
- *   Various openid_connect context. Tokens etc.
+ * @param array $context
+ *   OpenID context.
+ *
+ * @throws \Drupal\Core\TempStore\TempStoreException
+ * @throws \Drupal\dpl_login\Exception\AccessTokenCreationException
  */
 function dpl_login_openid_connect_post_authorize(AccountInterface $account, array $context): void {
   $access_token = AccessToken::createFromOpenidConnectContext($context);
+
   /** @var Drupal\dpl_login\UserTokensProvider $token_provider */
   $token_provider = \Drupal::service('dpl_login.user_tokens');
   $token_provider->setAccessToken($access_token);
@@ -61,13 +67,15 @@ function dpl_login_openid_connect_post_authorize(AccountInterface $account, arra
  *
  * @param \Drupal\user\UserInterface $account
  *   The user account being saved.
- * @param mixed[] $context
+ * @param array $context
  *   Various openid_connect context. Tokens etc.
  *
- *   We are ignoring the function declaration
- *   because PhpStan gives us an iterable error on UserInterface
- *   which we cannot handle for the moment.
- *   @phpstan-ignore-next-line
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ *   Storage execution.
+ *
+ * @phpstan-ignore-next-line
+ *   We are ignoring the function declaration because PhpStan gives us an
+ *   iterable error on UserInterface which we cannot handle for the moment.
  */
 function dpl_login_openid_connect_userinfo_save(UserInterface $account, array $context): void {
   // If the user is new we attach a role to the user.
@@ -80,11 +88,11 @@ function dpl_login_openid_connect_userinfo_save(UserInterface $account, array $c
 /**
  * Decide if the user has already been processed.
  *
- * @param mixed[] $openid_connect_context
+ * @param array $openid_connect_context
  *   Various openid_connect context. Tokens etc.
  *
  * @return bool
- *   Yes or no?
+ *   True if it has been processed else false.
  */
 function _dpl_login_user_has_been_processed(array $openid_connect_context): bool {
   // If we for some reason do not have the information

--- a/web/modules/custom/dpl_login/src/AccessToken.php
+++ b/web/modules/custom/dpl_login/src/AccessToken.php
@@ -26,11 +26,13 @@ class AccessToken {
    *
    * From the data of the openid connect context.
    *
-   * @param mixed[] $context
+   * @param array $context
    *   The openid connect context.
    *
    * @return AccessToken
    *   Token object created based on a json formed response.
+   *
+   * @throws \Drupal\dpl_login\Exception\AccessTokenCreationException
    */
   public static function createFromOpenidConnectContext(array $context): self {
     if (!$access_token = $context['tokens']['access_token'] ?? FALSE) {

--- a/web/modules/custom/dpl_login/src/Plugin/OpenIDConnectClient/Adgangsplatformen.php
+++ b/web/modules/custom/dpl_login/src/Plugin/OpenIDConnectClient/Adgangsplatformen.php
@@ -19,7 +19,7 @@ class Adgangsplatformen extends OpenIDConnectClientBase {
   /**
    * {@inheritdoc}
    *
-   * @return mixed[]
+   * @return array
    *   Default configuration.
    */
   public function defaultConfiguration(): array {
@@ -35,15 +35,15 @@ class Adgangsplatformen extends OpenIDConnectClientBase {
   /**
    * {@inheritdoc}
    *
-   * @param mixed[] $form
+   * @param array $form
    *   Drupal form.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   Drupal form state.
    *
-   * @return mixed[]
-   *   Drupla form array.
+   * @return array
+   *   Drupal form array.
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
     $form = parent::buildConfigurationForm($form, $form_state);
 
     $form['authorization_endpoint'] = [
@@ -78,7 +78,7 @@ class Adgangsplatformen extends OpenIDConnectClientBase {
   /**
    * {@inheritdoc}
    *
-   * @return mixed[]
+   * @return array
    *   Various endpoints.
    */
   public function getEndpoints(): array {
@@ -97,7 +97,7 @@ class Adgangsplatformen extends OpenIDConnectClientBase {
    * @param \Drupal\Core\GeneratedUrl $redirect_uri
    *   The redirect uri.
    *
-   * @return mixed[]
+   * @return array
    *   Url options array.
    */
   protected function getUrlOptions($scope, GeneratedUrl $redirect_uri): array {
@@ -114,7 +114,7 @@ class Adgangsplatformen extends OpenIDConnectClientBase {
    * handle / decode the missing / null value so we hardcode the decoded value
    * to be an empty array.
    *
-   * @return mixed[]
+   * @return array
    *   Decoded id token.
    */
   public function decodeIdToken($id_token): array {

--- a/web/modules/custom/dpl_login/src/Routing/RouteSubscriber.php
+++ b/web/modules/custom/dpl_login/src/Routing/RouteSubscriber.php
@@ -14,8 +14,8 @@ class RouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection): void {
-    // Rewire the core logout route to ours
-    // so we can logout users remotely as well.
+    // Rewire the core logout route to ours, so we can log out users remotely as
+    // well.
     if ($route = $collection->get('user.logout')) {
       $route->setPath('/logout');
     }

--- a/web/modules/custom/dpl_login/src/UserTokensProvider.php
+++ b/web/modules/custom/dpl_login/src/UserTokensProvider.php
@@ -32,6 +32,8 @@ class UserTokensProvider {
    *
    * @param \Drupal\dpl_login\AccessToken $accessToken
    *   Good old access token.
+   *
+   * @throws \Drupal\Core\TempStore\TempStoreException
    */
   public function setAccessToken(AccessToken $accessToken): void {
     $this->tempStore->set('access_token', $accessToken);
@@ -41,7 +43,7 @@ class UserTokensProvider {
    * Get access token.
    *
    * @return \Drupal\dpl_login\AccessToken|null
-   *   Accesstoken or NULL if no one has been stored.
+   *   Access token or NULL if no one has been stored.
    */
   public function getAccessToken(): ?AccessToken {
     return $this->tempStore->get('access_token');

--- a/web/modules/custom/dpl_login/tests/src/Unit/DplLoginControllerTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/DplLoginControllerTest.php
@@ -57,7 +57,7 @@ class DplLoginControllerTest extends UnitTestCase {
     $config_factory = $this->prophesize(ConfigFactoryInterface::class);
     $config_factory->get(LibraryTokenHandler::SETTINGS_KEY)->willReturn($config->reveal());
 
-    $unrouted_url_assembler = $this->prophesize(UnroutedUrlAssemblerInterface::class);
+    $un_routed_url_assembler = $this->prophesize(UnroutedUrlAssemblerInterface::class);
     $generated_url = $this->prophesize(GeneratedUrl::class);
     $generated_url->getGeneratedUrl()->willReturn('https://local.site');
     $url_generator = $this->prophesize(UrlGenerator::class);
@@ -67,14 +67,14 @@ class DplLoginControllerTest extends UnitTestCase {
     $container->set('logger.factory', $logger_factory->reveal());
     $container->set('dpl_login.user_tokens', $user_token_provider->reveal());
     $container->set('config.factory', $config_factory->reveal());
-    $container->set('unrouted_url_assembler', $unrouted_url_assembler->reveal());
+    $container->set('unrouted_url_assembler', $un_routed_url_assembler->reveal());
     $container->set('url_generator', $url_generator->reveal());
 
     \Drupal::setContainer($container);
   }
 
   /**
-   * Make sure an config missing exception is thrown.
+   * Make sure a config missing exception is thrown.
    */
   public function testThatExceptionIsThrownIfLogoutEndpointIsMissing(): void {
     $container = \Drupal::getContainer();


### PR DESCRIPTION
#### Link to issue

No issue.

#### Description

Trying to clean up the code style after switch til php 8 (sid effect of reading the code).

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The failed code style errors are from Drupal arrays that PHPStan whats us to define (due the check level is set to max). Not sure this will be possible: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type
