### PR TITLE
Disable git safe.directory protection on OSX

### DIFF
--- a/docker-compose.mac-nfs.yml
+++ b/docker-compose.mac-nfs.yml
@@ -1,4 +1,9 @@
-version: '3'
+version: "3"
+
+services:
+  cli:
+    volumes:
+      - "./docker/cli/.gitconfig:/home/.gitconfig"
 
 volumes:
   projectroot:

--- a/docker/cli/.gitconfig
+++ b/docker/cli/.gitconfig
@@ -1,0 +1,2 @@
+[safe]
+    directory = *


### PR DESCRIPTION
#### Description

[Because of a git security vulnerability a new `safe.directory` configuration was introduced](https://github.blog/2022-04-12-git-security-vulnerability-announced/).

This causes problems with volumes on OSX which has issues with handling file system permissions between Docker host and client.

Normally this is not an issue but Composer packages which are  distributed through git instead of zip files it is. Composer will try to clone the package on a mounted volume with dubious permissions. `drupal/coder` is such a package. This shows as running task dev:reset will fail with the following error:

```
fatal: detected dubious ownership in repository at '/app/vendor/drupal/coder'
```

To address the issue we configure git in the CLI container responsible for running Composer to mark all directories as safe effectively  disabling `safe.directory` handling. To limit the scope of this we only do this on OSX in development environment.

This has probably not been an issue earlier because we have been using images with an older version of Git without `safe.directory` handling.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
