### PR TITLE
Fix locale update cache invalidation

### DIFF
--- a/web/modules/custom/dpl_react/dpl_react.module
+++ b/web/modules/custom/dpl_react/dpl_react.module
@@ -144,9 +144,7 @@ function dpl_react_preprocess_dpl_react_app(array &$variables): void {
   $variables['#cache']['tags'][] = 'dpl_react_app:' . $variables['name'];
 
   // When changes to the interface language occurs then skip cache.
-  if (!in_array('languages:language_interface', $variables['#cache']['contexts'] ?? [])) {
-    $variables['#cache']['contexts'][] = 'languages:language_interface';
-  }
+  $variables['#cache']['tags'][] = 'locale';
 }
 
 /**

--- a/web/profiles/dpl_cms/dpl_cms.profile
+++ b/web/profiles/dpl_cms/dpl_cms.profile
@@ -75,8 +75,8 @@ function dpl_cms_batch_alter(&$batch) {
  * @see hook_batch_alter
  */
 function dpl_cms_locale_translation_batch_fetch_finished($success, $results) {
-  if ($success && !empty($results) && !empty($results['languages'])) {
-    _locale_refresh_translations(array_values($results['languages']));
+  if ($success && $languages = array_values($result['languages'] ?? [])) {
+    _locale_refresh_translations($languages);
   }
   locale_translation_batch_fetch_finished($success, $results);
 }

--- a/web/profiles/dpl_cms/dpl_cms.profile
+++ b/web/profiles/dpl_cms/dpl_cms.profile
@@ -68,8 +68,6 @@ function dpl_cms_batch_alter(&$batch) {
 /**
  * Implements callback_batch_finished().
  *
- * Set result message.
- *
  * @param bool $success
  *   TRUE if batch successfully completed.
  * @param array $results


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFMINI-16

#### Description
Invalidate locale cache tag when running locale-update:
Since the locale cache tag is not invalidated when running
`drush locale-update` we need to make sure it happens ourselves
by injecting our own batch finished callback.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
