### PR TITLE
Update `MaterialPageSkeleton` to reflect the new cover size on mobile

### DIFF
--- a/web/themes/custom/novel/templates/dpl-react-app--material.html.twig
+++ b/web/themes/custom/novel/templates/dpl-react-app--material.html.twig
@@ -3,7 +3,7 @@
     <section class="material-page ssc">
       <header class="material-header">
         <div class="material-header__cover">
-          <div class="ssc-square cover--size-xlarge"></div>
+          <div className="ssc-square cover cover--size-xlarge cover--aspect-xlarge"></div>
         </div>
         <div class="material-header__content">
           <div>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-522


#### Description
This PR is changing the `MaterialPageSkeleton` to reflect the new cover size on mobile.


#### Screenshot of the result


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/219
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/438