### PR TITLE
Switch to official Docker image for Wiremock

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -34,23 +34,23 @@ services:
     # We use wiremock-gui as it exposes a UI for inspecting the state of
     # WireMock. This can make debugging easier. It can seamlessly be replaced
     # with the official wiremock/wiremock image.
-    image: holomekc/wiremock-gui:2.33.2.1
+    image: wiremock/wiremock:2.32.0-alpine
+    # The following options are used:
+    # --enable-browser-proxying: Allows Wiremock to intercept all traffic from
+    # services  with HTTP(s)_PROXY pointing at it.
+    # --local-response-templating lets WireMock transfer values from request
+    # to mocked response
+    # --enable-stub-cors is required to make a browser running React
+    # components request resources.
+    # --verbose makes it easier to see requests and whether they are matched
+    # or not.
+    command: "--port=80 --https-port=443 --enable-browser-proxying --local-response-templating --enable-stub-cors --verbose --disable-banner"
     volumes:
       - 'projectroot:/app'
     ports:
       - 80
       - 443
     environment:
-      # The following options are used:
-      # --enable-browser-proxying: Allows Wiremock to intercept all traffic from
-      # services  with HTTP(s)_PROXY pointing at it.
-      # --local-response-templating lets WireMock transfer values from request
-      # to mocked response
-      # --enable-stub-cors is required to make a browser running React
-      # components request resources.
-      # --verbose makes it easier to see requests and whether they are matched
-      # or not.
-      WIREMOCK_OPTIONS: "--port=80,--https-port=443,--enable-browser-proxying,--local-response-templating,--enable-stub-cors,--verbose,--disable-banner"
       VIRTUAL_HOST: wiremock.${COMPOSE_PROJECT_NAME}.docker
       VIRTUAL_PORT: 80
 


### PR DESCRIPTION
Our current image holomekc/wiremock-gui is not compatible with Arm. Switch to the official version for Arm support.

This means we no longer will have a UI for Wiremock. However having an official build is preferable going forward. This also means we use the same image and version as on danskernesdigitalebibliotek/dpl-react.

#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
