### PR TITLE
Analyse profile with PHPStan and PHPCS

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -2,6 +2,7 @@
 <ruleset>
   <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
   <file>web/modules/custom</file>
+  <file>web/profiles/dpl_cms</file>
   <file>web/themes/custom</file>
   <!-- Exclude built assets used by Novel -->
   <exclude-pattern>web/themes/custom/novel/assets/*</exclude-pattern>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,6 +2,7 @@ parameters:
   level: max
   paths:
     - web/modules/custom
+    - web/profiles/dpl_cms
     - web/themes/custom
   ignoreErrors:
     - '#Unsafe usage of new static\(\).#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,5 +16,8 @@ parameters:
     # Ignore block inject create configuration parameter.
     - '#Drupal\\.*\\Plugin\\Block\\.*Block::__construct\(\) .* no value type specified in iterable type array\.#'
     - '#Drupal\\.*\\Plugin\\Block\\.*Block::create\(\) .* no value type specified in iterable type array\.#'
+  scanFiles:
+    # Needed to make locale_translation_batch_fetch_finished() discoverable.
+    - web/core/modules/locale/locale.batch.inc
 
 

--- a/web/profiles/dpl_cms/dpl_cms.install
+++ b/web/profiles/dpl_cms/dpl_cms.install
@@ -1,7 +1,11 @@
 <?php
+
 /**
  * @file
  * Install, update and uninstall functions for the dpl_cms install profile.
+ *
+ * Disable coding standards due to the currently empty content of this file.
+ * @phpcs:disable DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter
  */
 
 // Do not implement dpl_cms_install(). We run site installs with existing

--- a/web/profiles/dpl_cms/dpl_cms.profile
+++ b/web/profiles/dpl_cms/dpl_cms.profile
@@ -9,6 +9,9 @@ use Drupal\user\Entity\User;
 
 /**
  * Implements hook_updater_info_alter().
+ *
+ * @param mixed[] $updaters
+ *   An associative array of information about the updater(s) being provided.
  */
 function dpl_cms_updater_info_alter(&$updaters): void {
   // Extending the core updater module class.
@@ -19,8 +22,12 @@ function dpl_cms_updater_info_alter(&$updaters): void {
 
 /**
  * Implements hook_modules_installed().
+ *
+ * @param string[] $modules
+ *   An array of the modules that were installed.
  */
 function dpl_cms_modules_installed(array $modules, bool $is_syncing): void {
+  /** @var \Drupal\user\UserInterface $user */
   $user = User::load(1);
 
   // Make sure that the admin language of the admin user is set to english.
@@ -46,8 +53,11 @@ function dpl_cms_modules_installed(array $modules, bool $is_syncing): void {
 
 /**
  * Implements hook_batch_alter().
+ *
+ * @param mixed[] $batch
+ *   An associative array of batches.
  */
-function dpl_cms_batch_alter(&$batch) {
+function dpl_cms_batch_alter(&$batch): void {
   if (empty($batch['sets'])) {
     return;
   }
@@ -70,11 +80,11 @@ function dpl_cms_batch_alter(&$batch) {
  *
  * @param bool $success
  *   TRUE if batch successfully completed.
- * @param array $results
+ * @param mixed[] $results
  *   Batch results.
  * @see hook_batch_alter
  */
-function dpl_cms_locale_translation_batch_fetch_finished($success, $results) {
+function dpl_cms_locale_translation_batch_fetch_finished($success, $results): void {
   if ($success && $languages = array_values($results['languages'] ?? [])) {
     _locale_refresh_translations($languages);
     \Drupal::logger('dpl_cms')->notice("New translations were imported and translation cache was cleared.");

--- a/web/profiles/dpl_cms/dpl_cms.profile
+++ b/web/profiles/dpl_cms/dpl_cms.profile
@@ -13,7 +13,7 @@ use Drupal\user\Entity\User;
  * @param mixed[] $updaters
  *   An associative array of information about the updater(s) being provided.
  */
-function dpl_cms_updater_info_alter(&$updaters): void {
+function dpl_cms_updater_info_alter(array &$updaters): void {
   // Extending the core updater module class.
   // We need to change the path
   // because we want to persist the modules in a volume.
@@ -57,7 +57,7 @@ function dpl_cms_modules_installed(array $modules, bool $is_syncing): void {
  * @param mixed[] $batch
  *   An associative array of batches.
  */
-function dpl_cms_batch_alter(&$batch): void {
+function dpl_cms_batch_alter(array &$batch): void {
   if (empty($batch['sets'])) {
     return;
   }
@@ -82,9 +82,10 @@ function dpl_cms_batch_alter(&$batch): void {
  *   TRUE if batch successfully completed.
  * @param mixed[] $results
  *   Batch results.
+ *
  * @see hook_batch_alter
  */
-function dpl_cms_locale_translation_batch_fetch_finished($success, $results): void {
+function dpl_cms_locale_translation_batch_fetch_finished(bool $success, array $results): void {
   if ($success && $languages = array_values($results['languages'] ?? [])) {
     _locale_refresh_translations($languages);
     \Drupal::logger('dpl_cms')->notice("New translations were imported and translation cache was cleared.");


### PR DESCRIPTION
#### Description

Currently we only look in custom modules and themes. We need to look in the profile as well.

Check out the commits and action results to see the problems raised which have subsequently been fixed.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

I originally expected this to identify the problem in #372. It turns out this is not the case. [Apparently it is because PHPStan will not raise errors with undefined variables and `??`/null coalescence operator](https://phpstan.org/r/a54d4eeb-c276-479d-8102-9b5c56a4ff80). 

