### PR TITLE
ITKDev - 5590 - Move fees_page_url to general settings

### DIFF
--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -116,6 +116,20 @@ class GeneralSettingsForm extends ConfigFormBase {
       $disabled = TRUE;
     }
 
+    $form['fee_page'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Fee page', [], ['context' => 'Library Agency Configuration']),
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $form['fee_page']['fees_page_url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Fee page url', [], ['context' => 'Loan list (settings)']),
+      '#description' => $this->t('The link to the relevant fee page', [], ['context' => 'Loan list (settings)']),
+      '#default_value' => $config->get('fees_page_url') ?? '',
+    ];
+
     $form['reservations'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Reservations', [], ['context' => 'Library Agency Configuration']),
@@ -164,6 +178,7 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#collapsed' => FALSE,
       '#description' => $this->t('Select which branches should be excluded in different parts of the system.', [], ['context' => 'Library Agency Configuration']),
     ];
+
     $form['branches']['search'] = [
       '#type' => 'checkboxes',
       '#title' => $this->t('Search results', [], ['context' => 'Library Agency Configuration']),
@@ -172,6 +187,7 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#description' => $this->t('Holdings belonging to the selected branches will not be shown in search results.', [], ['context' => 'Library Agency Configuration']),
       "#disabled" => $disabled,
     ];
+
     $form['branches']['availability'] = [
       '#type' => 'checkboxes',
       '#title' => $this->t('Availability'),
@@ -180,6 +196,7 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#description' => $this->t('Holdings belonging to the selected branches will not considered when showing work availability.', [], ['context' => 'Library Agency Configuration']),
       "#disabled" => $disabled,
     ];
+
     $form['branches']['reservation'] = [
       '#type' => 'checkboxes',
       '#title' => $this->t('Reservations', [], ['context' => 'Library Agency Configuration']),
@@ -209,6 +226,7 @@ class GeneralSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->config('dpl_library_agency.general_settings')
       ->set('threshold_config', $form_state->getValue('threshold_config'))
+      ->set('fees_page_url', $form_state->getValue('fees_page_url'))
       ->set('reservation_sms_notifications_disabled', $form_state->getValue('reservation_sms_notifications_disabled'))
       ->set('pause_reservation_info_url', $form_state->getValue('pause_reservation_info_url'))
       ->set('pause_reservation_start_date_config', $form_state->getValue('pause_reservation_start_date_config'))

--- a/web/modules/custom/dpl_loans/src/Form/LoanListSettingsForm.php
+++ b/web/modules/custom/dpl_loans/src/Form/LoanListSettingsForm.php
@@ -38,15 +38,8 @@ class LoanListSettingsForm extends ConfigFormBase {
       '#tree' => FALSE,
     ];
 
-    $form['settings']['fees_page_url'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Fee page url', [], ['context' => 'Loan list (settings)']),
-      '#description' => $this->t('The link to the relevant fee page', [], ['context' => 'Loan list (settings)']),
-      '#default_value' => $config->get('fees_page_url') ?? '',
-    ];
-
     $form['settings']['material_overdue_url'] = [
-      '#type' => 'textfield',
+      '#type' => 'url',
       '#title' => $this->t('Material overdue url', [], ['context' => 'Loan list (settings)']),
       '#description' => $this->t('The link to the material overdue page', [], ['context' => 'Loan list (settings)']),
       '#default_value' => $config->get('material_overdue_url') ?? '',
@@ -75,15 +68,6 @@ class LoanListSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state): void {
-    $feesUrl = $form_state->getValue('fees_page_url');
-    if (!filter_var($feesUrl, FILTER_VALIDATE_URL)) {
-      $form_state->setErrorByName('fees_page_url', $this->t('The url "%url" is not a valid URL.', ['%url' => $feesUrl], ['context' => 'Loan list (settings)']));
-    }
-
-    $materialUrl = $form_state->getValue('material_overdue_url');
-    if (!filter_var($materialUrl, FILTER_VALIDATE_URL)) {
-      $form_state->setErrorByName('material_overdue_url', $this->t('The url "%url" is not a valid URL.', ['%url' => $materialUrl], ['context' => 'Loan list (settings)']));
-    }
   }
 
   /**
@@ -93,7 +77,6 @@ class LoanListSettingsForm extends ConfigFormBase {
     parent::submitForm($form, $form_state);
 
     $this->config('dpl_loan_list.settings')
-      ->set('fees_page_url', $form_state->getValue('fees_page_url'))
       ->set('material_overdue_url', $form_state->getValue('material_overdue_url'))
       ->set('page_size_desktop', $form_state->getValue('page_size_desktop'))
       ->set('page_size_mobile', $form_state->getValue('page_size_mobile'))

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -88,6 +88,7 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
     $loanListSettings = $this->configFactory->get('dpl_loan_list.settings');
     $fbsConfig = $this->configFactory->get('dpl_fbs.settings');
     $publizonConfig = $this->configFactory->get('dpl_publizon.settings');
+    $generalSettings = $this->configFactory->get('dpl_library_agency.general_settings');
 
     $data = [
       // Page size.
@@ -98,7 +99,7 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       // Urls.
       "fbs-base-url" => $fbsConfig->get('base_url'),
       "publizon-base-url" => $publizonConfig->get('base_url'),
-      'fees-page-url' => $loanListSettings->get('fees_page_url'),
+      'fees-page-url' => $generalSettings->get('fees_page_url'),
       'material-overdue-url' => $loanListSettings->get('material_overdue_url'),
       'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
       // Texts.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5590

#### Description

Move fee page url from loan list settings to general settings
Use url in material_overdue_url and remove validation

#### Screenshot of the result

<img width="657" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/15377965/0754cf41-2917-44f6-9484-a405d848a86c">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

n/a
