### PR TITLE
Drop registry credentials

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -53,11 +53,3 @@ environments:
       schedule: "M/15 * * * *"
       command: drush cron
       service: cli
-
-container-registries:
-  github:
-    username: any-user-works
-    # The password gets replaced with the value of an lagoon project environment-
-    # variable during lagoons build/deploy process.
-    password: GITHUB_REGISTRY_CREDENTIALS
-    url: ghcr.io


### PR DESCRIPTION
#### Description

The project does not reference any ghcr images during build, so we don't need to authenticate.

This is probably a leftover from a .lagoon.yml file from a "real" library site which needs to pull source-releases from ghcr

This is a duplicate of #160 for release/4.


#### Checklist

- [x] My complies with [our coding guidelines](../documentation/code-guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
