### PR TITLE
Update casing of loan list block plugin

### DIFF
--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Provides user loans list.
  *
- * @block(
+ * @Block(
  *   id = "dpl_loans_list_block",
  *   admin_label = "List user loans"
  * )


### PR DESCRIPTION
The plugin does not appear in the list of available blocks for placement on Lagoon but does so locally.

I tried updating the case of the Block annotation to follow what is used for [other blocks provided by Drupal Core](https://github.com/drupal/drupal/blob/9.5.x/core/modules/views/src/Plugin/Block/ViewsBlock.php).

As far as I can tell this fixes the issue. I assume it is a problem caused by different case sensitivity of file systems on OSX (locally) and Linux (Lagoon).

