### PR TITLE
ITKDev - Basic modules

### DIFF
--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -39,10 +39,6 @@ $settings['config_exclude_modules'] = ['devel', 'field_ui', 'restui'];
 // advanced security measure: '../config/sync'.
 $settings['config_sync_directory'] = '../config/sync';
 
-// Set service base urls for the external APIs.
-$config['dpl_fbs.settings'] = ['base_url' => 'https://fbs-openplatform.dbc.dk'];
-$config['dpl_publizon.settings'] = ['base_url' => 'https://pubhub-openplatform.test.dbc.dk'];
-
 // Set service base urls for the react apps.
 $config['dpl_react_apps.settings']['services'] = [
   'cover' => ['base_url' => 'https://cover.dandigbib.org'],
@@ -58,12 +54,6 @@ if (getenv('CI')) {
     CURLOPT_PROXY_SSL_VERIFYHOST => 0,
     CURLOPT_PROXY_SSL_VERIFYPEER => FALSE,
   ];
-  // Specify non-HTTP versions of endpoints. This is required to make Cypress
-  // mocking work. It does not support ignoring self-signed certificates from
-  // Wiremock.
-  // Service base urls for the external APIs.
-  $config['dpl_fbs.settings'] = ['base_url' => 'http://fbs-openplatform.dbc.dk'];
-  $config['dpl_publizon.settings'] = ['base_url' => 'http://pubhub-openplatform.test.dbc.dk'];
   // Adgangsplatformen OpenID Connect client.
   $config['openid_connect.settings.adgangsplatformen']['settings']['authorization_endpoint'] = 'http://login.bib.dk/oauth/authorize';
   $config['openid_connect.settings.adgangsplatformen']['settings']['token_endpoint'] = 'http://login.bib.dk/oauth/token/';

--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -54,6 +54,12 @@ if (getenv('CI')) {
     CURLOPT_PROXY_SSL_VERIFYHOST => 0,
     CURLOPT_PROXY_SSL_VERIFYPEER => FALSE,
   ];
+  // Specify non-HTTP versions of endpoints. This is required to make Cypress
+  // mocking work. It does not support ignoring self-signed certificates from
+  // Wiremock.
+  // Service base urls for the external APIs.
+  $config['dpl_fbs.settings'] = ['base_url' => 'http://fbs-openplatform.dbc.dk'];
+  $config['dpl_publizon.settings'] = ['base_url' => 'http://pubhub-openplatform.test.dbc.dk'];
   // Adgangsplatformen OpenID Connect client.
   $config['openid_connect.settings.adgangsplatformen']['settings']['authorization_endpoint'] = 'http://login.bib.dk/oauth/authorize';
   $config['openid_connect.settings.adgangsplatformen']['settings']['token_endpoint'] = 'http://login.bib.dk/oauth/token/';
@@ -98,7 +104,7 @@ if (getenv('LAGOON')) {
   if (
     // Do not enable the cache during install.
     !InstallerKernel::installationAttempted()
-    // Do not enable the the cache if php does not have the extension enabled.
+    // Do not enable the cache if php does not have the extension enabled.
     && extension_loaded('redis')
   ) {
     // Enable the cache backend.

--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,13 @@
         },
         {
             "type": "path",
-            "url": "packages/fbs-client"
+            "url": "packages/fbs-client",
+            "options": {
+                "versions": {
+                    "danskernesdigitalebibliotek/fbs-client": "dev-main"
+                }
+            }
         }
-
     ],
     "require": {
         "amazeeio/drupal_integrations": "0.3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e6c25ebaf00291e15eaf499bde7546e",
+    "content-hash": "f6cb2b4aeb6b1119245af3df4b7cfb1d",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1098,11 +1098,11 @@
         },
         {
             "name": "danskernesdigitalebibliotek/fbs-client",
-            "version": "dev-demo-23-01-27",
+            "version": "dev-main",
             "dist": {
                 "type": "path",
                 "url": "packages/fbs-client",
-                "reference": "311087cee2bc1d9a479da828c6f879db98e6cb2f"
+                "reference": "5ada3fe1856a6a1e504c281d08ed1558120990ef"
             },
             "require": {
                 "ext-curl": "*",
@@ -13153,6 +13153,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "danskernesdigitalebibliotek/dpl-design-system": 5,
+        "danskernesdigitalebibliotek/dpl-react": 5,
         "drupal/default_content": 15,
         "drupal/libraries": 10,
         "drupal/openapi_rest": 5

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -5,11 +5,13 @@ module:
   config_filter: 0
   config_ignore: 0
   dpl_campaign: 0
+  dpl_fbs: 0
   dpl_das: 0
   dpl_library_agency: 0
   dpl_library_token: 0
   dpl_login: 0
   dpl_mapp: 0
+  dpl_publizon: 0
   dpl_react: 0
   dpl_react_apps: 0
   dpl_url_proxy: 0

--- a/config/sync/dpl_fbs.settings.yml
+++ b/config/sync/dpl_fbs.settings.yml
@@ -1,0 +1,1 @@
+base_url: 'https://fbs-openplatform.dbc.dk'

--- a/config/sync/dpl_publizon.settings.yml
+++ b/config/sync/dpl_publizon.settings.yml
@@ -1,0 +1,1 @@
+base_url: 'https://pubhub-openplatform.dbc.dk'

--- a/web/modules/custom/dpl_fbs/dpl_fbs.info.yml
+++ b/web/modules/custom/dpl_fbs/dpl_fbs.info.yml
@@ -1,0 +1,5 @@
+name: DPL FBS
+description: Handle FBS configuration
+package: DPL
+type: module
+core_version_requirement: ^9

--- a/web/modules/custom/dpl_fbs/dpl_fbs.links.menu.yml
+++ b/web/modules/custom/dpl_fbs/dpl_fbs.links.menu.yml
@@ -1,0 +1,5 @@
+dpl_fbs.settings_form:
+  title: "FBS settings"
+  route_name: dpl_fbs.settings
+  description: "Change basic FBS settings"
+  parent: system.admin_config_services

--- a/web/modules/custom/dpl_fbs/dpl_fbs.module
+++ b/web/modules/custom/dpl_fbs/dpl_fbs.module
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @file
+ * Dpl_fbs drupal module file.
+ *
+ * Demonstrates how to use the dpl_react module
+ * and render components.
+ */

--- a/web/modules/custom/dpl_fbs/dpl_fbs.routing.yml
+++ b/web/modules/custom/dpl_fbs/dpl_fbs.routing.yml
@@ -1,0 +1,9 @@
+dpl_fbs.settings:
+  path: "/admin/config/services/fbs"
+  defaults:
+    _form: '\Drupal\dpl_fbs\Form\FbsSettingsForm'
+    _title: "FBS settings"
+  requirements:
+    _permission: "administer site configuration"
+  options:
+    _admin_route: TRUE

--- a/web/modules/custom/dpl_fbs/src/Form/FbsSettingsForm.php
+++ b/web/modules/custom/dpl_fbs/src/Form/FbsSettingsForm.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\dpl_fbs\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * FBS setting form.
+ */
+class FbsSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return [
+      'dpl_fbs.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'dpl_fbs_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('dpl_fbs.settings');
+
+    $form['settings'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Basic settings'),
+      '#tree' => FALSE,
+    ];
+
+    $form['settings']['base_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('FBS service url'),
+      '#default_value' => $config->get('base_url'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $url = $form_state->getValue('base_url');
+    if (!filter_var($url, FILTER_VALIDATE_URL)) {
+      $form_state->setErrorByName('base_url', $this->t('The url "%url" is not a valid URL.', ['%url' => $url]));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitForm($form, $form_state);
+
+    $this->config('dpl_fbs.settings')
+      ->set('base_url', $form_state->getValue('base_url'))
+      ->save();
+  }
+
+}

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -148,6 +148,19 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#description' => $this->t('If checked, SMS notifications for patrons will be disabled.'),
     ];
 
+    $form['thresholds'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Thresholds'),
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $form['thresholds']['threshold_config'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Set thresholds'),
+      '#default_value' => $config->get('threshold_config') ?? '{ "colorThresholds": { "danger": "0", "warning": "6" } }',
+    ];
+
     $form['branches'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Excluded branches'),
@@ -189,6 +202,7 @@ class GeneralSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->config('dpl_library_agency.general_settings')
       ->set('reservation_sms_notifications_disabled', $form_state->getValue('reservation_sms_notifications_disabled'))
+      ->set('threshold_config', $form_state->getValue('threshold_config'))
       ->save();
 
     $this->branchSettings->setExcludedAvailabilityBranches(array_filter($form_state->getValue('availability')));

--- a/web/modules/custom/dpl_publizon/dpl_publizon.info.yml
+++ b/web/modules/custom/dpl_publizon/dpl_publizon.info.yml
@@ -1,0 +1,5 @@
+name: DPL Publizon
+description: Handle publizon configuration
+package: DPL
+type: module
+core_version_requirement: ^9

--- a/web/modules/custom/dpl_publizon/dpl_publizon.links.menu.yml
+++ b/web/modules/custom/dpl_publizon/dpl_publizon.links.menu.yml
@@ -1,0 +1,5 @@
+dpl_publizon.settings_form:
+  title: "Publizon settings"
+  route_name: dpl_publizon.settings
+  description: "Change basic publizon settings"
+  parent: system.admin_config_services

--- a/web/modules/custom/dpl_publizon/dpl_publizon.module
+++ b/web/modules/custom/dpl_publizon/dpl_publizon.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Dpl_publizon drupal module file.
+ */

--- a/web/modules/custom/dpl_publizon/dpl_publizon.routing.yml
+++ b/web/modules/custom/dpl_publizon/dpl_publizon.routing.yml
@@ -1,0 +1,9 @@
+dpl_publizon.settings:
+  path: "/admin/config/services/publizon"
+  defaults:
+    _form: '\Drupal\dpl_publizon\Form\PublizonSettingsForm'
+    _title: "Publizon settings"
+  requirements:
+    _permission: "administer site configuration"
+  options:
+    _admin_route: TRUE

--- a/web/modules/custom/dpl_publizon/src/Form/PublizonSettingsForm.php
+++ b/web/modules/custom/dpl_publizon/src/Form/PublizonSettingsForm.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\dpl_publizon\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Publizon setting form.
+ */
+class PublizonSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return [
+      'dpl_publizon.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'dpl_publizon_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('dpl_publizon.settings');
+
+    $form['settings'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Basic settings'),
+      '#tree' => FALSE,
+    ];
+
+    $form['settings']['base_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Publizon service url'),
+      '#default_value' => $config->get('base_url'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    $url = $form_state->getValue('base_url');
+    if (!filter_var($url, FILTER_VALIDATE_URL)) {
+      $form_state->setErrorByName('base_url', $this->t('The url "%url" is not a valid URL.', ['%url' => $url]));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitForm($form, $form_state);
+    $this->config('dpl_publizon.settings')
+      ->set('base_url', $form_state->getValue('base_url'))
+      ->save();
+  }
+
+}


### PR DESCRIPTION
#### Link to issue

No ticket link as this is across may tickets.

#### Description

Basic support modules and configuration shared between the other PR's for the  user profile pages.

#### Screenshot of the result

N/A

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

* PHPStan errors is due to Stan not knowing about Drupal forms. 
* pa11y that fails is in the search code outside this PR.
* cypress tests that fails are ind the search pages and outside this PR.
