### PR TITLE
Secure CI variable type in dev:start task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,6 +52,9 @@ tasks:
     summary: Run docker compose
     cmds:
       - docker compose {{ .DOCKER_COMPOSE_FILES }} up -d {{if eq .CI "true"}}--quiet-pull{{end}}
+    vars:
+      CI:
+        sh: '[[ -z "${CI}" ]] && echo "false" || echo "true"'
 
   dev:stop:
     summary: Stop docker compose environment


### PR DESCRIPTION
#### Description

In some Task versions we got an error when checking the value of the CI environment variable if it was not set

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
