### PR TITLE
End2end - reservation

### DIFF
--- a/cypress/e2e/user-journey.cy.ts
+++ b/cypress/e2e/user-journey.cy.ts
@@ -66,9 +66,9 @@ describe("User journey", () => {
     });
 
     cy.visit("/search?q=Harry%2520Potter")
-      .get('[data-cy="search-result-title"]')
+      .get("[data-cy='search-result-title']")
       .should("contain", "Showing results for “Harry Potter” (109)")
-      .get('[data-cy="search-result-list"]')
+      .get("[data-cy='search-result-list']")
       .children()
       .eq(0)
       .click()
@@ -76,7 +76,7 @@ describe("User journey", () => {
       .should("include", "work/work-of:870970-basis:25245784");
   });
 
-  function materialPageMocking() {
+  function mockMaterialPage() {
     cy.createMapping({
       request: {
         method: "POST",
@@ -132,14 +132,14 @@ describe("User journey", () => {
   }
 
   it("Shows material page & can open reservation modal", () => {
-    materialPageMocking();
+    mockMaterialPage();
 
     cy.visit("/work/work-of:870970-basis:25245784")
       .contains("Harry Potter og Fønixordenen")
-      .get('[data-cy="material-header-buttons-physical"]')
+      .get("[data-cy='material-header-buttons-physical']")
       .should("contain", "Reserve bog")
       .click()
-      .get('[data-cy="modal"]')
+      .get("[data-cy='modal']")
       .should("contain", "Harry Potter og Fønixordenen");
   });
 

--- a/cypress/e2e/user-journey.cy.ts
+++ b/cypress/e2e/user-journey.cy.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const autosuggestData = require("../../wiremock/src/mappings/search/data/fbi/autosugggest.json");
 const searchResultData = require("../../wiremock/src/mappings/search/data/fbi/searchWithPagination.json");
+const availabilityLabelsData = require("../../wiremock/src/mappings/work/data/fbs/availability.json");
 
 describe("User journey", () => {
   it("Shows search suggestions & redirects to search result page", () => {
@@ -43,6 +44,32 @@ describe("User journey", () => {
         },
         status: 200,
         jsonBody: searchResultData,
+      },
+    });
+    cy.createMapping({
+      request: {
+        method: "GET",
+        urlPattern: ".*/availability/v3.*",
+      },
+      response: {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 200,
+        jsonBody: availabilityLabelsData,
+      },
+    });
+    cy.createMapping({
+      request: {
+        method: "GET",
+        urlPattern: ".*/holdings/v3.*",
+      },
+      response: {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 200,
+        jsonBody: workHoldingData,
       },
     });
 

--- a/cypress/e2e/user-journey.cy.ts
+++ b/cypress/e2e/user-journey.cy.ts
@@ -136,7 +136,9 @@ describe("User journey", () => {
       .contains("Harry Potter og Fønixordenen")
       .get('[data-cy="material-header-buttons-physical"]')
       .should("contain", "Reserve bog")
-      .click();
+      .click()
+      .get('[data-cy="modal"]')
+      .should("contain", "Harry Potter og Fønixordenen");
   });
 
   beforeEach(() => {

--- a/cypress/e2e/user-journey.cy.ts
+++ b/cypress/e2e/user-journey.cy.ts
@@ -1,5 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+/* eslint-disable @typescript-eslint/no-var-requires */
 const autosuggestData = require("../../wiremock/src/mappings/search/data/fbi/autosugggest.json");
+const searchResultData = require("../../wiremock/src/mappings/search/data/fbi/searchWithPagination.json");
 
 describe("User journey", () => {
   it("Shows search suggestions & redirects to search result page", () => {
@@ -28,6 +29,32 @@ describe("User journey", () => {
       .click()
       .url()
       .should("include", "search?q=Harry%2520Potter");
+  });
+
+  it("Shows search results & redirects to material page", () => {
+    cy.createMapping({
+      request: {
+        method: "POST",
+        url: "/opac/graphql",
+      },
+      response: {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 200,
+        jsonBody: searchResultData,
+      },
+    });
+
+    cy.visit("/search?q=Harry%2520Potter")
+      .get('[data-cy="search-result-title"]')
+      .should("contain", "Showing results for “Harry Potter” (109)")
+      .get('[data-cy="search-result-list"]')
+      .children()
+      .eq(0)
+      .click()
+      .url()
+      .should("include", "work/work-of:870970-basis:25245784");
   });
 
   beforeEach(() => {

--- a/cypress/e2e/user-journey.cy.ts
+++ b/cypress/e2e/user-journey.cy.ts
@@ -74,7 +74,7 @@ describe("User journey", () => {
       .should("include", "work/work-of:870970-basis:25245784");
   });
 
-  it("Shows material page & can open reservation modal", () => {
+  function materialPageMocking() {
     cy.createMapping({
       request: {
         method: "POST",
@@ -127,6 +127,10 @@ describe("User journey", () => {
         jsonBody: patronData,
       },
     });
+  }
+
+  it("Shows material page & can open reservation modal", () => {
+    materialPageMocking();
 
     cy.visit("/work/work-of:870970-basis:25245784")
       .contains("Harry Potter og Fønixordenen")

--- a/cypress/e2e/user-journey.cy.ts
+++ b/cypress/e2e/user-journey.cy.ts
@@ -1,0 +1,36 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const autosuggestData = require("../../wiremock/src/mappings/search/data/fbi/autosugggest.json");
+
+describe("User journey", () => {
+  it("Shows search suggestions & redirects to search result page", () => {
+    cy.createMapping({
+      request: {
+        method: "POST",
+        url: "/opac/graphql",
+      },
+      response: {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 200,
+        jsonBody: autosuggestData,
+      },
+    });
+
+    cy.visit("/")
+      .get(".header__menu-search-input")
+      .focus()
+      .type("harry")
+      .get(".autosuggest")
+      .should("be.visible")
+      .get(".autosuggest__text")
+      .eq(0)
+      .click()
+      .url()
+      .should("include", "search?q=Harry%2520Potter");
+  });
+
+  beforeEach(() => {
+    cy.resetMappings();
+  });
+});

--- a/cypress/e2e/user-journey.cy.ts
+++ b/cypress/e2e/user-journey.cy.ts
@@ -2,6 +2,9 @@
 const autosuggestData = require("../../wiremock/src/mappings/search/data/fbi/autosugggest.json");
 const searchResultData = require("../../wiremock/src/mappings/search/data/fbi/searchWithPagination.json");
 const availabilityLabelsData = require("../../wiremock/src/mappings/work/data/fbs/availability.json");
+const workData = require("../../wiremock/src/mappings/work/data/fbi/getMaterial.json");
+const workHoldingData = require("../../wiremock/src/mappings/work/data/fbs/holdings.json");
+const patronData = require("../../wiremock/src/mappings/work/data/fbs/patron.json");
 
 describe("User journey", () => {
   it("Shows search suggestions & redirects to search result page", () => {
@@ -69,6 +72,67 @@ describe("User journey", () => {
       .click()
       .url()
       .should("include", "work/work-of:870970-basis:25245784");
+  });
+
+  it("Shows material page & can open reservation modal", () => {
+    cy.createMapping({
+      request: {
+        method: "POST",
+        url: "/opac/graphql",
+      },
+      response: {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 200,
+        jsonBody: workData,
+      },
+    });
+    cy.createMapping({
+      request: {
+        method: "GET",
+        urlPattern: ".*/availability/v3.*",
+      },
+      response: {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 200,
+        jsonBody: availabilityLabelsData,
+      },
+    });
+    cy.createMapping({
+      request: {
+        method: "GET",
+        urlPattern: ".*/holdings/v3.*",
+      },
+      response: {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 200,
+        jsonBody: workHoldingData,
+      },
+    });
+    cy.createMapping({
+      request: {
+        method: "GET",
+        urlPattern: ".*/patrons/patronid/v2",
+      },
+      response: {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 200,
+        jsonBody: patronData,
+      },
+    });
+
+    cy.visit("/work/work-of:870970-basis:25245784")
+      .contains("Harry Potter og Fønixordenen")
+      .get('[data-cy="material-header-buttons-physical"]')
+      .should("contain", "Reserve bog")
+      .click();
   });
 
   beforeEach(() => {

--- a/cypress/e2e/user-journey.cy.ts
+++ b/cypress/e2e/user-journey.cy.ts
@@ -59,19 +59,6 @@ describe("User journey", () => {
         jsonBody: availabilityLabelsData,
       },
     });
-    cy.createMapping({
-      request: {
-        method: "GET",
-        urlPattern: ".*/holdings/v3.*",
-      },
-      response: {
-        headers: {
-          "Content-Type": "application/json",
-        },
-        status: 200,
-        jsonBody: workHoldingData,
-      },
-    });
 
     cy.visit("/search?q=Harry%2520Potter")
       .get('[data-cy="search-result-title"]')

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -34,23 +34,23 @@ services:
     # We use wiremock-gui as it exposes a UI for inspecting the state of
     # WireMock. This can make debugging easier. It can seamlessly be replaced
     # with the official wiremock/wiremock image.
-    image: holomekc/wiremock-gui:2.33.2.1
+    image: wiremock/wiremock:2.32.0-alpine
+    # The following options are used:
+    # --enable-browser-proxying: Allows Wiremock to intercept all traffic from
+    # services  with HTTP(s)_PROXY pointing at it.
+    # --local-response-templating lets WireMock transfer values from request
+    # to mocked response
+    # --enable-stub-cors is required to make a browser running React
+    # components request resources.
+    # --verbose makes it easier to see requests and whether they are matched
+    # or not.
+    command: "--port=80 --https-port=443 --enable-browser-proxying --local-response-templating --enable-stub-cors --verbose --disable-banner"
     volumes:
       - 'projectroot:/app'
     ports:
       - 80
       - 443
     environment:
-      # The following options are used:
-      # --enable-browser-proxying: Allows Wiremock to intercept all traffic from
-      # services  with HTTP(s)_PROXY pointing at it.
-      # --local-response-templating lets WireMock transfer values from request
-      # to mocked response
-      # --enable-stub-cors is required to make a browser running React
-      # components request resources.
-      # --verbose makes it easier to see requests and whether they are matched
-      # or not.
-      WIREMOCK_OPTIONS: "--port=80,--https-port=443,--enable-browser-proxying,--local-response-templating,--enable-stub-cors,--verbose,--disable-banner"
       VIRTUAL_HOST: wiremock.${COMPOSE_PROJECT_NAME}.docker
       VIRTUAL_PORT: 80
 

--- a/wiremock/src/mappings/search/data/fbi/autosugggest.json
+++ b/wiremock/src/mappings/search/data/fbi/autosugggest.json
@@ -1,0 +1,138 @@
+{
+  "data": {
+    "suggest": {
+      "result": [
+        {
+          "type": "TITLE",
+          "term": "Harry Potter og De Vises Sten",
+          "work": {
+            "workId": "work-of:870970-basis:22629344",
+            "titles": { "main": ["Harry Potter og De Vises Sten"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:22629344" } }
+          }
+        },
+        {
+          "type": "SUBJECT",
+          "term": "Harry Potter",
+          "work": {
+            "workId": "work-of:870970-basis:22677780",
+            "titles": { "main": ["Dummy Some Title"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:22677780" } }
+          }
+        },
+        {
+          "type": "SUBJECT",
+          "term": "Harry Hole",
+          "work": {
+            "workId": "work-of:870970-basis:53045650",
+            "titles": { "main": ["Dummy Some Title"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:53045650" } }
+          }
+        },
+        {
+          "type": "CREATOR",
+          "term": "Hartmut Rosa",
+          "work": {
+            "workId": "work-of:870970-basis:50999335",
+            "titles": { "main": ["Dummy Some Title"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:50999335" } }
+          }
+        },
+        {
+          "type": "CREATOR",
+          "term": "Susan Hart (f. 1956)",
+          "work": {
+            "workId": "work-of:870970-basis:28028881",
+            "titles": { "main": ["Dummy Some Title"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:28028881" } }
+          }
+        },
+        {
+          "type": "TITLE",
+          "term": "Harry Potter og fangen fra Azkaban",
+          "work": {
+            "workId": "work-of:870970-basis:22995154",
+            "titles": { "main": ["Dummy Some Title"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:22995154" } }
+          }
+        },
+        {
+          "type": "SUBJECT",
+          "term": "Harry Dresden",
+          "work": {
+            "workId": "work-of:870970-basis:53182623",
+            "titles": { "main": ["Dummy Some Title"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:53182623" } }
+          }
+        },
+        {
+          "type": "TITLE",
+          "term": "Harry Potter og Fønixordenen",
+          "work": {
+            "workId": "work-of:870970-basis:25245784",
+            "titles": { "main": ["Dummy Some Title"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:25245784" } }
+          }
+        },
+        {
+          "type": "CREATOR",
+          "term": "Yuval Noah Harari",
+          "work": {
+            "workId": "work-of:870970-basis:51725832",
+            "titles": { "main": ["Dummy Some Title"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:51725832" } }
+          }
+        },
+        {
+          "type": "TITLE",
+          "term": "Harry Potter and the philosopher's stone",
+          "work": {
+            "workId": "work-of:870970-basis:42042455",
+            "titles": { "main": ["Dummy Some Title"] },
+            "creators": [
+              { "display": "Dummy Jens Jensen" },
+              { "display": "Dummy Some Corporation" }
+            ],
+            "manifestations": { "first": { "pid": "870970-basis:42042455" } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/wiremock/src/mappings/work/data/fbs/availability.json
+++ b/wiremock/src/mappings/work/data/fbs/availability.json
@@ -1,0 +1,8 @@
+[
+  {
+    "available": true,
+    "recordId": "52557240",
+    "reservable": true,
+    "reservations": 2
+  }
+]

--- a/wiremock/src/mappings/work/data/fbs/patron.json
+++ b/wiremock/src/mappings/work/data/fbs/patron.json
@@ -1,0 +1,29 @@
+{
+  "authenticateStatus": "VALID",
+  "patron": {
+    "address": {
+      "coName": "",
+      "street": "10, Maple street",
+      "postalCode": "2000",
+      "city": "Copenhagen",
+      "country": "DK"
+    },
+    "allowBookings": false,
+    "birthday": "1989-12-13",
+    "blockStatus": null,
+    "defaultInterestPeriod": 180,
+    "emailAddress": "example@gmail.com",
+    "name": "John Doe",
+    "notificationProtocols": [],
+    "onHold": null,
+    "patronId": 20439779,
+    "phoneNumber": "12345678",
+    "preferredLanguage": null,
+    "preferredPickupBranch": "DK-775100",
+    "receiveEmail": true,
+    "receivePostalMail": false,
+    "receiveSms": false,
+    "resident": false,
+    "secondaryAddress": null
+  }
+}

--- a/wiremock/src/mappings/work/data/fbs/reservation.json
+++ b/wiremock/src/mappings/work/data/fbs/reservation.json
@@ -1,0 +1,25 @@
+{
+  "success": true,
+  "reservationResults": [
+    {
+      "periodical": null,
+      "recordId": "52557240",
+      "reservationDetails": {
+        "reservationId": 74218696,
+        "recordId": "52557240",
+        "state": "reserved",
+        "pickupBranch": "DK-775100",
+        "pickupDeadline": null,
+        "expiryDate": "2023-07-17",
+        "dateOfReservation": "2023-01-18T10:44:22.37",
+        "numberInQueue": 3,
+        "periodical": null,
+        "pickupNumber": null,
+        "ilBibliographicRecord": null,
+        "transactionId": "0867d98d-6f40-4adc-9826-a7aca8977cfe",
+        "reservationType": "normal"
+      },
+      "result": "success"
+    }
+  ]
+}

--- a/wiremock/src/mappings/work/data/fbs/reservationAvailability.json
+++ b/wiremock/src/mappings/work/data/fbs/reservationAvailability.json
@@ -1,0 +1,89 @@
+[
+  {
+    "recordId": "52557240",
+    "reservable": true,
+    "reservations": 3,
+    "holdings": [
+      {
+        "branch": { "branchId": "DK-775100", "title": "Hovedbiblioteket" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5119211680",
+            "available": false,
+            "periodical": null,
+            "materialGroup": {
+              "name": "standard",
+              "description": "31 dages lånetid til alm lånere"
+            }
+          },
+          {
+            "itemNumber": "5119211524",
+            "available": true,
+            "periodical": null,
+            "materialGroup": {
+              "name": "standard",
+              "description": "31 dages lånetid til alm lånere"
+            }
+          },
+          {
+            "itemNumber": "5119211672",
+            "available": false,
+            "periodical": null,
+            "materialGroup": {
+              "name": "standard",
+              "description": "31 dages lånetid til alm lånere"
+            }
+          },
+          {
+            "itemNumber": "5119211834",
+            "available": false,
+            "periodical": null,
+            "materialGroup": {
+              "name": "standard",
+              "description": "31 dages lånetid til alm lånere"
+            }
+          },
+          {
+            "itemNumber": "5119211753",
+            "available": false,
+            "periodical": null,
+            "materialGroup": {
+              "name": "standard",
+              "description": "31 dages lånetid til alm lånere"
+            }
+          },
+          {
+            "itemNumber": "5119211745",
+            "available": true,
+            "periodical": null,
+            "materialGroup": {
+              "name": "standard",
+              "description": "31 dages lånetid til alm lånere"
+            }
+          },
+          {
+            "itemNumber": "5119211737",
+            "available": false,
+            "periodical": null,
+            "materialGroup": {
+              "name": "standard",
+              "description": "31 dages lånetid til alm lånere"
+            }
+          },
+          {
+            "itemNumber": "5119211885",
+            "available": false,
+            "periodical": null,
+            "materialGroup": {
+              "name": "standard",
+              "description": "31 dages lånetid til alm lånere"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-310
https://reload.atlassian.net/browse/DDFSOEG-311

#### Description
This PR adds the last part of the reservation flow to the user journey cypress end-to-end test - reservation modal. The test checks whether key data that a user would be focusing on during their user journey is rendered and whether the reservation can be followed through to a confirmation screen.

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Contains #216 + #217 + #218