### PR TITLE
Url proxy functionality

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -10,6 +10,7 @@ ignored_config_entities:
   - ~dblog.settings
   - '~dpl_library_agency.general_settings:reservation_sms_notifications_disabled'
   - '~dpl_mapp.settings:domain'
+  - '~dpl_url_proxy.settings'
   - ~field.settings
   - ~field.storage.node.body
   - ~file.settings

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -9,6 +9,7 @@ module:
   dpl_mapp: 0
   dpl_react: 0
   dpl_react_apps: 0
+  dpl_url_proxy: 0
   dynamic_page_cache: 0
   field: 0
   file: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -8,3 +8,4 @@ weight: 2
 is_admin: null
 permissions:
   - 'administer library agency configuration'
+  - 'administer url proxy configuration'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -8,3 +8,4 @@ weight: 3
 is_admin: null
 permissions:
   - 'administer library agency configuration'
+  - 'administer url proxy configuration'

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -94,6 +94,7 @@ class DplReactAppsController extends ControllerBase {
         'search-url' => self::searchResultUrl(),
         'material-url' => self::materialUrl(),
         'auth-url' => self::authUrl(),
+        'url-proxy-url' => self::urlProxyUrl(),
         'material-header-author-by-text' => $this->t('By', [], $c),
         'periodikum-select-year-text' => $this->t('Year', [], $c),
         'periodikum-select-week-text' => $this->t('Week', [], $c),
@@ -159,6 +160,15 @@ class DplReactAppsController extends ControllerBase {
   public static function authUrl(): string {
     return self::ensureUrlIsString(
       Url::fromRoute('dpl_login.login')->toString()
+    );
+  }
+
+  /**
+   * Builds an url for the react apps to for proxy urls.
+   */
+  public static function urlProxyUrl(): string {
+    return self::ensureUrlIsString(
+      Url::fromRoute('dpl_url_proxy.generate_url')->toString()
     );
   }
 

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.info.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.info.yml
@@ -1,0 +1,6 @@
+name: 'dpl_url_proxy'
+type: module
+description: 'Module for generating specially formatted external urls'
+core: 8.x
+package: 'DPL'
+core_version_requirement: ^8 | ^9

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.info.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.info.yml
@@ -1,4 +1,4 @@
-name: 'dpl_url_proxy'
+name: 'Dpl Url Proxy'
 type: module
 description: 'Module for generating specially formatted external urls'
 core: 8.x

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.links.menu.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.links.menu.yml
@@ -1,0 +1,5 @@
+dpl_url_proxy.admin_settings:
+  title: 'Url proxy settings'
+  description: 'Configure the host names and replacement patterns for proxy urls.'
+  route_name: dpl_url_proxy.configure
+  parent: 'system.admin_config_services'

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.permissions.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.permissions.yml
@@ -1,0 +1,3 @@
+administer url proxy configuration:
+  title: 'Administer url proxy configuration'
+  description: 'Access for administering of the url proxy configuration.'

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
@@ -1,0 +1,9 @@
+dpl_url_proxy.configure:
+  path: 'admin/config/services/dpl-url-proxy'
+  defaults:
+    _form: '\Drupal\dpl_url_proxy\Form\ProxyUrlConfigurationForm'
+    _title: 'Configure proxy urls'
+  requirements:
+    _permission: 'access administration pages'
+  options:
+    _admin_route: TRUE

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
@@ -4,7 +4,7 @@ dpl_url_proxy.configure:
     _form: '\Drupal\dpl_url_proxy\Form\ProxyUrlConfigurationForm'
     _title: 'Configure proxy urls'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer library agency configuration'
   options:
     _admin_route: TRUE
 
@@ -13,7 +13,8 @@ dpl_url_proxy.generate_url:
   defaults:
     _controller: '\Drupal\dpl_url_proxy\Controller\DplUrlProxyController::generateUrl'
     _title: 'Generate proxy url'
+  methods:  [POST]
   requirements:
     _permission: 'access content'
   options:
-    no_cache: 'TRUE'
+    no_cache: TRUE

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
@@ -13,8 +13,5 @@ dpl_url_proxy.generate_url:
   defaults:
     _controller: '\Drupal\dpl_url_proxy\Controller\DplUrlProxyController::generateUrl'
     _title: 'Generate proxy url'
-  methods:  [POST]
   requirements:
     _permission: 'access content'
-  options:
-    no_cache: TRUE

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
@@ -4,7 +4,7 @@ dpl_url_proxy.configure:
     _form: '\Drupal\dpl_url_proxy\Form\ProxyUrlConfigurationForm'
     _title: 'Configure proxy urls'
   requirements:
-    _permission: 'administer library agency configuration'
+    _permission: 'administer url proxy configuration'
   options:
     _admin_route: TRUE
 

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.routing.yml
@@ -7,3 +7,13 @@ dpl_url_proxy.configure:
     _permission: 'access administration pages'
   options:
     _admin_route: TRUE
+
+dpl_url_proxy.generate_url:
+  path: '/dpl-url-proxy/generate-url'
+  defaults:
+    _controller: '\Drupal\dpl_url_proxy\Controller\DplUrlProxyController::generateUrl'
+    _title: 'Generate proxy url'
+  requirements:
+    _permission: 'access content'
+  options:
+    no_cache: 'TRUE'

--- a/web/modules/custom/dpl_url_proxy/src/Controller/DplUrlProxyController.php
+++ b/web/modules/custom/dpl_url_proxy/src/Controller/DplUrlProxyController.php
@@ -4,14 +4,12 @@ namespace Drupal\dpl_url_proxy\Controller;
 
 use Drupal\Core\Cache\CacheableJsonResponse;
 use Drupal\Core\Cache\CacheableMetadata;
-use Safe\Exceptions\JsonException;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\dpl_url_proxy\DplUrlProxyInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use function Safe\json_decode;
 use function Safe\parse_url;
 use function Safe\preg_replace;
 
@@ -107,8 +105,18 @@ class DplUrlProxyController extends ControllerBase {
       }
     }
 
-    $data = ['data' => ['url' => $url]];
-    $response = new CacheableJsonResponse($data);
+    $cacheTags = $this->configManager
+      ->getConfigFactory()
+      ->get(DplUrlProxyInterface::CONFIG_NAME)
+      ->getCacheTags();
+
+    $data = [
+      'data' => ['url' => $url],
+      '#cache' => [
+        'tags' => $cacheTags,
+      ],
+    ];
+    $response = new CacheableJsonResponse(['data' => $data['data']]);
     $response->addCacheableDependency(
       CacheableMetadata::createFromRenderArray($data)
     );

--- a/web/modules/custom/dpl_url_proxy/src/Controller/DplUrlProxyController.php
+++ b/web/modules/custom/dpl_url_proxy/src/Controller/DplUrlProxyController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\dpl_url_proxy\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\dpl_url_proxy\DplUrlProxyInterface;
+use Drupal\dpl_url_proxy\Form\ProxyUrlConfigurationForm;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Class DplUrlProxyController.
+ */
+class DplUrlProxyController extends ControllerBase {
+
+  /**
+   * Drupal\Core\Config\ConfigManagerInterface definition.
+   *
+   * @var \Drupal\Core\Config\ConfigManagerInterface
+   */
+  protected $configManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $instance = parent::create($container);
+    $instance->configManager = $container->get('config.manager');
+    // $logger_factory = $container->get('logger.factory');
+    // $instance->loggger = $logger_factory->get('dpl_url_proxy');
+
+    return $instance;
+  }
+
+  protected function getSavedValues() {
+    return $this->configManager
+    ->getConfigFactory()
+    ->get(DplUrlProxyInterface::CONFIG_NAME)
+    ->get('values', [
+      'prefix' => '',
+      'hostnames' => [],
+    ]);
+  }
+  /**
+   * John.
+   *
+   * @return string
+   *   Return Hello string.
+   */
+  public function generateUrl(Request $request) {
+    $t_opts = DplUrlProxyInterface::TRANSLATION_OPTIONS;
+    $saved_values = $this->getSavedValues();
+    $post_data = json_decode($request->getContent(), TRUE);
+    $url = $post_data['url'] ?? NULL;
+
+    if (!$host = parse_url($post_data['url'], PHP_URL_HOST)) {
+      throw new HttpException(400, $this->t('Provided url is not in the right format', [], $t_opts));
+    }
+
+    if (!$prefix = $saved_values['prefix'] ?? null) {
+      $this->getLogger('dpl_url_proxy')->error('Prefix is not set');
+      throw new HttpException(500, $this->t('Could not resolve url. Insufficient configuration', [], $t_opts));
+    }
+
+    // Search host names.
+    foreach ($saved_values['hostnames'] as $config) {
+      if ($host == $config['hostname']) {
+        // Rewrite/convert url using regex.
+        if (
+            (isset($config['expression']['regex']) && !empty($config['expression']['regex']))
+            && (isset($config['expression']['replacement']) && !empty($config['expression']['replacement']))
+          ) {
+            $url = preg_replace(
+              $config['expression']['regex'],
+              $config['expression']['replacement'],
+              $url
+            );
+        }
+
+        // Add prefix, if chosen.
+        if (!$config['disable_prefix']) {
+          // The URL is not encoded as it's send on to online resources proxies
+          // (ezproxy), which fails if the url is encoded.
+          $url = $prefix . $url;
+        }
+
+        // Exit the foreach loop.
+        break;
+      }
+    }
+
+    return new JsonResponse(['data' => $url]);
+  }
+
+}

