### PR TITLE
Use Markdownlint problem matcher v2

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Install problem matcher
-        uses: xt0rted/markdownlint-problem-matcher@v1
+        uses: xt0rted/markdownlint-problem-matcher@v2
       - name: Lint Markdown
         run: npx markdownlint-cli2
 


### PR DESCRIPTION
#### Description

This updates the runtime from Node 12 to Node 16. Node 12 is being
deprecated by GitHub and actions using it cause warnings.

See xt0rted/markdownlint-problem-matcher#527

#### Checklist

- [x] My complies with [our coding guidelines](../documentation/code-guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
