### PR TITLE
Lighthouse performance baseline

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -3,9 +3,8 @@ module.exports = {
     collect: {
       url: [
         "http://varnish:8080/",
-        // TODO: When performance has been improved these URl's can be reactivated:
-        // "http://varnish:8080/search?q=harry+potter&x=0&y=0",
-        // "http://varnish:8080/work/work-of:870970-basis:25245784?type=bog"
+        "http://varnish:8080/search?q=harry+potter&x=0&y=0",
+        "http://varnish:8080/work/work-of:870970-basis:25245784?type=bog"
       ],
       // Use 3 runs to test both cold and warm caches.
       numberOfRuns: 3,


### PR DESCRIPTION
to get a baseline for the lighthouse performance score
---
Uploading median LHR of http://varnish:8080/...success!
Open the report at https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1672702680764-34224.report.html
Uploading median LHR of http://varnish:8080/search?q=harry+potter&x=0&y=0...success!
Open the report at https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1672702681362-77216.report.html
Uploading median LHR of http://varnish:8080/work/work-of:870970-basis:25245784?type=bog...success!
Open the report at https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1672702681865-76191.report.html
No GitHub token set, skipping GitHub status check.
