### PR TITLE
Add go-to-text placeholder

### DIFF
--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -201,7 +201,6 @@ class DplReactAppsController extends ControllerBase {
         'find-on-shelf-modal-screen-reader-modal-description-text' => $this->t('Reservation modal screen reader description', [], $c),
         'genre-and-form-text' => $this->t('Genre', [], $c),
         'get-online-text' => $this->t('Get online', [], $c),
-        'go-to-e-reolen-text' => $this->t('Go to e-Reolen', [], $c),
         'go-to-text' => $this->t('Go to @source', [], $c),
         'have-no-interest-after-text' => $this->t('Have no interest after', [], $c),
         'hearts-icon-text' => $this->t('hearts', [], $c),

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -202,7 +202,7 @@ class DplReactAppsController extends ControllerBase {
         'genre-and-form-text' => $this->t('Genre', [], $c),
         'get-online-text' => $this->t('Get online', [], $c),
         'go-to-e-reolen-text' => $this->t('Go to e-Reolen', [], $c),
-        'go-to-text' => $this->t('Go to', [], $c),
+        'go-to-text' => $this->t('Go to @source', [], $c),
         'have-no-interest-after-text' => $this->t('Have no interest after', [], $c),
         'hearts-icon-text' => $this->t('hearts', [], $c),
         'identifier-text' => $this->t('Identifiers', [], $c),


### PR DESCRIPTION
#### Link to issue
DDFSOEG-301

#### Description
In order to maintain all the translatable system strings matching the dpl-react repository, I had to add a placeholder into the go-to-text system string. Also, the go-to-e-reolen-text is deprecated because of the introduction of string placeholders, so I removed it (it wasn't being used anywhere).

#### Checklist
- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a