### PR TITLE
Allow github bot to autocommit translation changes

### DIFF
--- a/.github/workflows/translate-source.yml
+++ b/.github/workflows/translate-source.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@master
       with:
         fetch-depth: 0
+        token: ${{ secrets.AUTOCOMMIT_GITHUB_TOKEN }}
     - name: Install go-task
       uses: arduino/setup-task@v1
       with:

--- a/cypress/e2e/withMappings/user-journey.cy.ts
+++ b/cypress/e2e/withMappings/user-journey.cy.ts
@@ -17,7 +17,7 @@ describe("User journey", () => {
     cy.visit("/search?q=Harry%2520Potter")
       .getBySel("search-result-title")
       .should("contain", "Showing results for “Harry")
-      .getBySel("availability-label")
+      .getBySel("search-result-item-availability")
       .should("exist")
       .getBySel("search-result-list")
       .children()


### PR DESCRIPTION
#### Description

This PR adds a PAT for the dpl-platform-bot to allow it to make commits on the develop branch.
We ran into the problem because the develop branch is protected. 
This should resolve the [issue](https://github.com/stefanzweifel/git-auto-commit-action#push-to-protected-branches).

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
