### PR TITLE
ITKDev - Disable anonymous page cache for redirects

### DIFF
--- a/web/modules/custom/dpl_patron_redirect/dpl_patron_redirect.services.yml
+++ b/web/modules/custom/dpl_patron_redirect/dpl_patron_redirect.services.yml
@@ -8,6 +8,7 @@ services:
         "@path.current",
         "@config.factory",
         "@current_user",
+        "@page_cache_kill_switch",
       ]
     tags:
       - { name: event_subscriber }

--- a/web/modules/custom/dpl_patron_redirect/src/EventSubscriber/RedirectPatronSubscriber.php
+++ b/web/modules/custom/dpl_patron_redirect/src/EventSubscriber/RedirectPatronSubscriber.php
@@ -74,6 +74,12 @@ class RedirectPatronSubscriber implements EventSubscriberInterface {
         // ignored.
         $_SESSION['openid_connect_destination'] = $path;
 
+        // Response built from the ThrustedRedirectReponse class is not cached.
+        // But the problem here is the page cache for anonymous requests, which
+        // caches all responses, even redirects and no matter if they are
+        // cacheable or not. This will kill that cache.
+        \Drupal::service('page_cache_kill_switch')->trigger();
+
         /** @var \Drupal\Core\GeneratedUrl $url */
         $url = Url::fromRoute('dpl_login.login')->toString(TRUE);
         $response = new TrustedRedirectResponse($url->getGeneratedUrl(), 307);


### PR DESCRIPTION
#### Link to issue

https://jira.itkdev.dk/browse/CMN-629

#### Description

Response built from the ThrustedRedirectReponse class is not cached.

But the problem here is the page cache for anonymous requests, which caches all responses, even redirects and no matter if they are cacheable or not.

This is a big problem for /user/me/* as it will create a redirect loop for login, which make open id connect throw an 500 back. 

#### Screenshot of the result

N/A

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

N/A
