### PR TITLE
Configure all REST endpoints to use the dpl_login_user_tokens provider

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -5,8 +5,8 @@ module:
   config_filter: 0
   config_ignore: 0
   dpl_campaign: 0
-  dpl_fbs: 0
   dpl_das: 0
+  dpl_fbs: 0
   dpl_library_agency: 0
   dpl_library_token: 0
   dpl_login: 0

--- a/config/sync/rest.resource.campaign.match.yml
+++ b/config/sync/rest.resource.campaign.match.yml
@@ -4,8 +4,8 @@ status: true
 dependencies:
   module:
     - dpl_campaign
+    - dpl_login
     - serialization
-    - user
 id: campaign.match
 plugin_id: 'campaign:match'
 granularity: resource
@@ -15,4 +15,4 @@ configuration:
   formats:
     - json
   authentication:
-    - cookie
+    - dpl_login_user_token

--- a/config/sync/rest.resource.proxy-url.yml
+++ b/config/sync/rest.resource.proxy-url.yml
@@ -3,9 +3,9 @@ langcode: da
 status: true
 dependencies:
   module:
+    - dpl_login
     - dpl_url_proxy
     - serialization
-    - user
 id: proxy-url
 plugin_id: proxy-url
 granularity: resource
@@ -15,4 +15,4 @@ configuration:
   formats:
     - json
   authentication:
-    - cookie
+    - dpl_login_user_token

--- a/documentation/api-development.md
+++ b/documentation/api-development.md
@@ -12,7 +12,9 @@ to expose endpoints from Drupal as an API to be consumed by external parties.
 2. Describe `uri_paths`, `route_parameters` and `responses` in the annotation as
    detailed as possible to create a strong specification.
 3. Install the REST UI module `drush pm-enable restui`
-4. Enable and configure the new REST resource
+4. Enable and configure the new REST resource. It is important to use the
+   `dpl_login_user_token` authentication provider for all resources which will
+   be used by the frontend this will provide a library or user token by default.
 5. Inspect the updated OpenAPI specification at `/openapi/rest?_format=json` to
    ensure looks as intended
 6. Run `task ci:openapi:validate` to validate the updated OpenAPI specification

--- a/openapi.json
+++ b/openapi.json
@@ -126,11 +126,7 @@
         "summary": "Get campaign matching search result facets",
         "operationId": "campaign:match:POST",
         "schemes": ["http"],
-        "security": [
-          {
-            "cookie": []
-          }
-        ]
+        "security": []
       }
     },
     "/dpl_das/order": {
@@ -224,11 +220,7 @@
         "summary": "Generate proxy url",
         "operationId": "proxy-url:GET",
         "schemes": ["http"],
-        "security": [
-          {
-            "cookie": []
-          }
-        ]
+        "security": []
       }
     }
   }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-376

#### Description

The frontend will pass a bearer token for the library or user by default. The UserTokenAuthProvider applies to such requests but for authentication to work it also has to be a valid authentication provider for the route.

Consequently we configure the campaign and proxy endpoints to use this instead.

In practice both endpoints are accessible by anonymous users but for some reason the authentication providers must match anyhow. If not the resources will return 403 and campaigns will not be displayed.

Update configuration accordingly.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The user journey tests fails errors unrelated to this PR.
