### PR TITLE
Prevent hard errors when branches cannot be retrieved from FBS

### DIFF
--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.services.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.services.yml
@@ -5,6 +5,14 @@ services:
   dpl_library_agency.branch_settings:
     class: Drupal\dpl_library_agency\BranchSettings
     arguments: ["@config.manager"]
+  dpl_library_agency.branch.repository:
+    class: Drupal\dpl_library_agency\Branch\FallbackBranchRepository
+    arguments:
+      - "@dpl_library_agency.branch.repository.cache"
+      - "@dpl_library_agency.branch.repository.empty"
+      - "@dpl_library_agency.logger"
+  dpl_library_agency.branch.repository.empty:
+    class: Drupal\dpl_library_agency\Branch\EmptyBranchRepository
   dpl_library_agency.branch.repository.cache:
     class: Drupal\dpl_library_agency\Branch\CacheableBranchRepository
     arguments:
@@ -25,3 +33,6 @@ services:
   dpl_library_agency.fbs_agency_api:
     class: DanskernesDigitaleBibliotek\FBS\Api\ExternalV1AgencyidApi
     factory: ["@dpl_library_agency.fbs_api_factory", "getAgencyApi"]
+  dpl_library_agency.logger:
+    parent: logger.channel_base
+    arguments: ["DPL Library Agency"]

--- a/web/modules/custom/dpl_library_agency/src/Branch/EmptyBranchRepository.php
+++ b/web/modules/custom/dpl_library_agency/src/Branch/EmptyBranchRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\dpl_library_agency\Branch;
+
+/**
+ * A branch repository which always returns an empty set.
+ */
+class EmptyBranchRepository implements BranchRepositoryInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBranches(): array {
+    return [];
+  }
+
+}

--- a/web/modules/custom/dpl_library_agency/src/Branch/FallbackBranchRepository.php
+++ b/web/modules/custom/dpl_library_agency/src/Branch/FallbackBranchRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\dpl_library_agency\Branch;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Repository with a fallback option.
+ *
+ * If an error/exception occurs when retrieving branches from one repository
+ * this will fall back to a secondary option.
+ */
+class FallbackBranchRepository implements BranchRepositoryInterface {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    private BranchRepositoryInterface $primaryRepository,
+    private BranchRepositoryInterface $secondaryRepository,
+    private LoggerInterface $logger
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBranches(): array {
+    try {
+      return $this->primaryRepository->getBranches();
+    }
+    catch (\Exception $e) {
+      $this->logger->warning('Unable to retrieve branches from %primary: %message. Falling back to %secondary',
+        [
+          '%primary' => $this->primaryRepository::class,
+          '%message' => $e->getMessage(),
+          '%secondary' => $this->secondaryRepository::class,
+        ]);
+      return $this->secondaryRepository->getBranches();
+    }
+  }
+
+}

--- a/web/modules/custom/dpl_library_agency/src/Branch/FbsBranchRepository.php
+++ b/web/modules/custom/dpl_library_agency/src/Branch/FbsBranchRepository.php
@@ -22,6 +22,8 @@ class FbsBranchRepository implements BranchRepositoryInterface {
 
   /**
    * {@inheritdoc}
+   *
+   * @throws \DanskernesDigitaleBibliotek\FBS\ApiException
    */
   public function getBranches(): array {
     return array_map(function (AgencyBranch $branch) {

--- a/web/modules/custom/dpl_library_token/dpl_library_token.install
+++ b/web/modules/custom/dpl_library_token/dpl_library_token.install
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * DPL Library Token install procedures.
+ */
+
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_requirements().
+ *
+ * @param string $phase
+ *   The phase for checking requirements.
+ *
+ * @return array[]
+ *   Any requirements for the module.
+ */
+function dpl_library_token_requirements($phase) : array {
+  if ($phase != "runtime") {
+    return [];
+  }
+
+  $context = ['context' => "Library Token"];
+  $requirement = [
+    'title' => t('Library token', [], $context),
+    'severity' => REQUIREMENT_OK,
+    'value' => t('Token available', [], $context),
+  ];
+
+  /** @var \Drupal\dpl_library_token\LibraryTokenHandler $handler */
+  $handler = \Drupal::service('dpl_library_token.handler');
+  if (!$handler->getToken()) {
+    $requirement['severity'] = REQUIREMENT_WARNING;
+    $requirement['value'] = t('No valid token available. <a href=":url">Run cron</a> to retrieve a new token.', [
+      ':url' => Url::fromRoute('system.cron_settings')->toString(),
+    ], $context);
+  }
+
+  return ['dpl_library_token' => $requirement];
+}

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -41,7 +41,7 @@ class DplReactAppsController extends ControllerBase {
       $container->get('renderer'),
       $container->get('dpl_library_agency.reservation_settings'),
       $container->get('dpl_library_agency.branch_settings'),
-      $container->get('dpl_library_agency.branch.repository.cache'),
+      $container->get('dpl_library_agency.branch.repository'),
     );
   }
 


### PR DESCRIPTION
#### Description

Some React apps require the CMS to expose a list of branches. If the site has no valid library token (e.g. due to missing or invalid  Adgangsplatformen configuration or because cron has not run) then fetching branches will fail with an exception bubbling up and a hard error.

A softer approach would be to log the problem and pass an empty set of branches. This would allow much of the functionality of the app to work. On the other hard we risk missing real problems which appear down the stream e.g. when patrons interact with the apps and cannot see any branches.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
