### PR TITLE
Add dpl library agency module with sms notification setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
                 "version": "0.3.0-rc6",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/reload/dpl-react/releases/download/release-indloggetudlogget-funktionalitet-DDFSOEG-178/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F4/dist.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -35,7 +35,7 @@
                 "type": "drupal-library",
                 "version": "v1.7.0-rc1",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-release%2F3/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-release%2F4/dist.zip",
                     "type": "zip"
                 }
             }
@@ -49,7 +49,7 @@
         "amazeeio/drupal_integrations": "0.3.5",
         "composer/installers": "1.11.0",
         "cweagans/composer-patches": "1.7.0",
-        "danskernesdigitalebibliotek/dpl-design-system": "^1.7@rc",
+        "danskernesdigitalebibliotek/dpl-design-system": "^1.7@RC",
         "danskernesdigitalebibliotek/dpl-react": "^0.3.0@RC",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "drupal/config_ignore": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cd22c4cdcbc767bc7dfb0c0ff9afe6a",
+    "content-hash": "c65ee3aa13602580846a2a3b334c9740",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1080,7 +1080,7 @@
             "version": "v1.7.0-rc1",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-release%2F3/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-release%2F4/dist.zip"
             },
             "type": "drupal-library"
         },
@@ -1089,7 +1089,7 @@
             "version": "0.3.0-rc6",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/reload/dpl-react/releases/download/release-indloggetudlogget-funktionalitet-DDFSOEG-178/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-release%2F4/dist.zip"
             },
             "require": {
                 "composer/installers": "^1.2.0"

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -8,6 +8,7 @@ ignored_config_entities:
   - '~core.entity_view_mode.node.*'
   - ~core.menu.static_menu_link_overrides
   - ~dblog.settings
+  - '~dpl_library_agency.general_settings:reservation_sms_notifications_disabled'
   - '~dpl_mapp.settings:domain'
   - ~field.settings
   - ~field.storage.node.body

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -3,6 +3,7 @@ module:
   breakpoint: 0
   config_filter: 0
   config_ignore: 0
+  dpl_library_agency: 0
   dpl_library_token: 0
   dpl_login: 0
   dpl_mapp: 0

--- a/config/sync/dpl_library_agency.general_settings.yml
+++ b/config/sync/dpl_library_agency.general_settings.yml
@@ -1,3 +1,1 @@
-library_agency_name: null
-sms_notifications_for_patrons_enabled: 1
 reservation_sms_notifications_disabled: 0

--- a/config/sync/dpl_library_agency.general_settings.yml
+++ b/config/sync/dpl_library_agency.general_settings.yml
@@ -1,0 +1,3 @@
+library_agency_name: null
+sms_notifications_for_patrons_enabled: 1
+reservation_sms_notifications_disabled: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -6,4 +6,5 @@ id: administrator
 label: Administrator
 weight: 2
 is_admin: null
-permissions: {  }
+permissions:
+  - 'administer library agency configuration'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -6,4 +6,5 @@ id: local_administrator
 label: 'Local Administrator'
 weight: 3
 is_admin: null
-permissions: {  }
+permissions:
+  - 'administer library agency configuration'

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.info.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.info.yml
@@ -1,0 +1,6 @@
+name: 'DPL Library Agency'
+type: module
+description: 'Module for handling library agency configuration and functionality'
+core: 8.x
+package: 'DPL'
+core_version_requirement: ^9 || ^8

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.links.menu.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.links.menu.yml
@@ -1,0 +1,10 @@
+dpl_library_agency.settings:
+  title: 'Library Agency'
+  route_name: dpl_library_agency.settings
+  parent: system.admin_config
+  weight: 0
+dpl_library_agency.general_settings_form:
+  title: 'General Settings'
+  description: 'Administer various settings for a library agency.'
+  route_name: dpl_library_agency.general_settings
+  parent: dpl_library_agency.settings

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.module
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.module
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Contains dpl_library_agency.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function dpl_library_agency_help(string $route_name, RouteMatchInterface $route_match): string {
+  switch ($route_name) {
+    // Help for the dpl_library_agency module.
+    case 'help.page.dpl_library_agency':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Module for handling library agency configuration and functionality') . '</p>';
+      return $output;
+
+    default:
+      return '';
+  }
+}
+
+/**
+ * Checks wether sms notifications for reservations are enabled.
+ *
+ * @return bool
+ *   TRUE if sms notifications are enabled, FALSE otherwise.
+ */
+function dpl_library_agency_reservation_sms_notifications_is_enabled(): bool {
+  $config = \Drupal::config('dpl_library_agency.general_settings');
+  if ($config->get('reservation_sms_notifications_disabled')) {
+    return FALSE;
+  }
+  return TRUE;
+}

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.module
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.module
@@ -4,17 +4,3 @@
  * @file
  * Contains dpl_library_agency.module.
  */
-
-/**
- * Checks wether sms notifications for reservations are enabled.
- *
- * @return bool
- *   TRUE if sms notifications are enabled, FALSE otherwise.
- */
-function dpl_library_agency_reservation_sms_notifications_is_enabled(): bool {
-  $config = \Drupal::config('dpl_library_agency.general_settings');
-  if ($config->get('reservation_sms_notifications_disabled')) {
-    return FALSE;
-  }
-  return TRUE;
-}

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.module
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.module
@@ -5,25 +5,6 @@
  * Contains dpl_library_agency.module.
  */
 
-use Drupal\Core\Routing\RouteMatchInterface;
-
-/**
- * Implements hook_help().
- */
-function dpl_library_agency_help(string $route_name, RouteMatchInterface $route_match): string {
-  switch ($route_name) {
-    // Help for the dpl_library_agency module.
-    case 'help.page.dpl_library_agency':
-      $output = '';
-      $output .= '<h3>' . t('About') . '</h3>';
-      $output .= '<p>' . t('Module for handling library agency configuration and functionality') . '</p>';
-      return $output;
-
-    default:
-      return '';
-  }
-}
-
 /**
  * Checks wether sms notifications for reservations are enabled.
  *

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.permissions.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.permissions.yml
@@ -1,3 +1,3 @@
 administer library agency configuration:
   title: 'Administer library agency configuration'
-  description: 'Read and view access for the library agency configuration.'
+  description: 'Access for administering of the library agency configuration.'

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.permissions.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.permissions.yml
@@ -1,0 +1,3 @@
+administer library agency configuration:
+  title: 'Administer library agency configuration'
+  description: 'Read and view access for the library agency configuration.'

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.routing.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.routing.yml
@@ -1,0 +1,17 @@
+dpl_library_agency.settings:
+  path: '/admin/config/dpl-library-agency'
+  defaults:
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'Library Agency'
+  requirements:
+    _permission: 'administer library agency configuration'
+
+dpl_library_agency.general_settings:
+  path: '/admin/config/dpl-library-agency/general-settings'
+  defaults:
+    _form: '\Drupal\dpl_library_agency\Form\GeneralSettingsForm'
+    _title: 'Dpl Library Agency General Settings'
+  requirements:
+    _permission: 'administer library agency configuration'
+  options:
+    _admin_route: TRUE

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.routing.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.routing.yml
@@ -10,7 +10,7 @@ dpl_library_agency.general_settings:
   path: '/admin/config/dpl-library-agency/general-settings'
   defaults:
     _form: '\Drupal\dpl_library_agency\Form\GeneralSettingsForm'
-    _title: 'Dpl Library Agency General Settings'
+    _title: 'General Settings'
   requirements:
     _permission: 'administer library agency configuration'
   options:

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.services.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.services.yml
@@ -1,0 +1,4 @@
+services:
+  dpl_library_agency.reservation_settings:
+    class: Drupal\dpl_library_agency\ReservationSettings
+    arguments: ['@config.manager']

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -54,7 +54,6 @@ class GeneralSettingsForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->config('dpl_library_agency.general_settings')
-      ->set('library_agency_name', $form_state->getValue('library_agency_name'))
       ->set('reservation_sms_notifications_disabled', $form_state->getValue('reservation_sms_notifications_disabled'))
       ->save();
 

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\dpl_library_agency\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * General Settings form for a library agency.
+ */
+class GeneralSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'dpl_library_agency_general_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'dpl_library_agency.general_settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('dpl_library_agency.general_settings');
+
+    $form['reservations'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Reservations'),
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $form['reservations']['reservation_sms_notifications_disabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable SMS notifications for reservations'),
+      '#default_value' => $config->get('reservation_sms_notifications_disabled'),
+      '#description' => $this->t('If checked, SMS notifications for patrons will be disabled.'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $this->config('dpl_library_agency.general_settings')
+      ->set('library_agency_name', $form_state->getValue('library_agency_name'))
+      ->set('reservation_sms_notifications_disabled', $form_state->getValue('reservation_sms_notifications_disabled'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -2,13 +2,47 @@
 
 namespace Drupal\dpl_library_agency\Form;
 
+use Drupal\Core\Cache\CacheTagsInvalidator;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\dpl_library_agency\ReservationSettings;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * General Settings form for a library agency.
  */
 class GeneralSettingsForm extends ConfigFormBase {
+
+
+  /**
+   * The cache tags invalidator.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsInvalidator
+   */
+  protected $cacheTagsInvalidator;
+
+  /**
+   * GeneralSettingsForm constructor.
+   */
+  public function __construct(
+    CacheTagsInvalidator $cacheTagsInvalidator,
+  ) {
+    $this->cacheTagsInvalidator = $cacheTagsInvalidator;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The Drupal service container.
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('cache_tags.invalidator'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -58,6 +92,7 @@ class GeneralSettingsForm extends ConfigFormBase {
       ->save();
 
     parent::submitForm($form, $form_state);
+    $this->cacheTagsInvalidator->invalidateTags(ReservationSettings::getCacheTagsSmsNotificationsIsEnabled());
   }
 
 }

--- a/web/modules/custom/dpl_library_agency/src/ReservationSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/ReservationSettings.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\dpl_library_agency;
+
+use Drupal\Core\Config\ConfigManagerInterface;
+
+/**
+ * Class that handles reservation settings for a library agency.
+ */
+class ReservationSettings implements ReservationSettingsInterface {
+
+  /**
+   * Drupal\Core\Config\ConfigManagerInterface definition.
+   *
+   * @var \Drupal\Core\Config\ConfigManagerInterface
+   */
+  protected $configManager;
+
+  /**
+   * Constructs a new ReservationSettings object.
+   */
+  public function __construct(ConfigManagerInterface $config_manager) {
+    $this->configManager = $config_manager;
+  }
+
+  /**
+   * Checks wether sms notifications for reservations are enabled.
+   *
+   * @return bool
+   *   TRUE if sms notifications are enabled, FALSE otherwise.
+   */
+  public function smsNotificationsIsEnabled(): bool {
+    $config = $this->configManager->getConfigFactory()->get('dpl_library_agency.general_settings');
+    if ($config->get('reservation_sms_notifications_disabled')) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Returns cache tags that is touched.
+   *
+   * The cache tags are related to sms notification settings.
+   *
+   * @return string[]
+   *   An array of cache tags.
+   */
+  public static function getCacheTagsSmsNotificationsIsEnabled(): array {
+    return ['dpl_react_app:material'];
+  }
+
+}

--- a/web/modules/custom/dpl_library_agency/src/ReservationSettingsInterface.php
+++ b/web/modules/custom/dpl_library_agency/src/ReservationSettingsInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\dpl_library_agency;
+
+/**
+ * Interface for the ReservationSettings class.
+ */
+interface ReservationSettingsInterface {
+
+  /**
+   * Tells if sms notifications are enabled for patrons.
+   *
+   * @return bool
+   *   TRUE if sms notifications are enabled, FALSE otherwise.
+   */
+  public function smsNotificationsIsEnabled(): bool;
+
+}

--- a/web/modules/custom/dpl_react/dpl_react.module
+++ b/web/modules/custom/dpl_react/dpl_react.module
@@ -81,6 +81,9 @@ function dpl_react_render(string $name, array $data = []): array {
         sprintf('dpl_react/%s', $name),
       ],
     ],
+    '#cache' => [
+      'tags' => ['dpl_react_app', 'dpl_react_app:' . $name],
+    ],
   ];
 
   return $build;

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.info.yml
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.info.yml
@@ -3,6 +3,7 @@ description: For integration of dpl_react apps on the site.
 package: DPL
 dependencies:
   - dpl_react:dpl_react
+  - dpl_library_agency:dpl_library_agency
 
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -5,11 +5,43 @@ namespace Drupal\dpl_react_apps\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\GeneratedUrl;
 use Drupal\Core\Url;
+use Drupal\dpl_library_agency\ReservationSettings;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Controller for rendering full page DPL React apps.
  */
 class DplReactAppsController extends ControllerBase {
+
+  /**
+   * Reservation settings service.
+   *
+   * @var \Drupal\dpl_library_agency\ReservationSettings
+   */
+  protected $reservationSettings;
+
+  /**
+   * DdplReactAppsController constructor.
+   */
+  public function __construct(
+    ReservationSettings $reservationSettings,
+  ) {
+    $this->reservationSettings = $reservationSettings;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The Drupal service container.
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('dpl_library_agency.reservation_settings'),
+    );
+  }
 
   /**
    * Render search result app.
@@ -56,7 +88,9 @@ class DplReactAppsController extends ControllerBase {
       'material' => dpl_react_render('material', [
         'wid' => $wid,
         'sms-notifications-for-reservations-enabled' =>
-        (int) dpl_library_agency_reservation_sms_notifications_is_enabled(),
+        // Data attributes can only be strings
+        // so we need to convert the boolean to a number (0/1).
+        (int) $this->reservationSettings->smsNotificationsIsEnabled(),
         'search-url' => self::searchResultUrl(),
         'material-url' => self::materialUrl(),
         'auth-url' => self::authUrl(),

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -55,6 +55,8 @@ class DplReactAppsController extends ControllerBase {
     return [
       'material' => dpl_react_render('material', [
         'wid' => $wid,
+        'sms-notifications-for-reservations-enabled' =>
+        (int) dpl_library_agency_reservation_sms_notifications_is_enabled(),
         'search-url' => self::searchResultUrl(),
         'material-url' => self::materialUrl(),
         'auth-url' => self::authUrl(),

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -87,7 +87,7 @@ class DplReactAppsController extends ControllerBase {
     return [
       'material' => dpl_react_render('material', [
         'wid' => $wid,
-        'sms-notifications-for-reservations-enabled' =>
+        'sms-notifications-for-reservations-enabled-config' =>
         // Data attributes can only be strings
         // so we need to convert the boolean to a number (0/1).
         (int) $this->reservationSettings->smsNotificationsIsEnabled(),


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-209

#### Description

This PR introduces a new module for handling configuration belonging to a library agency.
The first part of the configuration is the possibility for an administartor to control wether it is possible for patrons to get notified by sms about current reservations.

#### Screenshot of the result

<img width="865" alt="image" src="https://user-images.githubusercontent.com/998889/191207601-62bf9907-e224-4028-8155-e1ab6135df4a.png">

---

<img width="453" alt="image" src="https://user-images.githubusercontent.com/998889/191207660-04b35029-f2fd-45e1-8221-e126ba1fb7b7.png">

#### Checklist

- [x] My complies with [our coding guidelines](../documentation/code-guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
