### PR TITLE
Use placeholder in search loading title

### DIFF
--- a/cypress/e2e/withMappings/user-journey.cy.ts
+++ b/cypress/e2e/withMappings/user-journey.cy.ts
@@ -14,13 +14,13 @@ describe("User journey", () => {
   });
 
   it("Shows search results & redirects to material page", () => {
-    cy.visit("/search?q=Harry%2520Potter")
+    cy.visit("/search?q=Harry+Potter")
       .getBySel("search-result-header")
-      .should("contain", "Showing results for “Harry")
-      .getBySel("search-result-item-availability")
-      .should("exist")
-      .getBySel("search-result-list")
-      .children()
+      .should("contain", 'Showing results for "Harry Potter"')
+      .getBySel("card-list-item-availability")
+      .should("exist");
+
+    cy.getBySel("card-list-item")
       .first()
       .click()
       .url()

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -135,7 +135,7 @@ class DplReactAppsController extends ControllerBase {
       'results-text' => $this->t('results', [], ['context' => 'Search Result']),
       'show-more-text' => $this->t('Show more', [], ['context' => 'Search Result']),
       'show-results-text' => $this->t('Show results', [], ['context' => 'Search Result']),
-      'showing-results-for-text' => $this->t('Showing results for', [], ['context' => 'Search Result'])->__toString(),
+      'showing-results-for-text' => $this->t('Showing results for "@query"', [], ['context' => 'Search Result'])->__toString(),
       'showing-text' => $this->t('Showing', [], ['context' => 'Search Result']),
       'unavailable-text' => $this->t('Unavailable', [], ['context' => 'Search Result']),
     // Add external API base urls.

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -135,7 +135,7 @@ class DplReactAppsController extends ControllerBase {
       'results-text' => $this->t('results', [], ['context' => 'Search Result']),
       'show-more-text' => $this->t('Show more', [], ['context' => 'Search Result']),
       'show-results-text' => $this->t('Show results', [], ['context' => 'Search Result']),
-      'showing-results-for-text' => $this->t('Showing results for "@query"', [], ['context' => 'Search Result'])->__toString(),
+      'showing-results-for-text' => $this->t('Showing results for "@query"', [], ['context' => 'Search Result']),
       'showing-text' => $this->t('Showing', [], ['context' => 'Search Result']),
       'unavailable-text' => $this->t('Unavailable', [], ['context' => 'Search Result']),
     // Add external API base urls.

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -5,7 +5,7 @@
  * Novel Theme.
  */
 
-use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Component\Render\FormattableMarkup;
 
 use function Safe\file_get_contents;
 use function Safe\sprintf;
@@ -68,10 +68,11 @@ function novel_preprocess_dpl_react_app__search_header(array &$variables): void 
 function novel_preprocess_dpl_react_app__search_result(array &$variables): void {
   $q = \Drupal::request()->query->get('q') ?? "";
   $loading_text = $variables['data']['showing-results-for-text'] ?? "";
+  // We deliberately do not use the translation API here.
+  // The text data prop has already been translated
+  // and now we need to replace the placeholder.
   $showing_results_for_text = (
-    // We have already translated the string in the react app.
-    // phpcs:ignore Drupal.Semantics.FunctionT.NotLiteralString
-    new TranslatableMarkup($loading_text, ['@query' => $q])
+    new FormattableMarkup($loading_text, ['@query' => $q])
   )->__toString();
 
   $variables += [

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Component\Render\FormattableMarkup;
-
 use function Safe\file_get_contents;
 use function Safe\sprintf;
 
@@ -67,7 +66,7 @@ function novel_preprocess_dpl_react_app__search_header(array &$variables): void 
  */
 function novel_preprocess_dpl_react_app__search_result(array &$variables): void {
   $q = \Drupal::request()->query->get('q') ?? "";
-  $loading_text = $variables['data']['showing-results-for-text'] ?? "";
+  $loading_text = (string) ($variables['data']['showing-results-for-text'] ?? "");
   // We deliberately do not use the translation API here.
   // The text data prop has already been translated
   // and now we need to replace the placeholder.

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -5,6 +5,8 @@
  * Novel Theme.
  */
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 use function Safe\file_get_contents;
 use function Safe\sprintf;
 
@@ -64,9 +66,16 @@ function novel_preprocess_dpl_react_app__search_header(array &$variables): void 
  *   The variables for the theme hook.
  */
 function novel_preprocess_dpl_react_app__search_result(array &$variables): void {
+  $q = \Drupal::request()->query->get('q') ?? "";
+  $loading_text = $variables['data']['showing-results-for-text'] ?? "";
+  $showing_results_for_text = (
+    // We have already translated the string in the react app.
+    // phpcs:ignore Drupal.Semantics.FunctionT.NotLiteralString
+    new TranslatableMarkup($loading_text, ['@query' => $q])
+  )->__toString();
+
   $variables += [
-    'q' => \Drupal::request()->query->get('q') ?? "",
-    'showing_results_for_text' => $variables['data']['showing-results-for-text'] ?? "",
+    'showing_results_for_text' => $showing_results_for_text,
     'number_of_fake_result_items' => 5,
   ];
 

--- a/web/themes/custom/novel/templates/dpl-react-app--search-result.html.twig
+++ b/web/themes/custom/novel/templates/dpl-react-app--search-result.html.twig
@@ -2,8 +2,8 @@
   <div{{ attributes }}>
     <div class="search-result-page">
       {% if showing_results_for_text and q %}
-        <h1 class="text-header-h2 mb-16 search-result-title text-loading" >
-          {{ showing_results_for_text }} "{{ q }}"
+        <h1 class="text-header-h2 mb-16 search-result-title text-loading">
+          {{ showing_results_for_text }}
         </h1>
       {% endif %}
       <div class="search-result-page__skeleton-facet-line--mobile">

--- a/web/themes/custom/novel/templates/dpl-react-app--search-result.html.twig
+++ b/web/themes/custom/novel/templates/dpl-react-app--search-result.html.twig
@@ -1,7 +1,7 @@
 <div class="dpl-react-app-container--page">
   <div{{ attributes }}>
     <div class="search-result-page">
-      {% if showing_results_for_text and q %}
+      {% if showing_results_for_text %}
         <h1 class="text-header-h2 mb-16 search-result-title text-loading">
           {{ showing_results_for_text }}
         </h1>


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-519

#### Description

Since dpl-react was changed to use query placeholder in the search title we need to do the same in dpl-cms.

Reference:
https://github.com/danskernesdigitalebibliotek/dpl-react/commit/eb14285a868acd27e457d5b89b08b5eb77a65b8e


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
