### PR TITLE
Fixing user-journey reservation test

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -148,13 +148,14 @@ jobs:
         run: task ci:reset
       - name: Run Cypress
         run: task ci:cypress
-      - name: Archive vidoes
+      - name: Archive videoes
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: cypress-videos
           path: cypress/videos
       - name: Archive screenshots
-        if: ${{ failure() }}
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: cypress-screenshots

--- a/cypress/e2e/withMappings/user-journey.cy.ts
+++ b/cypress/e2e/withMappings/user-journey.cy.ts
@@ -52,6 +52,7 @@ describe("User journey", () => {
     // We have to wait for the modal to be fully rendered
     // and the event listeners to be attached.
     // Read more: https://www.cypress.io/blog/2019/01/22/when-can-the-test-click/
+    // TODO: Consider using the pipe package in the future...
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(2000);
     cy.getBySel("reservation-modal-submit-button").click();

--- a/cypress/e2e/withMappings/user-journey.cy.ts
+++ b/cypress/e2e/withMappings/user-journey.cy.ts
@@ -30,9 +30,15 @@ describe("User journey", () => {
     cy.visit("/work/work-of:870970-basis:54181744")
       .getBySel("material-header-content")
       .scrollIntoView()
-      .contains("Harry Potter og Fønixordenen")
-      .getBySel("material-header-buttons-physical")
-      .should("contain", "Reserve bog");
+      .contains("Harry Potter og Fønixordenen");
+    // Wait for service to fill reserve button with the right text.
+    // TODO: Consider using the pipe package in the future...
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(2000);
+    cy.getBySel("material-header-buttons-physical").should(
+      "contain",
+      "Reserve bog"
+    );
   });
 
   it("Can open reservation modal & reserve a material", () => {

--- a/cypress/e2e/withMappings/user-journey.cy.ts
+++ b/cypress/e2e/withMappings/user-journey.cy.ts
@@ -43,6 +43,9 @@ describe("User journey", () => {
     cy.visit("/work/work-of:870970-basis:54181744");
     cy.getBySel("material-header-author-text").scrollIntoView();
     cy.getBySel("material-header-buttons-physical").click();
+    // We have to wait for the modal to be fully rendered.
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(2000);
     cy.getBySel("reservation-modal-parallel")
       .should("be.visible")
       .and("contain", "Harry Potter og Fønixordenen");

--- a/cypress/e2e/withMappings/user-journey.cy.ts
+++ b/cypress/e2e/withMappings/user-journey.cy.ts
@@ -2,7 +2,6 @@ describe("User journey", () => {
   it("Shows search suggestions & redirects to search result page", () => {
     cy.visit("/")
       .getBySel("search-header-input")
-      .focus()
       .type("harry")
       .getBySel("autosuggest")
       .should("be.visible")
@@ -36,8 +35,7 @@ describe("User journey", () => {
       .should("contain", "Reserve bog");
   });
 
-  // TODO: Fix the failing test. It is not able, for some reason, to press the submit button.
-  it.skip("Can open reservation modal & reserve a material", () => {
+  it("Can open reservation modal & reserve a material", () => {
     const authorizationCode = "7c5e3213aea6ef42ec97dfeaa6f5b1d454d856dc";
     const accessToken = "447131b0a03fe0421204c54e5c21a60d70030fd1";
     const userGuid = "19a4ae39-be07-4db9-a8b7-8bbb29f03da6";
@@ -45,9 +43,14 @@ describe("User journey", () => {
     cy.visit("/work/work-of:870970-basis:54181744");
     cy.getBySel("material-header-author-text").scrollIntoView();
     cy.getBySel("material-header-buttons-physical").click();
-    cy.getBySel("modal")
+    cy.getBySel("reservation-modal-parallel")
       .should("be.visible")
       .and("contain", "Harry Potter og Fønixordenen");
+    // We have to wait for the modal to be fully rendered
+    // and the event listeners to be attached.
+    // Read more: https://www.cypress.io/blog/2019/01/22/when-can-the-test-click/
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(2000);
     cy.getBySel("reservation-modal-submit-button").click();
     cy.getBySel("reservation-success-title-text")
       .should("exist")

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -171,6 +171,9 @@ class DplReactAppsController extends ControllerBase {
       'branches-config' => $this->buildBranchesJsonProp($this->branchRepository->getBranches()),
       'blacklisted-availability-branches-config' => $this->buildBranchesListProp($this->branchSettings->getExcludedAvailabilityBranches()),
       'blacklisted-pickup-branches-config' => $this->buildBranchesListProp($this->branchSettings->getExcludedReservationBranches()),
+     // @todo Remove when instant loans are used.
+      'blacklisted-instant-loan-branches-config' => "",
+      'instant-loan-config' => '{}',
       // Urls.
       'auth-url' => self::authUrl(),
       'material-url' => self::materialUrl(),


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-504

#### Description
Make sure event handler is present on reserve-btn by making sure that modal is fully mounted.
Inspired by [this article](https://www.cypress.io/blog/2019/01/22/when-can-the-test-click/).

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

There are several changes from latest demo branch and instant loan PR that need to me merged before this fully works