### PR TITLE
Change opac to next + Remove .test from publizon service

### DIFF
--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -41,12 +41,12 @@ $settings['config_sync_directory'] = '../config/sync';
 
 // Set service base urls for the external APIs.
 $config['dpl_fbs.settings'] = ['base_url' => 'https://fbs-openplatform.dbc.dk'];
-$config['dpl_publizon.settings'] = ['base_url' => 'https://pubhub-openplatform.test.dbc.dk'];
+$config['dpl_publizon.settings'] = ['base_url' => 'https://pubhub-openplatform.dbc.dk'];
 
 // Set service base urls for the react apps.
 $config['dpl_react_apps.settings']['services'] = [
   'cover' => ['base_url' => 'https://cover.dandigbib.org'],
-  'fbi' => ['base_url' => 'https://fbi-api.dbc.dk/opac/graphql'],
+  'fbi' => ['base_url' => 'https://fbi-api.dbc.dk/next/graphql'],
   'material-list' => ['base_url' => 'https://prod.materiallist.dandigbib.org'],
 ];
 
@@ -63,7 +63,7 @@ if (getenv('CI')) {
   // Wiremock.
   // Service base urls for the external APIs.
   $config['dpl_fbs.settings'] = ['base_url' => 'http://fbs-openplatform.dbc.dk'];
-  $config['dpl_publizon.settings'] = ['base_url' => 'http://pubhub-openplatform.test.dbc.dk'];
+  $config['dpl_publizon.settings'] = ['base_url' => 'http://pubhub-openplatform.dbc.dk'];
   // Adgangsplatformen OpenID Connect client.
   $config['openid_connect.settings.adgangsplatformen']['settings']['authorization_endpoint'] = 'http://login.bib.dk/oauth/authorize';
   $config['openid_connect.settings.adgangsplatformen']['settings']['token_endpoint'] = 'http://login.bib.dk/oauth/token/';
@@ -79,7 +79,7 @@ if (getenv('CI')) {
   // We need http domains for testing in CI context.
   $config['dpl_react_apps.settings']['services'] = [
     'cover' => ['base_url' => 'http://cover.dandigbib.org'],
-    'fbi' => ['base_url' => 'http://fbi-api.dbc.dk/opac/graphql'],
+    'fbi' => ['base_url' => 'http://fbi-api.dbc.dk/next/graphql'],
     'material-list' => ['base_url' => 'http://prod.materiallist.dandigbib.org'],
   ];
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-416
https://reload.atlassian.net/browse/DSC-34

#### This PR change following:
- Change profile on `fbi-api` from 'opac' to 'next'
- Change `publizon` service to production

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.