### PR TITLE
Run Lighthouse test 5 times instead of 3 to reduce variance

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -7,8 +7,9 @@ module.exports = {
         "http://varnish:8080/search?q=harry+potter&x=0&y=0",
         "http://varnish:8080/work/work-of:870970-basis:25245784?type=bog"
       ],
-      // Use 3 runs to test both cold and warm caches.
-      numberOfRuns: 3,
+      // Use 5 runs to reduce problems regarding variance in the results.
+      // https://github.com/GoogleChrome/lighthouse/blob/main/docs/variability.md
+      numberOfRuns: 5,
       settings: {
         chromeFlags: "--no-sandbox",
         // Lighthouse best practices require HTTPS but we do not this available


### PR DESCRIPTION
We currently see some runs failing while others do not. Run more times to reduce the risk of variance.

5 is a number mentioned multiple times in the Lighthouse docs at  https://github.com/GoogleChrome/lighthouse/blob/main/docs/variability.md

#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