--- a/web/modules/custom/dpl_url_proxy/src/Controller/DplUrlProxyController.php
+++ b/web/modules/custom/dpl_url_proxy/src/Controller/DplUrlProxyController.php
@@ -43,16 +43,14 @@ class DplUrlProxyController extends ControllerBase {
    */
   protected function getConfiguration(): array {
     // We need to provide a default value here if the configuration is not
-    // available. But Phpstan does not get it :).
-    // phpcs:ignore
-    /** @phpstan-ignore-next-line */
+    // available.
     return $this->configManager
       ->getConfigFactory()
       ->get(DplUrlProxyInterface::CONFIG_NAME)
-      ->get('values', [
+      ->get('values') ?? [
         'prefix' => '',
         'hostnames' => [],
-      ]);
+      ];
   }
 
   /**

--- a/web/modules/custom/dpl_url_proxy/src/DplUrlProxyInterface.php
+++ b/web/modules/custom/dpl_url_proxy/src/DplUrlProxyInterface.php
@@ -9,7 +9,7 @@ interface DplUrlProxyInterface {
 
   const CONFIG_NAME = 'dpl_url_proxy.settings';
   const TRANSLATION_OPTIONS = [
-    'context' => 'dpl_url_proxy',
+    'context' => 'Url Proxy',
   ];
 
 }

--- a/web/modules/custom/dpl_url_proxy/src/DplUrlProxyInterface.php
+++ b/web/modules/custom/dpl_url_proxy/src/DplUrlProxyInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\dpl_url_proxy;
+
+/**
+ * Interface for dpl_url_proxy constants.
+ */
+interface DplUrlProxyInterface {
+
+  const CONFIG_NAME = 'dpl_url_proxy.settings';
+  const TRANSLATION_OPTIONS = [
+    'context' => 'dpl_url_proxy',
+  ];
+
+}

--- a/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
+++ b/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
@@ -18,14 +18,12 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
   use StringTranslationTrait;
   use MessengerTrait;
 
-  public const CONFIG_NAME = 'dpl_url_proxy.settings';
-
   /**
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
     return [
-      self::CONFIG_NAME,
+      DplUrlProxyInterface::CONFIG_NAME,
     ];
   }
 
@@ -36,7 +34,7 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
    *   The url proxy configuration.
    */
   protected function getConfiguration() {
-    $config = $this->config(self::CONFIG_NAME);
+    $config = $this->config(DplUrlProxyInterface::CONFIG_NAME);
     return $config->get('values') ?? [
       'prefix' => '',
       'hostnames' => [],
@@ -223,7 +221,7 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function getFormId(): string {
-    return 'form_api_example_ajax_addmore';
+    return 'proxy-url-configuration';
   }
 
   /**

--- a/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
+++ b/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
@@ -28,7 +28,15 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
     ];
   }
 
-  protected function getSavedValues() {
+
+  /**
+   *
+   * Get the url proxy configuration.
+   *
+   * @return mixed[]
+   *  The url proxy configuration.
+   */
+  protected function getConfiguration() {
     $config = $this->config(self::CONFIG_NAME);
     return $config->get('values', [
       'prefix' => '',
@@ -36,18 +44,21 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
     ]);
   }
 
-  protected function getFormStateValues (FormStateInterface $form_state) {
-    return array_reduce($form_state->getValue(['hostnames']), function(
-      $carry, $item
-    ) {
-      if(!empty($item['name'])) {
-        unset($item['remove_this']);
-        $carry[] = $item;
-      }
-      return $carry;
-    }, []);
-  }
+  // protected function getFormStateValues (FormStateInterface $form_state) {
+  //   return array_reduce($form_state->getValue(['hostnames']), function(
+  //     $carry, $item
+  //   ) {
+  //     if(!empty($item['name'])) {
+  //       unset($item['remove_this']);
+  //       $carry[] = $item;
+  //     }
+  //     return $carry;
+  //   }, []);
+  // }
 
+  /**
+   * Create indexes used for the host names add more/delete part.
+   */
   protected function constructHostnameIndexes ($form_state, $values) {
     $indexes = $form_state->get('indexes');
 
@@ -62,10 +73,17 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
     return [0];
   }
 
-  protected function regexIsConfiguredLabel($values): string {
+  /**
+   * Creates a label for an "expression" fieldset if configured.
+   *
+   * @param array $element
+   *   Host name element.
+   *
+   */
+  protected function regexIsConfiguredLabel($element): string {
     if(
-      empty($values['expression']['regex'])
-      && empty($values['expression']['replacement'])
+      empty($element['expression']['regex'])
+      && empty($element['expression']['replacement'])
     ) {
       return "";
     }
@@ -76,11 +94,14 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $t_opts = DplUrlProxyInterface::TRANSLATION_OPTIONS;
-    $indexes = $this->constructHostnameIndexes($form_state, $this->getSavedValues());
+    $indexes = $this->constructHostnameIndexes($form_state, $this->getConfiguration());
     $form_state->set('indexes', $indexes);
-    $saved_values = $this->getSavedValues();
+    $saved_values = $this->getConfiguration();
 
     $form['#tree'] = TRUE;
     $form['description'] = [
@@ -210,6 +231,16 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
     return $form['hostnames'];
   }
 
+  /**
+   * Adds one more host name element.
+   *
+   * @param array $form
+   *   Drupal form array
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *  Drupal form state
+   *
+   * @return void
+   */
   public function addOne(array &$form, FormStateInterface $form_state): void {
     $indexes = $form_state->get('indexes');
     $last = end($indexes);
@@ -218,7 +249,16 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
     $form_state->setRebuild();
   }
 
-
+  /**
+   * Removed one host name element.
+   *
+   * @param array $form
+   *   Drupal form array
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *  Drupal form state
+   *
+   * @return void
+   */
   public function removeOne(array &$form, FormStateInterface $form_state): void {
     $remove_value = $form_state->getTriggeringElement()['#name'];
     $key = array_search($remove_value, $form_state->get('indexes'));
@@ -228,6 +268,9 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
     $form_state->setRebuild();
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $values = [];
     if ($form_state->getValue('prefix')) {

--- a/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
+++ b/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Drupal\dpl_url_proxy\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Class ProxyUrlConfigurationForm.
+ *
+ * @package Drupal\dpl_url_proxy\Form
+ */
+class ProxyUrlConfigurationForm extends ConfigFormBase {
+  use StringTranslationTrait;
+  use MessengerTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'dpl_url_proxy.settings',
+    ];
+  }
+
+  protected function getSavedValues() {
+    $config = $this->config('dpl_url_proxy.settings');
+    return $config->get('values');
+  }
+
+  protected function getFormStateValues (FormStateInterface $form_state) {
+    return array_reduce($form_state->getValue(['hostnames']), function($carry, $item) {
+      if(!empty($item['name'])) {
+        unset($item['remove_this']);
+        $carry[] = $item;
+      }
+      return $carry;
+    }, []);
+  }
+
+  protected function constructIndexes ($form_state, $values) {
+    $indexes = $form_state->get('indexes');
+
+    if ($indexes !== NULL) {
+      return $indexes;
+    }
+
+    if ($values) {
+      return array_keys($values);
+    }
+
+    return [0];
+  }
+
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['description'] = [
+      '#type' => 'item',
+      '#markup' => $this->t('This configuration form is for administering proxy url generation.'),
+    ];
+
+    $indexes = $this->constructIndexes($form_state, $this->getSavedValues());
+    $form_state->set('indexes', $indexes);
+    $saved_values = $this->getSavedValues();
+
+    $form['#tree'] = TRUE;
+    $form['hostnames'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Hostnames'),
+      '#prefix' => '<div id="hostnames-fieldset-wrapper">',
+      '#suffix' => '</div>',
+    ];
+
+    foreach($indexes as $index) {
+      $form['hostnames'][$index] = [
+        '#type' => 'fieldset',
+        '#title' => $this->t('Hostname'),
+      ];
+      $form['hostnames'][$index]['name'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Name'),
+        '#default_value' => $saved_values[$index]['name'] ?? '',
+      ];
+      $form['hostnames'][$index]['shoe_size'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Shoe size'),
+        '#default_value' => $saved_values[$index]['shoe_size'] ?? '',
+      ];
+      $form['hostnames'][$index]['remove_this'] = [
+        '#name' => $index,
+        '#type' => 'submit',
+        '#value' => $this->t('Remove this'),
+        '#submit' => ['::removeOne'],
+        '#ajax' => [
+          'callback' => '::addmoreCallback',
+          'wrapper' => 'hostnames-fieldset-wrapper',
+        ],
+      ];
+    }
+
+    $form['hostnames']['actions'] = [
+      '#type' => 'actions',
+    ];
+    $form['hostnames']['actions']['add'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add one more'),
+      '#submit' => ['::addOne'],
+      '#ajax' => [
+        'callback' => '::addmoreCallback',
+        'wrapper' => 'hostnames-fieldset-wrapper',
+      ],
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Submit'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'form_api_example_ajax_addmore';
+  }
+
+  public function addmoreCallback(array &$form, FormStateInterface $form_state) {
+    return $form['hostnames'];
+  }
+
+  public function addOne(array &$form, FormStateInterface $form_state) {
+    $indexes = $form_state->get('indexes');
+    $last = end($indexes);
+    $indexes[] = $last + 1;
+    $form_state->set('indexes', $indexes);
+    $form_state->setRebuild();
+  }
+
+
+  public function removeOne(array &$form, FormStateInterface $form_state) {
+    $remove_value = $form_state->getTriggeringElement()['#name'];
+    $key = array_search($remove_value, $form_state->get('indexes'));
+    if ($key !== false) {
+      unset($form_state->get('indexes')[$key]);
+    }
+    $form_state->setRebuild();
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $values = array_reduce($form_state->getValue(['hostnames']), function($carry, $item) {
+      if(!empty($item['name'])) {
+        unset($item['remove_this']);
+        $carry[] = $item;
+      }
+      return $carry;
+    }, []);
+
+    $output = json_encode($values, JSON_PRETTY_PRINT);
+    $this->messenger()->addMessage($output);
+
+    $this->config('dpl_url_proxy.settings')
+      ->set('values', $values)
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+}

--- a/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
+++ b/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
@@ -43,6 +43,9 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
     ];
   }
 
+  // Phpstan and phpcs is conflicting about the return type.
+  // phpcs:disable Drupal.Commenting.FunctionComment.InvalidReturn
+
   /**
    * Create indexes used for the host names add more/delete part.
    *
@@ -51,7 +54,7 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
    * @param mixed[] $values
    *   Saved configuration.
    *
-   * @return arrayint|string
+   * @return array<int|string>
    *   The indexes.
    */
   protected function constructHostnameIndexes(FormStateInterface $form_state, array $values): array {
@@ -67,6 +70,8 @@ class ProxyUrlConfigurationForm extends ConfigFormBase {
 
     return [0];
   }
+
+  // phpcs:enable
 
   /**
    * Creates a label for an "expression" fieldset if configured.

--- a/web/modules/custom/dpl_url_proxy/tests/src/Unit/DplUrlProxyControllerTest.php
+++ b/web/modules/custom/dpl_url_proxy/tests/src/Unit/DplUrlProxyControllerTest.php
@@ -105,6 +105,7 @@ class DplUrlProxyControllerTest extends UnitTestCase {
    */
   public function testThatEndpointChangesUrl(array $input, array $expected_output, array $conf): void {
     $config = $this->prophesize(ImmutableConfig::class);
+    $config->getCacheTags()->willReturn([]);
     $config->get(Argument::any(), Argument::any())->willReturn($conf);
 
     $config_factory = $this->prophesize(ConfigFactoryInterface::class);

--- a/web/modules/custom/dpl_url_proxy/tests/src/Unit/DplUrlProxyControllerTest.php
+++ b/web/modules/custom/dpl_url_proxy/tests/src/Unit/DplUrlProxyControllerTest.php
@@ -92,7 +92,7 @@ class DplUrlProxyControllerTest extends UnitTestCase {
   }
 
   /**
-   * Data provider for testThatUrlIsGenerated.
+   * Test that the url is generated correctly.
    *
    * @param mixed[] $input
    *   The input from the request body.

--- a/web/modules/custom/dpl_url_proxy/tests/src/Unit/DplUrlProxyControllerTest.php
+++ b/web/modules/custom/dpl_url_proxy/tests/src/Unit/DplUrlProxyControllerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Drupal\Tests\dpl_library_token\Unit;
+
+use phpmock\MockBuilder;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ConfigManagerInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\StringTranslation\TranslationManager;
+use Drupal\dpl_url_proxy\Controller\DplUrlProxyController;
+use Drupal\dpl_url_proxy\DplUrlProxyInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Unit tests for the Library Token Handler.
+ */
+class DplUrlProxyControllerTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    // $logger = $this->prophesize(LoggerInterface::class);
+    // $logger->error(Argument::any(), Argument::any())->shouldNotBeCalled();
+    // $logger_factory = $this->prophesize(LoggerChannelFactoryInterface::class);
+    // $logger_factory->get(Argument::any())->willReturn($logger->reveal());
+
+    $config = $this->prophesize(ImmutableConfig::class);
+    $config->get('values', [
+      'prefix' => '',
+      'hostnames' => [],
+    ])->willReturn([
+      'prefix' => '',
+      'hostnames' => [],
+    ]);
+
+    $config_factory = $this->prophesize(ConfigFactoryInterface::class);
+    $config_factory->get(DplUrlProxyInterface::CONFIG_NAME)->willReturn($config->reveal());
+
+    $config_manager = $this->prophesize(ConfigManagerInterface::class);
+    $config_manager->getConfigFactory()->willReturn($config_factory->reveal());
+
+    $string_translation = $this->prophesize(TranslationManager::class);
+    $container = new ContainerBuilder();
+    // $container->set('logger.factory', $logger_factory->reveal());
+    $container->set('config.manager', $config_manager->reveal());
+    $container->set('string_translation', $string_translation->reveal());
+
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   *
+   */
+  public function testThatExceptionIsThrownIfPostDataIsMissing(): void {
+    $container = \Drupal::getContainer();
+    $controller = DplUrlProxyController::create($container);
+
+    $this->expectException(HttpException::class);
+    $this->expectExceptionMessage('Post body could not be decoded');
+
+    $request = new Request();
+    $controller->generateUrl($request);
+  }
+
+  /**
+   *
+   */
+  public function testThatExceptionIsThrownIfPostDataIsNotContainingUrlProperty(): void {
+    $container = \Drupal::getContainer();
+    $controller = DplUrlProxyController::create($container);
+
+    $this->expectException(HttpException::class);
+    $this->expectExceptionMessage('Post body could not be decoded');
+
+    $request = new Request([], ['foo' => 'bar']);
+    $controller->generateUrl($request);
+  }
+
+  /**
+   *
+   */
+  public function testThatExceptionIsThrownIfPostDataIsContainingMalignUrl(): void {
+    $container = \Drupal::getContainer();
+    $controller = DplUrlProxyController::create($container);
+
+    $this->expectException(HttpException::class);
+    $this->expectExceptionMessage('Provided url is not in the right format');
+
+    $request = Request::create(
+      '/dpl-url-proxy/generate-url',
+      'POST', [], [], [], [], json_encode(['url' => 'foo'])
+    );
+
+    $controller->generateUrl($request);
+  }
+
+  public function testThatExceptionIsThrownIfPrefixIsNotSet(): void {
+    $container = \Drupal::getContainer();
+    $controller = DplUrlProxyController::create($container);
+
+    $this->expectException(HttpException::class);
+    $this->expectExceptionMessage('Could not resolve url. Insufficient configuration');
+
+    $request = Request::create(
+      '/dpl-url-proxy/generate-url',
+      'POST', [], [], [], [], json_encode(['url' => 'http://foo.bar'])
+    );
+
+    $controller->generateUrl($request);
+  }
+
+  /**
+   * @dataProvider testThatEndpointChangesUrlProvider
+   */
+  public function testThatEndpointChangesUrl($input, $expected_output, $conf): void {
+    $config = $this->prophesize(ImmutableConfig::class);
+    $config->get(Argument::any(), Argument::any())->willReturn($conf);
+
+    $config_factory = $this->prophesize(ConfigFactoryInterface::class);
+    $config_factory->get(DplUrlProxyInterface::CONFIG_NAME)->willReturn($config->reveal());
+
+    $config_manager = $this->prophesize(ConfigManagerInterface::class);
+    $config_manager->getConfigFactory()->willReturn($config_factory->reveal());
+
+    $container = new ContainerBuilder();
+    $container->set('config.manager', $config_manager->reveal());
+    $controller = DplUrlProxyController::create($container);
+
+    $request = Request::create(
+      '/dpl-url-proxy/generate-url',
+      'POST', [], [], [], [], json_encode($input)
+    );
+
+    $response = $controller->generateUrl($request);
+
+    $this->assertEquals(
+      json_encode($expected_output),
+      $response->getContent()
+    );
+  }
+
+  /**
+   *
+   */
+  public function testThatEndpointChangesUrlProvider() {
+    $conf = [
+      'prefix' => 'http://bib101.bibbaser.dk/login?url=',
+      'hostnames' => [
+        [
+          'hostname' => 'john.com',
+          'expression' =>
+          [
+            'regex' => '/(.*)ohn(.*)/',
+            'replacement' => '$1ane$2',
+          ],
+          'disable_prefix' => 0,
+        ],
+        [
+          'hostname' => 'sally.com',
+          'expression' =>
+          [
+            'regex' => '/(p)[a]+(lle)/',
+            'replacement' => '$1o$2',
+          ],
+          'disable_prefix' => 1,
+        ],
+      ],
+    ];
+
+    return [
+      [
+        ['url' => 'http://john.com'],
+        ['data' => 'http://bib101.bibbaser.dk/login?url=http://jane.com'],
+        $conf
+      ],
+      [
+        ['url' => 'http://sally.com?foo=palle'],
+        ['data' => 'http://sally.com?foo=polle'],
+        $conf
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-235

#### Description

This PR adds a new module called: dpl_url_proxy.
The module does following:
* Exposes a configuration form only adminesterable by admin/local_admin
* Provides an endpoint to be used by clients (in current project: react apps) to translate material urls.
* Sets an url prop on the material react app for the url proxy endpoint.
 
#### Screenshot of the result
<img width="429" alt="image" src="https://user-images.githubusercontent.com/998889/192247218-b78cc010-f001-4fba-8d9a-f6fcd0a9f998.png">

<img width="845" alt="image" src="https://user-images.githubusercontent.com/998889/192247068-17e9bb3e-c6ff-49d8-9619-e4eb4d2ae200.png">


<img width="1026" alt="image" src="https://user-images.githubusercontent.com/998889/192247013-b5fb8de9-ab41-4f81-ba1c-31dd208756b7.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../documentation/code-guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

