### PR TITLE
Add Patron permission to REST endpoints

### DIFF
--- a/config/sync/user.role.patron.yml
+++ b/config/sync/user.role.patron.yml
@@ -14,6 +14,8 @@ permissions:
   - 'delete own campaign content'
   - 'edit any campaign content'
   - 'edit own campaign content'
+  - 'restful get proxy-url'
+  - 'restful post campaign:match'
   - 'revert campaign revisions'
   - 'view campaign revisions'
   - 'view own unpublished content'


### PR DESCRIPTION

#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-490

#### Description
Add Patron permission to REST endpoints
Both proxy url and campaign matching should work for the Patron role as well

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
