### PR TITLE
Drop registry credentials

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -53,11 +53,3 @@ environments:
       schedule: "M/15 * * * *"
       command: drush cron
       service: cli
-
-container-registries:
-  github:
-    username: any-user-works
-    # The password gets replaced with the value of an lagoon project environment-
-    # variable during lagoons build/deploy process.
-    password: GITHUB_REGISTRY_CREDENTIALS
-    url: ghcr.io


### PR DESCRIPTION
This is probably a leftover from a .lagoon.yml file from a "real" library site which needs to pull source-releases
from ghcr

#### Link to issue

https://reload.atlassian.net/browse/DDFDPDEL-212

#### Description

During the re-install of Lagoon I realized that we have a section in `.lagoon.yml` for getting privileged access to the Github container registry. This is a bit wird as the dpl-cms projct does not reference any images in that registry as of this point.

I've removed the section, and removed the personal access token from the dpl-cms project in Lagoon.

If I'm right this PR should be able to produce a functional PR site.

#### Checklist

- [x] My complies with [our coding guidelines](../documentation/code-guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

