### PR TITLE
5863: Removing some unused link inputs

### DIFF
--- a/web/modules/custom/dpl_dashboard/src/Form/DashboardSettingsForm.php
+++ b/web/modules/custom/dpl_dashboard/src/Form/DashboardSettingsForm.php
@@ -66,54 +66,6 @@ class DashboardSettingsForm extends ConfigFormBase {
       '#tree' => FALSE,
     ];
 
-    $form['settings']['intermediate_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Fees url', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('intermediate_url') ?? '',
-    ];
-
-    $form['settings']['pay_owed_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Pay owed url', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('pay_owed_url') ?? '',
-    ];
-
-    $form['settings']['physical_loans_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Physical loans url', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('physical_loans_url') ?? '',
-    ];
-
-    $form['settings']['loans_overdue_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Loans overdue url', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('loans_overdue_url') ?? '',
-    ];
-
-    $form['settings']['loans_soon_overdue_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Loans soon overdue url', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('loans_soon_overdue_url') ?? '',
-    ];
-
-    $form['settings']['loans_not_overdue_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Loans not overdue url', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('loans_not_overdue_url') ?? '',
-    ];
-
-    $form['settings']['reservations_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Reservations url', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('reservations_url') ?? '',
-    ];
-
-    $form['settings']['fees_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Fees url', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('fees_url') ?? '',
-    ];
-
     $form['settings']['page_size_mobile'] = [
       '#type' => 'number',
       '#title' => $this->t('Page size mobile', [], ['context' => 'Dashboard (settings)']),
@@ -139,14 +91,6 @@ class DashboardSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     parent::submitForm($form, $form_state);
     $this->config($this->configService->getConfigKey())
-      ->set('intermediate_url', $form_state->getValue('intermediate_url'))
-      ->set('pay_owed_url', $form_state->getValue('pay_owed_url'))
-      ->set('physical_loans_url', $form_state->getValue('physical_loans_url'))
-      ->set('loans_overdue_url', $form_state->getValue('loans_overdue_url'))
-      ->set('fees_url', $form_state->getValue('fees_url'))
-      ->set('loans_soon_overdue_url', $form_state->getValue('loans_soon_overdue_url'))
-      ->set('loans_not_overdue_url', $form_state->getValue('loans_not_overdue_url'))
-      ->set('reservations_url', $form_state->getValue('reservations_url'))
       ->set('page_size_desktop', $form_state->getValue('page_size_desktop'))
       ->set('page_size_mobile', $form_state->getValue('page_size_mobile'))
       ->save();

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -89,6 +89,10 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
 
       // Urls.
       'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
+      'fees-page-url' => '/user/me/fees',
+      'intermediate-url' => '/user/me/intermediates',
+      'reservations-url' => '/user/me/reservations',
+      'physical-loans-url' => '/user/me/loans',
       'search-url' => DplReactAppsController::searchResultUrl(),
       'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url'),
 

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -89,16 +89,7 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
 
       // Urls.
       'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
-      'fees-page-url' => $generalSettings->get('fees_page_url'),
-      'intermediate-url' => $dashboardSettings->get('intermediate_url'),
-      'loans-not-overdue-url' => $dashboardSettings->get('loans_not_overdue_url'),
-      'loans-overdue-url' => $dashboardSettings->get('loans_overdue_url'),
-      'loans-soon-overdue-url' => $dashboardSettings->get('loans_soon_overdue_url'),
-      'pay-owed-url' => $dashboardSettings->get('pay_owed_url'),
-      'physical-loans-url' => $dashboardSettings->get('physical_loans_url'),
-      'reservations-url' => $dashboardSettings->get('reservations_url'),
       'search-url' => DplReactAppsController::searchResultUrl(),
-      'fees-url' => $dashboardSettings->get('fees_url'),
       'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url'),
 
       // Texts.

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -123,13 +123,6 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#collapsed' => FALSE,
     ];
 
-    $form['fee_page']['fees_page_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Fee page url', [], ['context' => 'Loan list (settings)']),
-      '#description' => $this->t('The link to the relevant fee page', [], ['context' => 'Loan list (settings)']),
-      '#default_value' => $config->get('fees_page_url') ?? '',
-    ];
-
     $form['reservations'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Reservations', [], ['context' => 'Library Agency Configuration']),
@@ -263,7 +256,6 @@ class GeneralSettingsForm extends ConfigFormBase {
       ->set('threshold_config', $form_state->getValue('threshold_config'))
       ->set('reservation_detail_allow_remove_ready_reservations_config', $form_state->getValue('reservation_detail_allow_remove_ready_reservations_config'))
       ->set('interest_periods_config', $form_state->getValue('interest_periods_config'))
-      ->set('fees_page_url', $form_state->getValue('fees_page_url'))
       ->set('reservation_sms_notifications_disabled', $form_state->getValue('reservation_sms_notifications_disabled'))
       ->set('pause_reservation_info_url', $form_state->getValue('pause_reservation_info_url'))
       ->set('redirect_on_blocked_url', $form_state->getValue('redirect_on_blocked_url'))

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -101,7 +101,6 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       // Urls.
       'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url'),
       'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
-      'fees-page-url' => $generalSettings->get('fees_page_url'),
       'material-overdue-url' => $loanListSettings->get('material_overdue_url'),
 
       // Texts.

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -99,6 +99,7 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       "threshold-config" => $this->getThresholdConfig(),
 
       // Urls.
+      'fees-page-url' => '/user/me/fees',
       'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url'),
       'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
       'material-overdue-url' => $loanListSettings->get('material_overdue_url'),

--- a/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
+++ b/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
@@ -132,6 +132,7 @@ class PatronMenuBlock extends BlockBase implements ContainerFactoryPluginInterfa
       'interest-periods-config' => DplReactAppsController::getInterestPeriods(),
 
       // Urls.
+      'fees-page-url' => '/user/me/fees',
       "menu-login-url" => Url::fromRoute('dpl_login.login', [], ['absolute' => TRUE])->toString(),
       "menu-log-out-url" => Url::fromRoute('dpl_login.logout', [], ['absolute' => TRUE])->toString(),
       "menu-sign-up-url" => Url::fromRoute('dpl_patron_reg.information', [], ['absolute' => TRUE])->toString(),

--- a/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
+++ b/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
@@ -132,7 +132,6 @@ class PatronMenuBlock extends BlockBase implements ContainerFactoryPluginInterfa
       'interest-periods-config' => DplReactAppsController::getInterestPeriods(),
 
       // Urls.
-      'fees-page-url' => $generalSettings->get('fees_page_url'),
       "menu-login-url" => Url::fromRoute('dpl_login.login', [], ['absolute' => TRUE])->toString(),
       "menu-log-out-url" => Url::fromRoute('dpl_login.logout', [], ['absolute' => TRUE])->toString(),
       "menu-sign-up-url" => Url::fromRoute('dpl_patron_reg.information', [], ['absolute' => TRUE])->toString(),


### PR DESCRIPTION
 ...and replacing some with hardcoded counterparts in dpl-react

#### Link to issue

[Please add a link to the issue being addressed by this change.](https://platform.dandigbib.org/issues/5863)

#### Description

Some of the links previously to be defined by each library branch, is now to be hardcoded. e.g (/user/me/loans, /user/me/fees etc)

#### Screenshot of the result

N/A

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
