### PR TITLE
Clear cache when interface language changes

### DIFF
--- a/web/modules/custom/dpl_react/dpl_react.module
+++ b/web/modules/custom/dpl_react/dpl_react.module
@@ -142,6 +142,11 @@ function dpl_react_preprocess_dpl_react_app(array &$variables): void {
 
   $variables['#cache']['tags'][] = 'dpl_react_app';
   $variables['#cache']['tags'][] = 'dpl_react_app:' . $variables['name'];
+
+  // When changes to the interface language occurs then skip cache.
+  if (!in_array('languages:language_interface', $variables['#cache']['contexts'] ?? [])) {
+    $variables['#cache']['contexts'][] = 'languages:language_interface';
+  }
 }
 
 /**


### PR DESCRIPTION
With this change all apps gets their cache invalidated when user interface text is changed

#### Link to issue

https://reload.atlassian.net/browse/DDFMINI-16

#### Description

Discovered that interface texts did not change when an administrator updated translation.


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
