### PR TITLE
Add correct url prop for the url proxy endpoint

### DIFF
--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -240,7 +240,7 @@ class DplReactAppsController extends ControllerBase {
    */
   public static function urlProxyUrl(): string {
     return self::ensureUrlIsString(
-      Url::fromRoute('dpl_url_proxy.generate_url')->toString()
+      Url::fromRoute('rest.proxy-url.GET')->toString()
     );
   }
 


### PR DESCRIPTION
#### Description

Since the proxy handling changed from controller to rest resource we need to refer to another route name.

#### Checklist

- [ ] My complies with [our coding guidelines](../documentation/code-guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
