### PR TITLE
Ignore iterable type PHPStan errors for Drupal Form API

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,7 @@ parameters:
     - '#Unsafe usage of new static\(\).#'
     # Drupal Form API makes extensive use for arrays which we cannot provide
     # more detailed typing of.
-    - '#.*\:\:(buildForm|getEditableConfigNames|submitForm)\(\) .* no value type specified in iterable type array\.#'
+    - '#.*\:\:(buildForm|getEditableConfigNames|submitForm|validateForm)\(\) .* no value type specified in iterable type array\.#'
     # Drupal has many different iterable interfaces we do not want to provide
     # iterable typing for.
     - '#no value type specified in iterable type Drupal\\.*Interface#'


### PR DESCRIPTION
#### Description

Ignore iterable type PHPStan errors for Drupal Form API.

Drupal Form API makes extensive use for arrays which we cannot provide more detailed typing of.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

n/a