### PR TITLE
Revert "Fix input passing to webhook action in translation workflow"

### DIFF
--- a/.github/workflows/translate-source.yml
+++ b/.github/workflows/translate-source.yml
@@ -37,7 +37,7 @@ jobs:
         commit_message: New translations were found
     - name: Make Poeditor look for changes
       uses: distributhor/workflow-webhook@v2
-      with:
+      env:
         webhook_url: ${{ secrets.POEDITOR_WEBHOOK_URL }}
         # POEditor webhooks to not use secrets but the action requires a value.
         webhook_secret: 'xxxx'


### PR DESCRIPTION
#### Description

This action does in fact use env instead of with for input.

This reverts commit 18d8429bf29a6df7871ed82c84218662ba57eb45.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
