### PR TITLE
Digital Archive Service module

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -18,5 +18,11 @@
     <exclude name="Drupal.Commenting.HookComment.HookParamDoc"/>
     <exclude name="Drupal.Commenting.HookComment.HookReturnDoc"/>
     <exclude name="Drupal.Commenting.HookComment.HookCommentFormat"/>
+    <!--
+      Disable variable checking rules which both overlap and conflict with
+      PHPStan as suggested by Drupal Coder developers:
+      https://www.drupal.org/project/coder/issues/3253472#comment-14508517
+    -->
+    <exclude name="Drupal.Commenting.VariableComment.IncorrectVarType"/>
   </rule>
 </ruleset>

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -15,6 +15,7 @@ ignored_config_entities:
   - '~core.entity_view_mode.paragraph.*'
   - ~core.menu.static_menu_link_overrides
   - ~dblog.settings
+  - '~dpl_das.settings:url'
   - '~dpl_library_agency.general_settings:reservation_sms_notifications_disabled'
   - '~dpl_mapp.settings:domain'
   - '~field.field.node.campaign.*'

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -54,6 +54,9 @@ ignored_config_entities:
   - ~purge_queuer_coretags
   - ~purge.logger_channels
   - ~purge.plugins
+  - ~rest.resource.campaign.match
+  - ~rest.resource.dpl_das_digital_article_order
+  - ~rest.resource.proxy-url
   - '~system.action.node_*_action'
   - '~system.action.user_*_action'
   - ~system.authorize

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -4,6 +4,7 @@ module:
   config_filter: 0
   config_ignore: 0
   dpl_campaign: 0
+  dpl_das: 0
   dpl_library_agency: 0
   dpl_library_token: 0
   dpl_login: 0

--- a/config/sync/dpl_das.settings.yml
+++ b/config/sync/dpl_das.settings.yml
@@ -1,0 +1,3 @@
+url: 'https://webservice.statsbiblioteket.dk/elba-webservices/services/placecopyrequest'
+username: some-username
+password: a-password

--- a/config/sync/rest.resource.dpl_das_digital_article_order.yml
+++ b/config/sync/rest.resource.dpl_das_digital_article_order.yml
@@ -1,0 +1,18 @@
+uuid: 75f4b568-1125-4d30-8251-a330a0f5d66e
+langcode: en
+status: true
+dependencies:
+  module:
+    - dpl_das
+    - serialization
+    - user
+id: dpl_das_digital_article_order
+plugin_id: dpl_das_digital_article_order
+granularity: resource
+configuration:
+  methods:
+    - POST
+  formats:
+    - json
+  authentication:
+    - cookie

--- a/config/sync/rest.resource.dpl_das_digital_article_order.yml
+++ b/config/sync/rest.resource.dpl_das_digital_article_order.yml
@@ -4,8 +4,8 @@ status: true
 dependencies:
   module:
     - dpl_das
+    - dpl_login
     - serialization
-    - user
 id: dpl_das_digital_article_order
 plugin_id: dpl_das_digital_article_order
 granularity: resource
@@ -15,4 +15,4 @@ configuration:
   formats:
     - json
   authentication:
-    - cookie
+    - dpl_login_user_token

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -7,6 +7,7 @@ label: Administrator
 weight: 2
 is_admin: null
 permissions:
+  - 'administer dpl_das configuration'
   - 'administer library agency configuration'
   - 'administer url proxy configuration'
   - 'view own unpublished content'

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -13,3 +13,4 @@ permissions:
   - 'access openapi api docs'
   - 'restful get proxy-url'
   - 'restful post campaign:match'
+  - 'restful post dpl_das_digital_article_order'

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -13,4 +13,3 @@ permissions:
   - 'access openapi api docs'
   - 'restful get proxy-url'
   - 'restful post campaign:match'
-  - 'restful post dpl_das_digital_article_order'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -7,6 +7,7 @@ label: 'Local Administrator'
 weight: 3
 is_admin: null
 permissions:
+  - 'administer dpl_das configuration'
   - 'administer library agency configuration'
   - 'administer url proxy configuration'
   - 'view own unpublished content'

--- a/config/sync/user.role.patron.yml
+++ b/config/sync/user.role.patron.yml
@@ -14,6 +14,7 @@ permissions:
   - 'delete own campaign content'
   - 'edit any campaign content'
   - 'edit own campaign content'
+  - 'restful post dpl_das_digital_article_order'
   - 'revert campaign revisions'
   - 'view campaign revisions'
   - 'view own unpublished content'

--- a/openapi.json
+++ b/openapi.json
@@ -173,11 +173,7 @@
         "summary": "Digital Article Order",
         "operationId": "dpl_das_digital_article_order:POST",
         "schemes": ["http"],
-        "security": [
-          {
-            "cookie": []
-          }
-        ]
+        "security": []
       }
     },
     "/dpl-url-proxy": {

--- a/openapi.json
+++ b/openapi.json
@@ -35,7 +35,7 @@
             "required": true,
             "description": "Request format",
             "default": "json"
-          },
+          }, 
           {
             "name": "facets",
             "description": "A facet to match against",
@@ -133,6 +133,53 @@
         ]
       }
     },
