### PR TITLE
Clear the cache once again when installing

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -9,6 +9,9 @@ tasks:
         command: |
           if tables=$(drush sqlq "show tables like 'node';") && [ -z "$tables" ]; then
             drush si --existing-config -y
+            # Practice shows that the cache needs to be cleared to avoid
+            # configuration errors even after a site install.
+            drush cr
           fi
         service: cli
         shell: bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -104,6 +104,9 @@ tasks:
       - task dev:start
       # Install site.
       - task dev:cli -- drush site-install --existing-config -y
+      # Practice shows that the cache needs to be cleared to avoid configuration
+      # errors even after a site install.
+      - task dev:cache:clear:drupal
       # Import translations.
       - task dev:cli -- drush locale-check
       - task dev:cli -- drush locale-update


### PR DESCRIPTION
#### Description

We have been seeing errors as shown below when trying to install the 
site. This occurs occasionally both on CI and sometimes locally. We have
not been able to recreate the error consistently.
https://www.drupal.org/project/varnish_purge/issues/3346464

To address this we rebuild the cache immediately after doing a site
install.

While we cannot be sure that this prevents the problem from occuring
then practice has shown that the error does not occur [over 20 site 
installs on GitHub Actions](https://github.com/danskernesdigitalebibliotek/dpl-cms/actions/runs/4363657714). The error typically occurred more frequently
than that.

By adding this to our Taskfile we ensure that it addresses the problem
in CI as well as for local development.

Also clear the cache in the same manor in Lagoon.

```
[...]
Notice: >  [notice] Checked da translation for schemata. 
Notice: >  [notice] Checked da translation for varnish_purge.
Notice: >  [notice] Checked da translation for dpl_cms.
Notice: >  [notice] Message: Checked available interface translation updates for 16 projects.
> 
> PHP Fatal error:  Uncaught Drupal\Core\Entity\Exception\NoCorrespondingEntityClassException: The Drupal\varnish_purger\Entity\VarnishPurgerSettings class does not correspond to an entity type. in /app/web/core/lib/Drupal/Core/Entity/EntityTypeRepository.php:98
> Stack trace:
> #0 /app/web/core/lib/Drupal/Core/Entity/EntityBase.php(487): Drupal\Core\Entity\EntityTypeRepository->getEntityTypeFromClass('Drupal\\varnish_...')
```

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.