### PR TITLE
Add multiple match configuration for instant loans

### DIFF
--- a/web/modules/custom/dpl_instant_loan/src/Form/DplInstantLoanSettingsForm.php
+++ b/web/modules/custom/dpl_instant_loan/src/Form/DplInstantLoanSettingsForm.php
@@ -87,7 +87,7 @@ class DplInstantLoanSettingsForm extends ConfigFormBase {
     $form['match_strings'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Match Strings', [], ['context' => 'dpl_instant_loan']),
-    // Set the number of visible rows for the textarea.
+      // Set the number of visible rows for the textarea.
       '#rows' => 5,
       '#description' => $this->t('Text used to identify materials which are available for instant loans.<br/> You can write multiple strings - each on a spearate line.<br/> To find a match one of the strings must be present in the material group of such materials.'),
       '#default_value' => implode("\n", $config->get('match_strings')),

--- a/web/modules/custom/dpl_instant_loan/src/Form/DplInstantLoanSettingsForm.php
+++ b/web/modules/custom/dpl_instant_loan/src/Form/DplInstantLoanSettingsForm.php
@@ -89,7 +89,7 @@ class DplInstantLoanSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Match Strings', [], ['context' => 'dpl_instant_loan']),
       // Set the number of visible rows for the textarea.
       '#rows' => 5,
-      '#description' => $this->t('Text used to identify materials which are available for instant loans.<br/> You can write multiple strings - each on a spearate line.<br/> To find a match one of the strings must be present in the material group of such materials.'),
+      '#description' => $this->t('Text used to identify materials which are available for instant loans.<br/> You can write multiple strings - each on a spearate line.<br/> To find a match one of the strings must be present in the material group of such materials.', [], ['context' => 'dpl_instant_loan']),
       '#default_value' => implode("\n", $config->get('match_strings')),
       '#states' => $config_field_states,
     ];

--- a/web/modules/custom/dpl_instant_loan/src/Form/DplInstantLoanSettingsForm.php
+++ b/web/modules/custom/dpl_instant_loan/src/Form/DplInstantLoanSettingsForm.php
@@ -84,15 +84,13 @@ class DplInstantLoanSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('enabled'),
     ];
 
-    $form['match_string'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Match String', [], ['context' => 'dpl_instant_loan']),
-      '#description' => $this->t(
-        'Text used to identify materials which are available for instant loans. This text must be present in the material group of such materials.',
-        [],
-        ['context' => 'dpl_instant_loan']
-      ),
-      '#default_value' => $config->get('match_string'),
+    $form['match_strings'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Match Strings', [], ['context' => 'dpl_instant_loan']),
+    // Set the number of visible rows for the textarea.
+      '#rows' => 5,
+      '#description' => $this->t('Text used to identify materials which are available for instant loans.<br/> You can write multiple strings - each on a spearate line.<br/> To find a match one of the strings must be present in the material group of such materials.'),
+      '#default_value' => implode("\n", $config->get('match_strings')),
       '#states' => $config_field_states,
     ];
 
@@ -117,7 +115,7 @@ class DplInstantLoanSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->config($this->configService->getConfigKey())
       ->set('enabled', $form_state->getValue('enabled'))
-      ->set('match_string', $form_state->getValue('match_string'))
+      ->set('match_strings', explode("\n", $form_state->getValue('match_strings')) ?? [])
       ->set('threshold', $form_state->getValue('threshold'))
       ->save();
 

--- a/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
+++ b/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
@@ -5,14 +5,12 @@ namespace Drupal\dpl_patron_reg\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\dpl_library_agency\Branch\Branch;
 use Drupal\dpl_login\UserTokensProvider;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\dpl_library_agency\Branch\BranchRepositoryInterface;
 use Drupal\dpl_library_agency\BranchSettings;
-use function Safe\json_encode as json_encode;
 
 /**
  * Provides user registration block.


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DSC-69

#### Description

It should be possible to match materials by multiple strings so the configuration form element has been changed from a text input field to a textarea.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The PR is connected to the changes in this [PR](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/519).
