### PR TITLE
Enable XDebug per service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,6 @@ x-environment:
     WEBROOT: web
     # Uncomment if you like to have the system behave like in production
     #LAGOON_ENVIRONMENT_TYPE: production
-    # Uncomment to enable xdebug and then restart via `docker-compose up -d`
-    #XDEBUG_ENABLE: "true"
 
 services:
   varnish: # Caching HTTP reverse proxy that serves (mostly) anonymous requests.
@@ -67,6 +65,8 @@ services:
     user: root
     environment:
       << : *default-environment # loads the defined environment variables from the top
+      # Uncomment to enable xdebug for cli tools
+      #XDEBUG_ENABLE: "true"
     labels:
       # Lagoon Labels
       lagoon.type: cli-persistent
@@ -110,6 +110,8 @@ services:
     << : *default-volumes # loads the defined volumes from the top
     environment:
       << : *default-environment # loads the defined environment variables from the top
+      # Uncomment to enable xdebug for web requests and then restart via `docker-compose up -d`
+      #XDEBUG_ENABLE: "true"
     labels:
       lagoon.type: nginx-php-persistent
       lagoon.name: nginx # we want this service be part of the nginx pod in Lagoon


### PR DESCRIPTION
#### Description

Currently XDebug is enabled centrally in a single environment variable which is used across services. This makes it easy to enable but causes problems because it will cause both web requests and CLI tools to use  XDebug.

Debugging CLI tools with XDebug can be helpful but also cause problems because CLI tools e.g. Drush are often invoked during development. With Xdebug enabled this can cause slowness and breakpoints to be triggered which were intended for web requests.

Splitting up the values allow developers to enable XDebug selectively e.g. only for web requests through PHP-FPM.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
