### PR TITLE
Disable connecting existing users with OpenID Connect module

### DIFF
--- a/config/sync/openid_connect.settings.yml
+++ b/config/sync/openid_connect.settings.yml
@@ -1,5 +1,5 @@
 always_save_userinfo: true
-connect_existing_users: true
+connect_existing_users: false
 override_registration_settings: true
 user_login_display: below
 userinfo_mappings:


### PR DESCRIPTION
#### Description

This is marked as a secure risk by the module maintainers and it is not something that we require for the system to work.

![Monosnap Status report | DPL CMS 2022-12-20 12-40-22](https://user-images.githubusercontent.com/73966/208658601-6c532eb0-257c-4d12-b03f-4dabb27f2f82.png)

[The OpenID Connect module allows different OpenID Connect accounts with the same address to be associated with the same Drupal account](https://git.drupalcode.org/project/openid_connect/-/blob/2.x/src/OpenIDConnect.php#L353-369). Since we only plan to use Adgangsplatformen for OpenID Connect Authorization and [we generate a unique and invalid email address for Adgangsplatformen users](https://github.com/reload/dpl-cms/blob/main/web/modules/custom/dpl_login/dpl_login.module#L25-L25) we will not and cannot use this connection feature anyway.

Adgangsplatformen maps an OpenID Connect account with a Drupal user based on the unique `sub` (subject) key. This does not change with this.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