+    "/dpl_das/order": {
+      "post": {
+        "parameters": [
+          {
+            "name": "_format",
+            "in": "query",
+            "type": "string",
+            "enum": ["json"],
+            "required": true,
+            "description": "Request format",
+            "default": "json"
+          }, 
+          {
+            "name": "order",
+            "description": "Digital article order",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "pid": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Digital Article Order",
+        "operationId": "dpl_das_digital_article_order:POST",
+        "schemes": ["http"],
+        "security": [
+          {
+            "cookie": []
+          }
+        ]
+      }
+    },
     "/dpl-url-proxy": {
       "get": {
         "parameters": [
@@ -144,7 +191,7 @@
             "required": true,
             "description": "Request format",
             "default": "json"
-          },
+          }, 
           {
             "name": "url",
             "description": "A url to an online resource which may be accessible through a proxy which requires rewriting of the url",

--- a/web/modules/custom/dpl_campaign/dpl_campaign.info.yml
+++ b/web/modules/custom/dpl_campaign/dpl_campaign.info.yml
@@ -5,4 +5,5 @@ core: 8.x
 package: "DPL"
 core_version_requirement: ^9 || ^8
 dependencies:
+  - drupal:serialization
   - handy_cache_tags:handy_cache_tags

--- a/web/modules/custom/dpl_das/dpl_das.info.yml
+++ b/web/modules/custom/dpl_das/dpl_das.info.yml
@@ -6,3 +6,4 @@ core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:serialization
+  - dpl_login:dpl_login

--- a/web/modules/custom/dpl_das/dpl_das.info.yml
+++ b/web/modules/custom/dpl_das/dpl_das.info.yml
@@ -1,0 +1,6 @@
+name: Digital Archive Service
+type: module
+description: Allow patrons to order digital copies of articles from the Royal Danish Library
+package: DPL
+core: 8.x
+core_version_requirement: ^8 || ^9

--- a/web/modules/custom/dpl_das/dpl_das.info.yml
+++ b/web/modules/custom/dpl_das/dpl_das.info.yml
@@ -4,3 +4,5 @@ description: Allow patrons to order digital copies of articles from the Royal Da
 package: DPL
 core: 8.x
 core_version_requirement: ^8 || ^9
+dependencies:
+  - drupal:serialization

--- a/web/modules/custom/dpl_das/dpl_das.links.menu.yml
+++ b/web/modules/custom/dpl_das/dpl_das.links.menu.yml
@@ -1,0 +1,5 @@
+dpl_das.settings_form:
+  title: "Digital Archive Service"
+  description: "Configure Digital Archive Service."
+  parent: "system.admin_config_services"
+  route_name: dpl_das.settings_form

--- a/web/modules/custom/dpl_das/dpl_das.permissions.yml
+++ b/web/modules/custom/dpl_das/dpl_das.permissions.yml
@@ -1,0 +1,2 @@
+administer dpl_das configuration:
+  title: "Administer Digital Archive Service configuration"

--- a/web/modules/custom/dpl_das/dpl_das.routing.yml
+++ b/web/modules/custom/dpl_das/dpl_das.routing.yml
@@ -1,0 +1,7 @@
+dpl_das.settings_form:
+  path: "/admin/config/system/dpl-das"
+  defaults:
+    _title: "Digital Archive Service settings"
+    _form: 'Drupal\dpl_das\Form\SettingsForm'
+  requirements:
+    _permission: "administer dpl_das configuration"

--- a/web/modules/custom/dpl_das/dpl_das.services.yml
+++ b/web/modules/custom/dpl_das/dpl_das.services.yml
@@ -1,0 +1,13 @@
+services:
+  dpl_das.serializer:
+    class: Symfony\Component\Serializer\Serializer
+    arguments:
+      - ["@dpl_das.normalizer.object"]
+      - ["@serializer.encoder.json", "@serializer.encoder.xml"]
+  dpl_das.normalizer.object:
+    class: Symfony\Component\Serializer\Normalizer\ObjectNormalizer
+  dpl_das.client:
+    class: Drupal\dpl_das\Elba\Client
+    arguments:
+      - "@http_client"
+      - "@serializer.encoder.xml"

--- a/web/modules/custom/dpl_das/src/Elba/Client.php
+++ b/web/modules/custom/dpl_das/src/Elba/Client.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\dpl_das\Elba;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+
+/**
+ * Client for Elba webservices.
+ *
+ * These web services are provided by the Royal Danish Library.
+ *
+ * @see https://webservice.statsbiblioteket.dk/elba-webservices/
+ */
+class Client {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    private ClientInterface $client,
+    private EncoderInterface $encoder,
+    // Note that the uri is all lower case despite the provided documentation.
+    // This is intentional and required for the service to work.
+    private string $uri = "https://webservice.statsbiblioteket.dk/elba-webservices/services/placecopyrequest",
+  ) {}
+
+  /**
+   * Order a digital copy of an article to be sent to the patron by email.
+   */
+  public function placeCopy(PlaceCopyRequest $placeCopy): void {
+    // The XML encoder does not provide a way to add a namespace to objects.
+    // Convert it to an array to fix this.
+    $request = (array) $placeCopy;
+    $request['@xmlns'] = "http://statsbiblioteket.dk/xws/elba-placecopyrequest-schema";
+
+    $xml = $this->encoder->encode($request, "xml", [
+      // Existing integrations use XML 1.0. Keep doing to for consistency.
+      "xml_version" => "1.0",
+      "xml_encoding" => "utf-8",
+      "xml_root_node_name" => "placeCopyRequest",
+    ]);
+
+    try {
+      $this->client->send(new Request(
+        "POST",
+        $this->uri,
+        // Content type matches encoding.
+        ["Content-Type" => "application/xml; charset=UTF8"],
+        $xml
+      ), [
+        // This is intentionally set high because the service is known to be
+        // slow. Typical response times are about 10 seconds.
+        RequestOptions::TIMEOUT => 30,
+      ]);
+    }
+    catch (GuzzleException $e) {
+      throw new Exception($e);
+    }
+  }
+
+}

--- a/web/modules/custom/dpl_das/src/Elba/Exception.php
+++ b/web/modules/custom/dpl_das/src/Elba/Exception.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\dpl_das\Elba;
+
+/**
+ * An error returned by the Elba webservice.
+ */
+class Exception extends \RuntimeException {
+
+}

--- a/web/modules/custom/dpl_das/src/Elba/PlaceCopyRequest.php
+++ b/web/modules/custom/dpl_das/src/Elba/PlaceCopyRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\dpl_das\Elba;
+
+/**
+ * Value object for requests for digital copies of articles.
+ *
+ * The service supports a range of different values. This only specifies the
+ * ones that we need.
+ *
+ * @see https://webservice.statsbiblioteket.dk/elba-webservices/placeCopyRequest.xsd
+ */
+class PlaceCopyRequest {
+
+  /**
+   * Constructor.
+   *
+   * @param string $ws_user
+   *   The username to use for accessing the service. This is a service account
+   *   user name that must be provided by the Royal Danish Library.
+   * @param string $ws_password
+   *   The password for the service account.
+   * @param string $agencyId
+   *   The agency id / ISIL number for the library on behalf of which the
+   *   article is ordered. e.g. 775100 for the Aarhus City Libraries.
+   * @param string $pid
+   *   The post id for the article to order a digital copy of.
+   *   Example: 870971-tsart:34310815.
+   * @param string $userMail
+   *   The email of the user to send the digital copy of the article to.
+   */
+  public function __construct(
+    public string $ws_user,
+    public string $ws_password,
+    public string $agencyId,
+    public string $pid,
+    public string $userMail
+  ) {}
+
+}

--- a/web/modules/custom/dpl_das/src/Form/SettingsForm.php
+++ b/web/modules/custom/dpl_das/src/Form/SettingsForm.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\dpl_das\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Configure Digital Archive Service settings for this site.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'dpl_das_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['dpl_das.settings'];
+  }
+
+  /**
+   * Translates a string to the current language or to a given language.
+   *
+   * @param string $string
+   *   A string containing the English text to translate.
+   * @param mixed[] $args
+   *   Replacements to make after translation. Based on the first character of
+   *   the key, the value is escaped and/or themed.
+   * @param mixed[] $options
+   *   An associative array of additional options.
+   */
+  protected function t($string, array $args = [], array $options = []): TranslatableMarkup {
+    // Intentionally transfer the string originally passed to t().
+    // phpcs:ignore Drupal.Semantics.FunctionT.NotLiteralString
+    return parent::t($string, $args, array_merge($options, ['context' => 'Digital Article Service']));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['webservice'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Webservice integration'),
+    ];
+    $form['webservice']['url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Url'),
+      '#description' => $this->t('The service endpoint for "placeCopyRequest"'),
+      '#default_value' => $this->config('dpl_das.settings')->get('url') ?? "https://webservice.statsbiblioteket.dk/elba-webservices/services/placecopyrequest",
+    ];
+    $form['webservice']['username'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Username'),
+      '#description' => $this->t('The username required to use the webservice.'),
+      '#default_value' => $this->config('dpl_das.settings')->get('username'),
+    ];
+    $form['webservice']['password'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Password'),
+      '#description' => $this->t('The password required to use the webservice.'),
+      '#default_value' => $this->config('dpl_das.settings')->get('password'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) : void {
+    $this->config('dpl_das.settings')
+      ->set('url', $form_state->getValue('url'))
+      ->set('username', $form_state->getValue('username'))
+      ->set('password', $form_state->getValue('password'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/web/modules/custom/dpl_das/src/Input/ArticleOrder.php
+++ b/web/modules/custom/dpl_das/src/Input/ArticleOrder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\dpl_das\Input;
+
+/**
+ * Value object for an order for a digital copy of an article by a patron.
+ */
+class ArticleOrder {
+
+  /**
+   * Constructor.
+   *
+   * @param string $pid
+   *   The post id for the article to order a digital copy of.
+   *   Example: 870971-tsart:34310815.
+   * @param string $email
+   *   The email of the user to send the digital copy of the article to.
+   */
+  public function __construct(
+    public string $pid,
+    public string $email
+  ) {}
+
+}

--- a/web/modules/custom/dpl_das/src/Plugin/rest/resource/DigitalArticleOrderResource.php
+++ b/web/modules/custom/dpl_das/src/Plugin/rest/resource/DigitalArticleOrderResource.php
@@ -7,6 +7,7 @@ use Drupal\dpl_das\Elba\Client;
 use Drupal\dpl_das\Elba\Exception;
 use Drupal\dpl_das\Elba\PlaceCopyRequest;
 use Drupal\dpl_das\Input\ArticleOrder;
+use Drupal\dpl_login\LibraryAgencyIdProvider;
 use Drupal\rest\ModifiedResourceResponse;
 use Drupal\rest\Plugin\ResourceBase;
 use Drupal\rest\ResourceResponseInterface;
@@ -91,6 +92,13 @@ class DigitalArticleOrderResource extends ResourceBase {
   private ConfigManagerInterface $configManager;
 
   /**
+   * Access to library agency id.
+   *
+   * @var \Drupal\dpl_login\LibraryAgencyIdProvider
+   */
+  private LibraryAgencyIdProvider $libraryAgencyIdProvider;
+
+  /**
    * Creates an instance of the plugin.
    *
    * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
@@ -117,6 +125,7 @@ class DigitalArticleOrderResource extends ResourceBase {
     $instance->serializer = $container->get('dpl_das.serializer');
     $instance->client = $container->get('dpl_das.client');
     $instance->configManager = $container->get('config.manager');
+    $instance->libraryAgencyIdProvider = $container->get('dpl_login.library_agency_id_provider');
 
     return $instance;
   }
@@ -143,7 +152,7 @@ class DigitalArticleOrderResource extends ResourceBase {
     $request = new PlaceCopyRequest(
       $config->get('username'),
       $config->get("password"),
-      "775100",
+      $this->libraryAgencyIdProvider->getAgencyId(),
       $order->pid,
       $order->email
     );

--- a/web/modules/custom/dpl_das/src/Plugin/rest/resource/DigitalArticleOrderResource.php
+++ b/web/modules/custom/dpl_das/src/Plugin/rest/resource/DigitalArticleOrderResource.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Drupal\dpl_das\Plugin\rest\resource;
+
+use Drupal\Core\Config\ConfigManagerInterface;
+use Drupal\dpl_das\Elba\Client;
+use Drupal\dpl_das\Elba\Exception;
+use Drupal\dpl_das\Elba\PlaceCopyRequest;
+use Drupal\dpl_das\Input\ArticleOrder;
+use Drupal\rest\ModifiedResourceResponse;
+use Drupal\rest\Plugin\ResourceBase;
+use Drupal\rest\ResourceResponseInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Resource for managing orders of digital articles.
+ *
+ * Digitizing articles is managed by the Royal Danish Library. Ordering an
+ * article is supported by the Elba webservices.
+ *
+ * Accessing this service requires a service account with an username and
+ * password and is thus not designed for direct browser based access by patron.
+ * Consequently it is exposed through the CMS instead.
+ *
+ * There is no canonical path for orders since this is not supported by the
+ * service. Patrons will have to consult their mail for confirmation that an
+ * order has been placed.
+ *
+ * @RestResource (
+ *   id = "dpl_das_digital_article_order",
+ *   label = @Translation("Digital Article Order"),
+ *   uri_paths = {
+ *     "create" = "/dpl_das/order",
+ *   },
+ *
+ *   payload = {
+ *     "name" = "order",
+ *     "description" = "Digital article order",
+ *     "in" = "body",
+ *     "schema" = {
+ *       "type" = "object",
+ *       "properties" = {
+ *         "pid" = {
+ *           "type" = "string",
+ *         },
+ *         "email" = {
+ *           "type" = "string",
+ *         },
+ *       },
+ *     },
+ *   },
+ *
+ *   responses = {
+ *     201 = {
+ *       "description" = "OK",
+ *     },
+ *     400 = {
+ *      "descriptions" = "Invalid input",
+ *     },
+ *     500 = {
+ *       "description" = "Internal server error",
+ *     },
+ *   }
+ * )
+ */
+class DigitalArticleOrderResource extends ResourceBase {
+
+  /**
+   * Serializer used to validate/convert incoming requests to value objects.
+   *
+   * @var \Symfony\Component\Serializer\SerializerInterface
+   */
+  private SerializerInterface $serializer;
+
+  /**
+   * Elba client to pass incoming requests to.
+   *
+   * @var \Drupal\dpl_das\Elba\Client
+   */
+  private Client $client;
+
+  /**
+   * Access to local configuration.
+   *
+   * @var \Drupal\Core\Config\ConfigManagerInterface
+   */
+  private ConfigManagerInterface $configManager;
+
+  /**
+   * Creates an instance of the plugin.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container to pull out services used in the plugin.
+   * @param mixed[] $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   *
+   * @return static
+   *   Returns an instance of this plugin.
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->getParameter('serializer.formats'),
+      $container->get('logger.factory')->get('rest'),
+    );
+
+    $instance->serializer = $container->get('dpl_das.serializer');
+    $instance->client = $container->get('dpl_das.client');
+    $instance->configManager = $container->get('config.manager');
+
+    return $instance;
+  }
+
+  /**
+   * Receive incoming requests to order digital articles.
+   */
+  public function post(Request $request): ResourceResponseInterface {
+    $order_data = $request->getContent();
+    if (!$order_data) {
+      throw new HttpException(400, 'No article order data provided');
+    }
+
+    try {
+      /** @var \Drupal\dpl_das\Input\ArticleOrder $order */
+      $order = $this->serializer->deserialize($order_data, ArticleOrder::class, 'json');
+    }
+    catch (UnexpectedValueException $e) {
+      throw new HttpException(400, "Invalid article order data: {$e->getMessage()}}");
+    }
+
+    $config = $this->configManager->getConfigFactory()->get('dpl_das.settings');
+
+    $request = new PlaceCopyRequest(
+      $config->get('username'),
+      $config->get("password"),
+      "775100",
+      $order->pid,
+      $order->email
+    );
+
+    try {
+      $this->client->placeCopy($request);
+      $this->logger->info("Placed order for digital article %pid", ['%pid' => $order->pid]);
+      return new ModifiedResourceResponse(NULL, 201);
+    }
+    catch (Exception $e) {
+      throw new HttpException(500,
+        "Unable to order digital copy of {$order->pid}: ({$e->getCode()}) {$e->getMessage()}", $e);
+    }
+
+  }
+
+}

--- a/web/modules/custom/dpl_library_token/dpl_library_token.services.yml
+++ b/web/modules/custom/dpl_library_token/dpl_library_token.services.yml
@@ -3,8 +3,8 @@ services:
     class: Drupal\dpl_library_token\LibraryTokenHandler
     arguments:
       [
+        "@dpl_login.adgangsplatformen.config",
         "@keyvalue.expirable",
-        "@config.factory",
         "@http_client",
         "@logger.factory",
       ]

--- a/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
@@ -8,7 +8,6 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
-use Drupal\dpl_library_token\Exception\MissingConfigurationException;
 use function Safe\sprintf as sprintf;
 
 /**
@@ -68,8 +67,6 @@ class LibraryTokenHandler {
     $this->tokenCollection = $keyValueFactory->get(self::TOKEN_COLLECTION_KEY);
     $this->httpClient = $http_client;
     $this->logger = $logger->get(self::LOGGER_KEY);
-
-    $this->validateSettings();
   }
 
   /**
@@ -164,24 +161,6 @@ class LibraryTokenHandler {
     }
 
     return $token;
-  }
-
-  /**
-   * Validate settings. Exception is thrown if a setting is missing.
-   */
-  protected function validateSettings(): void {
-    foreach ([
-      'token_endpoint',
-      'client_id',
-      'client_secret',
-      'agency_id',
-    ] as $config_key) {
-      if (empty($this->adgangsplatformenConfig->asArray()[$config_key])) {
-        throw new MissingConfigurationException(
-          sprintf('Adgangsplatformen plugin config variable %s is missing', $config_key)
-        );
-      }
-    }
   }
 
 }

--- a/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\dpl_library_token;
 
+use Drupal\dpl_login\Adgangsplatformen\Config;
 use Psr\Log\LogLevel;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
 use Drupal\dpl_library_token\Exception\MissingConfigurationException;
@@ -19,18 +19,14 @@ class LibraryTokenHandler {
   const LIBRARY_TOKEN_KEY = 'library_token';
   const TOKEN_COLLECTION_KEY = 'dpl_library_token';
   const NEXT_EXECUTION_KEY = 'dpl_library_token.next_execution';
-  // @todo This could be moved to a new service
-  // handling adgangsplatform configuration.
-  // @see dpl_login_install() and \Drupal\dpl_login\Controller\DplLoginController
-  const SETTINGS_KEY = 'openid_connect.settings.adgangsplatformen';
   const LOGGER_KEY = 'dpl_library_tokens';
 
   /**
-   * Cron Configuration.
+   * Configuration for Adgangsplatformen.
    *
-   * @var mixed[]
+   * @var \Drupal\dpl_login\Adgangsplatformen\Config
    */
-  protected $settings;
+  protected $adgangsplatformenConfig;
   /**
    * Key value store.
    *
@@ -53,24 +49,23 @@ class LibraryTokenHandler {
   /**
    * Constructs the LibraryTokenHandler service.
    *
+   * @param \Drupal\dpl_login\Adgangsplatformen\Config $config
+   *   Configuration.
    * @param \Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface $keyValueFactory
    *   The key value expire keyValueFactory.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   *   Configuration.
    * @param \GuzzleHttp\ClientInterface $http_client
    *   The HTTP client.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger
    *   The library token logger channel.
    */
   public function __construct(
+    Config $config,
     KeyValueExpirableFactoryInterface $keyValueFactory,
-    ConfigFactoryInterface $configFactory,
     ClientInterface $http_client,
     LoggerChannelFactoryInterface $logger
   ) {
+    $this->adgangsplatformenConfig = $config;
     $this->tokenCollection = $keyValueFactory->get(self::TOKEN_COLLECTION_KEY);
-    $this->settings = $configFactory
-      ->get(self::SETTINGS_KEY)->get('settings');
     $this->httpClient = $http_client;
     $this->logger = $logger->get(self::LOGGER_KEY);
 
@@ -128,18 +123,18 @@ class LibraryTokenHandler {
     $token = NULL;
 
     try {
-      $agency = sprintf('@%d', $this->settings['agency_id']);
+      $agency = sprintf('@%d', $this->adgangsplatformenConfig->getAgencyId());
 
       $response = $this->httpClient
-        ->request('POST', $this->settings['token_endpoint'], [
+        ->request('POST', $this->adgangsplatformenConfig->getTokenEndpoint(), [
           'form_params' => [
             'grant_type' => 'password',
             'username' => $agency,
             'password' => $agency,
           ],
           'auth' => [
-            $this->settings['client_id'],
-            $this->settings['client_secret'],
+            $this->adgangsplatformenConfig->getClientId(),
+            $this->adgangsplatformenConfig->getClientSecret(),
           ],
         ]);
 
@@ -181,7 +176,7 @@ class LibraryTokenHandler {
       'client_secret',
       'agency_id',
     ] as $config_key) {
-      if (empty($this->settings[$config_key])) {
+      if (empty($this->adgangsplatformenConfig->asArray()[$config_key])) {
         throw new MissingConfigurationException(
           sprintf('Adgangsplatformen plugin config variable %s is missing', $config_key)
         );

--- a/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
+++ b/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
@@ -6,6 +6,7 @@
 namespace Drupal\Tests\dpl_library_token\Unit;
 
 use Drupal\Core\Config\ConfigBase;
+use Drupal\dpl_login\Adgangsplatformen\Config;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Prophecy\Argument;
@@ -211,7 +212,8 @@ class LibraryTokenHandlerTest extends UnitTestCase {
       ]);
     }
     $config_factory = $this->prophesize(ConfigFactoryInterface::class);
-    $config_factory->get(LibraryTokenHandler::SETTINGS_KEY)->willReturn($config);
+    $config_factory->get(Config::CONFIG_KEY)->willReturn($config);
+    $adgangsplatformen_config = new Config($config_factory->reveal());
 
     if (!$logger) {
       $logger = $this->prophesize(LoggerChannelInterface::class)->reveal();
@@ -221,8 +223,8 @@ class LibraryTokenHandlerTest extends UnitTestCase {
     $logger_factory->get(LibraryTokenHandler::LOGGER_KEY)->willReturn($logger);
 
     return new LibraryTokenHandler(
+      $adgangsplatformen_config,
       $key_value_factory,
-      $config_factory->reveal(),
       $client,
       $logger_factory->reveal()
     );

--- a/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
+++ b/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
@@ -134,6 +134,9 @@ class LibraryTokenHandlerTest extends UnitTestCase {
       ->shouldBeCalledTimes(1);
 
     $logger = $this->prophesize(LoggerChannelInterface::class);
+    $logger->log(LogLevel::ERROR, Argument::any(), Argument::that(function(array $context) use ($message) {
+      return $context['@error_message'] == $message;
+    }))->shouldBeCalledTimes(1);
     $logger_factory = $this->prophesize(LoggerChannelFactoryInterface::class);
     $logger_factory->get(LibraryTokenHandler::LOGGER_KEY)->willReturn($logger->reveal());
 
@@ -142,8 +145,6 @@ class LibraryTokenHandlerTest extends UnitTestCase {
     $config = $this->prophesize(ImmutableConfig::class);
     $config->get('settings')->willReturn($settings);
 
-    $this->expectException(MissingConfigurationException::class);
-    $this->expectExceptionMessage($message);
     $handler = $this->createTokenHandler(
       $key_value_factory->reveal(),
       $client->reveal(),
@@ -162,17 +163,24 @@ class LibraryTokenHandlerTest extends UnitTestCase {
   public function provideExceptionMessages(): array {
     return [
       [
-        NULL,
+        [
+          'agency_id' => 'agency_id',
+          'client_id' => 'client_id',
+          'client_secret' => 'client_secret',
+        ],
         'Adgangsplatformen plugin config variable token_endpoint is missing',
       ],
       [
         [
+          'agency_id' => 'agency_id',
           'token_endpoint' => 'token_endpoint',
+          'client_secret' => 'client_secret',
         ],
         'Adgangsplatformen plugin config variable client_id is missing',
       ],
       [
         [
+          'agency_id' => 'agency_id',
           'token_endpoint' => 'token_endpoint',
           'client_id' => 'client_id',
         ],

--- a/web/modules/custom/dpl_login/dpl_login.info.yml
+++ b/web/modules/custom/dpl_login/dpl_login.info.yml
@@ -7,4 +7,3 @@ core_version_requirement: ^9
 
 dependencies:
   - openid_connect:openid_connect
-  - dpl_library_token:dpl_library_token

--- a/web/modules/custom/dpl_login/dpl_login.install
+++ b/web/modules/custom/dpl_login/dpl_login.install
@@ -6,6 +6,47 @@
  */
 
 use Drupal\Core\Config\Config;
+use Drupal\Core\Link;
+use Drupal\dpl_login\Exception\MissingConfigurationException;
+
+/**
+ * Implements hook_requirements().
+ *
+ * @param string $phase
+ *   The phase for checking requirements.
+ *
+ * @return array[]
+ *   Any requirements for the module.
+ */
+function dpl_login_requirements($phase) : array {
+  if ($phase != "runtime") {
+    return [];
+  }
+
+  $context = ['context' => "Login"];
+  $requirement = [
+    'title' => t('Adgangsplatformen', [], $context),
+    'severity' => REQUIREMENT_OK,
+    'value' => t('Integration configured', [], $context),
+  ];
+
+  /** @var \Drupal\dpl_login\Adgangsplatformen\Config $config */
+  $config = \Drupal::service('dpl_login.adgangsplatformen.config');
+  try {
+    $config->getAgencyId();
+    $config->getClientId();
+    $config->getClientSecret();
+    $config->getTokenEndpoint();
+    $config->getLogoutEndpoint();
+  }
+  catch (MissingConfigurationException $e) {
+    $requirement['severity'] = REQUIREMENT_ERROR;
+    $requirement['value'] = $e->getMessage();
+  }
+  $requirement['value'] = Link::createFromRoute($requirement['value'], 'openid_connect.admin_settings');
+
+  return ['dpl_login' => $requirement];
+}
 
 /**
  * Implements hook_install().

--- a/web/modules/custom/dpl_login/dpl_login.services.yml
+++ b/web/modules/custom/dpl_login/dpl_login.services.yml
@@ -13,10 +13,8 @@ services:
   dpl_login.authentication.user_token:
     class: Drupal\dpl_login\UserTokenAuthProvider
     arguments:
-      - "adgangsplatformen"
-      - "@config.factory"
+      - "@dpl_login.adgangsplatformen.client"
       - "@module_handler"
-      - "@plugin.manager.openid_connect_client"
       - "@openid_connect.authmap"
     tags:
       - {
@@ -24,3 +22,19 @@ services:
           provider_id: "dpl_login_user_token",
           priority: 0,
         }
+  dpl_login.library_agency_id_provider:
+    class: Drupal\dpl_login\LibraryAgencyIdProvider
+    arguments: ["@dpl_login.adgangsplatformen.config"]
+  dpl_login.adgangsplatformen.client:
+    class: Drupal\dpl_login\Plugin\OpenIDConnectClient\Adgangsplatformen
+    factory: ["@dpl_login.adgangsplatformen.factory", "createInstance"]
+  dpl_login.adgangsplatformen.factory:
+    class: Drupal\dpl_login\Adgangsplatformen\Factory
+    arguments:
+      [
+        "@plugin.manager.openid_connect_client",
+        "@dpl_login.adgangsplatformen.config",
+      ]
+  dpl_login.adgangsplatformen.config:
+    class: Drupal\dpl_login\Adgangsplatformen\Config
+    arguments: ["@config.factory"]

--- a/web/modules/custom/dpl_login/dpl_login.services.yml
+++ b/web/modules/custom/dpl_login/dpl_login.services.yml
@@ -3,6 +3,24 @@ services:
     class: Drupal\dpl_login\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
+  dpl_login.route_disable_csrf:
+    class: Drupal\dpl_login\Routing\DisableCsrfCheckSubscriber
+    tags:
+      - { name: event_subscriber }
   dpl_login.user_tokens:
     class: Drupal\dpl_login\UserTokensProvider
     arguments: ["@tempstore.private"]
+  dpl_login.authentication.user_token:
+    class: Drupal\dpl_login\UserTokenAuthProvider
+    arguments:
+      - "adgangsplatformen"
+      - "@config.factory"
+      - "@module_handler"
+      - "@plugin.manager.openid_connect_client"
+      - "@openid_connect.authmap"
+    tags:
+      - {
+          name: authentication_provider,
+          provider_id: "dpl_login_user_token",
+          priority: 0,
+        }

--- a/web/modules/custom/dpl_login/dpl_login.services.yml
+++ b/web/modules/custom/dpl_login/dpl_login.services.yml
@@ -1,6 +1,6 @@
 services:
-  dpl_login.route_subscriber:
-    class: Drupal\dpl_login\Routing\RouteSubscriber
+  dpl_login.route_rewire_logout:
+    class: Drupal\dpl_login\Routing\RewireLogoutSubscriber
     tags:
       - { name: event_subscriber }
   dpl_login.route_disable_csrf:

--- a/web/modules/custom/dpl_login/src/Adgangsplatformen/Config.php
+++ b/web/modules/custom/dpl_login/src/Adgangsplatformen/Config.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\dpl_login\Adgangsplatformen;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\dpl_login\Exception\MissingConfigurationException;
+use function Safe\sprintf as sprintf;
+
+/**
+ * Structured access to configuration for Adgangsplatformen.
+ *
+ * Adgangsplatformen is implemented as a plugin for the OpenID Connect Drupal
+ * module but we need access to the stored values elsewhere in the system.
+ * This class provides structured access to what would otherwise be an map
+ * of strings.
+ */
+class Config {
+
+  /**
+   * The Drupal configuration key under which the config is stored.
+   */
+  const CONFIG_KEY = "openid_connect.settings.adgangsplatformen";
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    private ConfigFactoryInterface $config
+  ) {}
+
+  /**
+   * Returns the configuration as an array.
+   *
+   * This is primarily for usage with the OpenID Connect plugin system which
+   * also expects array storage.
+   *
+   * @return string[]
+   *   Map of Adgangsplatformen configuration.
+   */
+  public function asArray() : array {
+    $settings = $this->config->get(self::CONFIG_KEY)->get('settings');
+    return (is_array($settings)) ? $settings : [];
+  }
+
+  /**
+   * Get a specific configuration value.
+   *
+   * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
+   */
+  private function getValue(string $key) : string {
+    $settings = $this->asArray();
+    return $settings[$key] ?? throw new MissingConfigurationException(
+      sprintf('Adgangsplatformen plugin config variable %s is missing', $key)
+    );
+  }
+
+  /**
+   * Get the agency id of the current library.
+   *
+   * Agency ids are also known as ISIL numbers. If this is the only value you
+   * need from the configuration then you should use the following class.
+   *
+   * @see LibraryAgencyIdProvider
+   *
+   * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
+   */
+  public function getAgencyId(): string {
+    return $this->getValue('agency_id');
+
+  }
+
+  /**
+   * Get the url where browsers should be redirected to when logging out.
+   *
+   * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
+   */
+  public function getLogoutEndpoint(): string {
+    return $this->getValue('logout_endpoint');
+  }
+
+  /**
+   * Get the url where a client can retrieve an OAuth access token.
+   *
+   * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
+   */
+  public function getTokenEndpoint(): string {
+    return $this->getValue('token_endpoint');
+  }
+
+  /**
+   * Get the client id to use when accessing Adgangsplatformen.
+   *
+   * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
+   */
+  public function getClientId(): string {
+    return $this->getValue('client_id');
+  }
+
+  /**
+   * Get the client secret to use when accessing Adgangsplatformen.
+   *
+   * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
+   */
+  public function getClientSecret(): string {
+    return $this->getValue('client_secret');
+  }
+
+}

--- a/web/modules/custom/dpl_login/src/Adgangsplatformen/Config.php
+++ b/web/modules/custom/dpl_login/src/Adgangsplatformen/Config.php
@@ -29,16 +29,15 @@ class Config {
   ) {}
 
   /**
-   * Returns the configuration as an array.
-   *
-   * This is primarily for usage with the OpenID Connect plugin system which
-   * also expects array storage.
+   * Returns the configuration formatted for an OpenID Connect plugin.
    *
    * @return string[]
    *   Map of Adgangsplatformen configuration.
    */
-  public function asArray() : array {
+  public function pluginConfig() : array {
     $settings = $this->config->get(self::CONFIG_KEY)->get('settings');
+    // Do not throw an exception here even if configuration is missing. Errors
+    // are handled is passed to the OpenID Connect plugin.
     return (is_array($settings)) ? $settings : [];
   }
 
@@ -48,7 +47,7 @@ class Config {
    * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
    */
   private function getValue(string $key) : string {
-    $settings = $this->asArray();
+    $settings = $this->config->get(self::CONFIG_KEY)->get('settings');
     $setting = $settings[$key] ?? '';
     // Assume that the Adgangsplatformen configuration should always be set so
     // throw exception instead of returning a nullable or empty string.

--- a/web/modules/custom/dpl_login/src/Adgangsplatformen/Config.php
+++ b/web/modules/custom/dpl_login/src/Adgangsplatformen/Config.php
@@ -49,7 +49,11 @@ class Config {
    */
   private function getValue(string $key) : string {
     $settings = $this->asArray();
-    return $settings[$key] ?? throw new MissingConfigurationException(
+    $setting = $settings[$key] ?? '';
+    // Assume that the Adgangsplatformen configuration should always be set so
+    // throw exception instead of returning a nullable or empty string.
+    // @see dpl_login_requirements().
+    return ($setting) ? $setting : throw new MissingConfigurationException(
       sprintf('Adgangsplatformen plugin config variable %s is missing', $key)
     );
   }

--- a/web/modules/custom/dpl_login/src/Adgangsplatformen/Factory.php
+++ b/web/modules/custom/dpl_login/src/Adgangsplatformen/Factory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\dpl_login\Adgangsplatformen;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\openid_connect\Plugin\OpenIDConnectClientInterface;
+
+/**
+ * Factory for creating Adgangsplatformen OpenID Connect client instances.
+ *
+ * This class is not intended for direct usage. It allows us to create a client
+ * as a service.
+ */
+class Factory {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    private PluginManagerInterface $manager,
+    private Config $config
+  ) {}
+
+  /**
+   * Create an Adgangsplatformen OpenID Connect client instance.
+   */
+  public function createInstance(): OpenIDConnectClientInterface {
+    /** @var \Drupal\openid_connect\Plugin\OpenIDConnectClientInterface $plugin */
+    $plugin = $this->manager->createInstance('adgangsplatformen', $this->config->asArray());
+    return $plugin;
+  }
+
+}

--- a/web/modules/custom/dpl_login/src/Adgangsplatformen/Factory.php
+++ b/web/modules/custom/dpl_login/src/Adgangsplatformen/Factory.php
@@ -26,7 +26,7 @@ class Factory {
    */
   public function createInstance(): OpenIDConnectClientInterface {
     /** @var \Drupal\openid_connect\Plugin\OpenIDConnectClientInterface $plugin */
-    $plugin = $this->manager->createInstance('adgangsplatformen', $this->config->asArray());
+    $plugin = $this->manager->createInstance('adgangsplatformen', $this->config->pluginConfig());
     return $plugin;
   }
 

--- a/web/modules/custom/dpl_login/src/LibraryAgencyIdProvider.php
+++ b/web/modules/custom/dpl_login/src/LibraryAgencyIdProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\dpl_login;
+
+use Drupal\dpl_login\Adgangsplatformen\Config;
+
+/**
+ * Provider for accessing the agency id for the current library organisation.
+ *
+ * The agency id is also referred to as the ISIL nummber or library number
+ * (biblioteksnummer). Example: 710100 is the agency id for the Copenhagen City
+ * Libraries.
+ *
+ * It is sometimes prefixed by a country code e.g. DK-710100 but this should
+ * not be the case here.
+ *
+ * The provider is located within the DPL Login module because with the
+ * integration with Adgangsplatformen most of such information should be
+ * contained within libary and patron tokens. Some legacy systems might still
+ * require this info. This class provides a single point of entry.
+ */
+class LibraryAgencyIdProvider {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    private Config $config
+  ) {}
+
+  /**
+   * Return the agency id for the current library.
+   *
+   * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
+   */
+  public function getAgencyId(): string {
+    return $this->config->getAgencyId();
+  }
+
+}

--- a/web/modules/custom/dpl_login/src/Routing/DisableCsrfCheckSubscriber.php
+++ b/web/modules/custom/dpl_login/src/Routing/DisableCsrfCheckSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\dpl_login\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Disable cross-site-request-forgery checks on token requests.
+ *
+ * Drupal will by default require a CSRF token to be included with
+ * authenticated HTTP requests altering state.
+ *
+ * We hold the CMS to the same security levels as other business systems in the
+ * NEXT platform. Thus we deem a valid user token sufficient and we remove
+ * this requirement for all routes using the user token authentication
+ * provider.
+ *
+ * @see \Drupal\Core\Access\CsrfRequestHeaderAccessCheck
+ * @see \Drupal\dpl_login\UserTokenAuthProvider
+ */
+class DisableCsrfCheckSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection): void {
+    foreach ($collection->getIterator() as $route) {
+      if ($route->getOption('_auth') == ["dpl_login_user_token"]) {
+        $requirements = $route->getRequirements();
+        unset($requirements['_csrf_request_header_token']);
+        $route->setRequirements($requirements);
+      }
+    }
+  }
+
+}

--- a/web/modules/custom/dpl_login/src/Routing/RewireLogoutSubscriber.php
+++ b/web/modules/custom/dpl_login/src/Routing/RewireLogoutSubscriber.php
@@ -8,7 +8,7 @@ use Symfony\Component\Routing\RouteCollection;
 /**
  * Listens to the dynamic route events.
  */
-class RouteSubscriber extends RouteSubscriberBase {
+class RewireLogoutSubscriber extends RouteSubscriberBase {
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
+++ b/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
@@ -67,6 +67,9 @@ class UserTokenAuthProvider implements AuthenticationProviderInterface {
     // associated Drupal user from the OpenID Connect authmap.
     $context = [];
     $this->moduleHandler->alter('openid_connect_userinfo', $user_info, $context);
+    if (!isset($user_info['sub'])) {
+      return NULL;
+    }
 
     $user = $this->authmap->userLoadBySub($user_info['sub'], $this->client->getPluginId());
     return ($user instanceof AccountInterface) ? $user : NULL;

--- a/web/modules/custom/dpl_login/tests/src/Unit/ConfigTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/ConfigTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\Tests\dpl_login\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\dpl_login\Adgangsplatformen\Config;
+use Drupal\dpl_login\Exception\MissingConfigurationException;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * Unit test for the Adgangsplatformen configuration.
+ *
+ * @covers \Drupal\dpl_login\Adgangsplatformen\Config
+ */
+class ConfigTest extends UnitTestCase {
+
+  /**
+   * A mock basis for an Adgangsplatformen Config object under test.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy<ImmutableConfig>
+   */
+  protected ObjectProphecy $config;
+
+  /**
+   * A mock config factory which can return a mock config object.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy<ConfigFactoryInterface>
+   */
+  protected ObjectProphecy $configFactory;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    $this->config = $config = $this->prophesize(ImmutableConfig::class);
+    $this->config->get('settings')->willReturn([
+      'agency_id' => '775100',
+      'client_id' => 'abcd-1234',
+      'client_secret' => 'something_super_secret',
+      'token_endpoint' => 'http://auth.tld/token',
+      'logout_endpoint' => 'http://auth.tld/logout',
+    ]);
+
+    $this->configFactory = $this->prophesize(ConfigFactoryInterface::class);
+    $this->configFactory->get(Config::CONFIG_KEY)->will(function () use ($config) {
+      // Reveal the configuration on demand.
+      return $config->reveal();
+    });
+  }
+
+  /**
+   * Ensure configuration is returned in a format expected by plugins.
+   */
+  public function testAsArray(): void {
+    $config = new Config($this->configFactory->reveal());
+    $this->assertSame([
+      'agency_id' => '775100',
+      'client_id' => 'abcd-1234',
+      'client_secret' => 'something_super_secret',
+      'token_endpoint' => 'http://auth.tld/token',
+      'logout_endpoint' => 'http://auth.tld/logout',
+    ], $config->asArray());
+  }
+
+  /**
+   * If configuration is missing an empty array must be returned.
+   */
+  public function testAsArrayMissingConfig(): void {
+    $this->config->get('settings')->willReturn(NULL);
+    $config = new Config($this->configFactory->reveal());
+    $this->assertSame([], $config->asArray());
+  }
+
+  /**
+   * Accessors must provide typed access to the configuration.
+   */
+  public function testAccessors(): void {
+    $config = new Config($this->configFactory->reveal());
+    $this->assertEquals('775100', $config->getAgencyId());
+    $this->assertEquals('abcd-1234', $config->getClientId());
+    $this->assertEquals('something_super_secret', $config->getClientSecret());
+    $this->assertEquals('http://auth.tld/token', $config->getTokenEndpoint());
+    $this->assertEquals('http://auth.tld/logout', $config->getLogoutEndpoint());
+  }
+
+  /**
+   * If configuration is missing then accessors will throw an exception.
+   */
+  public function testAccessorsMissingConfig(): void {
+    $this->config->get('settings')->willReturn([]);
+    $config = new Config($this->configFactory->reveal());
+    $this->expectException(MissingConfigurationException::class);
+    $config->getAgencyId();
+  }
+
+}

--- a/web/modules/custom/dpl_login/tests/src/Unit/ConfigTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/ConfigTest.php
@@ -57,7 +57,7 @@ class ConfigTest extends UnitTestCase {
   /**
    * Ensure configuration is returned in a format expected by plugins.
    */
-  public function testAsArray(): void {
+  public function testPluginConfig(): void {
     $config = new Config($this->configFactory->reveal());
     $this->assertSame([
       'agency_id' => '775100',
@@ -66,16 +66,16 @@ class ConfigTest extends UnitTestCase {
       'token_endpoint' => 'http://auth.tld/token',
       'userinfo_endpoint' => 'http://auth.tld/userinfo',
       'logout_endpoint' => 'http://auth.tld/logout',
-    ], $config->asArray());
+    ], $config->pluginConfig());
   }
 
   /**
    * If configuration is missing an empty array must be returned.
    */
-  public function testAsArrayMissingConfig(): void {
+  public function testMissingPluginConfig(): void {
     $this->config->get('settings')->willReturn(NULL);
     $config = new Config($this->configFactory->reveal());
-    $this->assertSame([], $config->asArray());
+    $this->assertSame([], $config->pluginConfig());
   }
 
   /**

--- a/web/modules/custom/dpl_login/tests/src/Unit/ConfigTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/ConfigTest.php
@@ -40,6 +40,10 @@ class ConfigTest extends UnitTestCase {
       'client_id' => 'abcd-1234',
       'client_secret' => 'something_super_secret',
       'token_endpoint' => 'http://auth.tld/token',
+      // Even though this config entry is not supported with an accessor it is
+      // important for OpenID Connect plugins to work so ensure it is handled
+      // correctly.
+      'userinfo_endpoint' => 'http://auth.tld/userinfo',
       'logout_endpoint' => 'http://auth.tld/logout',
     ]);
 
@@ -60,6 +64,7 @@ class ConfigTest extends UnitTestCase {
       'client_id' => 'abcd-1234',
       'client_secret' => 'something_super_secret',
       'token_endpoint' => 'http://auth.tld/token',
+      'userinfo_endpoint' => 'http://auth.tld/userinfo',
       'logout_endpoint' => 'http://auth.tld/logout',
     ], $config->asArray());
   }

--- a/web/modules/custom/dpl_login/tests/src/Unit/DplLoginControllerTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/DplLoginControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\dpl_library_token\Unit;
+namespace Drupal\Tests\dpl_login\Unit;
 
 use Drupal\dpl_login\Adgangsplatformen\Config;
 use phpmock\Mock;

--- a/web/modules/custom/dpl_login/tests/src/Unit/UserTokenAuthProviderTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/UserTokenAuthProviderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\Tests\dpl_login\Unit;
+
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\dpl_login\UserTokenAuthProvider;
+use Drupal\openid_connect\OpenIDConnectAuthmap;
+use Drupal\openid_connect\Plugin\OpenIDConnectClientInterface;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Unit test for the user token authentication provider.
+ *
+ * @covers \Drupal\dpl_login\UserTokenAuthProvider
+ */
+class UserTokenAuthProviderTest extends UnitTestCase {
+
+  /**
+   * Mock OpenID Connect client used to look up user info from tokens.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy<OpenIDConnectClientInterface>
+   */
+  private ObjectProphecy $openIdClient;
+
+  /**
+   * Mock module handler to allow alters of user info.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy<ModuleHandlerInterface>
+   */
+  private ObjectProphecy $moduleInvoker;
+
+  /**
+   * Mock authmap to map user ids to user accounts.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy<OpenIDConnectAuthmap>
+   */
+  private ObjectProphecy $authMap;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    $this->openIdClient = $this->prophesize(OpenIDConnectClientInterface::class);
+    $this->moduleInvoker = $this->prophesize(ModuleHandlerInterface::class);
+    $this->authMap = $this->prophesize(OpenIDConnectAuthmap::class);
+  }
+
+  /**
+   * Any request should not be handled by the provider.
+   */
+  public function testRegularRequestsDoesNotApply(): void {
+    $provider = new UserTokenAuthProvider($this->openIdClient->reveal(), $this->moduleInvoker->reveal(), $this->authMap->reveal());
+    $this->assertFalse($provider->applies(new Request()));
+  }
+
+  /**
+   * A request with a bearer token should be handled by the provider.
+   */
+  public function testRequestWithBearerTokenApplies(): void {
+    $provider = new UserTokenAuthProvider($this->openIdClient->reveal(), $this->moduleInvoker->reveal(), $this->authMap->reveal());
+
+    $request = new Request();
+    $request->headers->set('Authorization', 'Bearer abcd1234');
+
+    $this->assertTrue($provider->applies($request));
+  }
+
+  /**
+   * A request with another type of authorization scheme should not be handled.
+   */
+  public function testRequestWithBasicAuthDoesNotApply(): void {
+    $provider = new UserTokenAuthProvider($this->openIdClient->reveal(), $this->moduleInvoker->reveal(), $this->authMap->reveal());
+
+    $request = new Request();
+    $request->headers->set('Authorization', 'Basic abcd1234');
+
+    $this->assertFalse($provider->applies($request));
+  }
+
+  /**
+   * A request with a bearer token mapping to a known user should authenticate.
+   */
+  public function testKnownBearerTokenAuthenticatesUser(): void {
+    $user = ($this->prophesize(AccountInterface::class))->reveal();
+    $this->authMap->userLoadBySub('unique-patron-id', 'adgangsplatformen')->willReturn($user);
+    $this->openIdClient->retrieveUserInfo('abcd1234')->willReturn([
+      'sub' => 'unique-patron-id',
+    ]);
+    $this->openIdClient->getPluginId()->willReturn('adgangsplatformen');
+
+    $provider = new UserTokenAuthProvider($this->openIdClient->reveal(), $this->moduleInvoker->reveal(), $this->authMap->reveal());
+
+    $request = new Request();
+    $request->headers->set('Authorization', 'Bearer abcd1234');
+
+    $authenticatedUser = $provider->authenticate($request);
+    $this->assertEquals($user, $authenticatedUser);
+  }
+
+  /**
+   * A request with an unknown bearer token should not authenticate.
+   */
+  public function testUnknownBearerTokenDoesNotAuthenticate(): void {
+    $this->openIdClient->retrieveUserInfo('1234abcd')->willReturn([]);
+    $provider = new UserTokenAuthProvider($this->openIdClient->reveal(), $this->moduleInvoker->reveal(), $this->authMap->reveal());
+
+    $request = new Request();
+    $request->headers->set('Authorization', 'Bearer 1234abcd');
+
+    $this->assertNull($provider->authenticate($request));
+  }
+
+  /**
+   * A request with a known bearer token mapping to an unknown user does not.
+   */
+  public function testUnknownPatronIdDoesNotAuthenticateUser(): void {
+    $this->authMap->userLoadBySub('unknown-patron-id', 'adgangsplatformen')->willReturn(FALSE);
+    $this->openIdClient->retrieveUserInfo('abcd1234')->willReturn([
+      'sub' => 'unknown-patron-id',
+    ]);
+    $this->openIdClient->getPluginId()->willReturn('adgangsplatformen');
+
+    $provider = new UserTokenAuthProvider($this->openIdClient->reveal(), $this->moduleInvoker->reveal(), $this->authMap->reveal());
+
+    $request = new Request();
+    $request->headers->set('Authorization', 'Bearer abcd1234');
+
+    $this->assertNull($provider->authenticate($request));
+  }
+
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-304

#### Description

This PR adds a new dpl_das module which provides integration between the DPL platform and the Digital Archive Service (Elba webservices) provided by the Royal Danish Library.

Besides implementing the modue with the integration the PR provides two main changes;

1. Implementing a Drupal authentication provider for Adgangsplatformen tokens. This is used to protect the endpoint against unauthorized access.
2. Refactoring Adgangsplatformen configuration access. To avoid passing out strings and unstructured arrays this central configuration is moved to a couple of classes.

Please read through the commits for additional commentary.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
