### PR TITLE
Show verbose error messages during development

### DIFF
--- a/assets/development.settings.php
+++ b/assets/development.settings.php
@@ -1,0 +1,5 @@
+<?php
+
+# Enable verbose error reporting.
+$config['system.logging']['error_level'] = 'verbose';
+

--- a/composer.json
+++ b/composer.json
@@ -130,6 +130,7 @@
             ],
             "file-mapping": {
                 "[web-root]/sites/default/all.settings.php": "assets/all.settings.php",
+                "[web-root]/sites/default/development.settings.php": "assets/development.settings.php",
                 "[web-root]/.eslintrc.json": false,
                 "[project-root]/.gitattributes": {
                     "append": "assets/.gitattributes"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8072e5b169d988c07946277c57db4bae",
+    "content-hash": "7db51d0915e4f0312fe2fa430704b365",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/web/sites/default/.gitignore
+++ b/web/sites/default/.gitignore
@@ -1,4 +1,5 @@
 /all.settings.php
+/development.settings.php
 /default.development.services.yml
 /default.services.yml
 /settings.lagoon.php


### PR DESCRIPTION
#### Description

By default Drupal will show a generic error message when an error  occurs. This forces developers to check logs to see the actual problem. This is desirable for production sites but requires unnecessary work during development.

Add a development.settings.php file containing a setting to enable verbose error handling. Lagoon environment types ensure that this is only read in development environments e.g. locally.

See:
- https://docs.lagoon.sh/using-lagoon-advanced/environment-types/
- https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
