### PR TITLE
Add sticky header dependencies from design system

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -65,3 +65,14 @@ environments:
       schedule: "M/30 * * * *"
       command: drush locale-check && drush locale-update
       service: cli
+  pr-384:
+    cronjobs:
+    - name: drush cron
+      schedule: "M/15 * * * *"
+      command: drush cron
+      service: cli
+    - name: import translations
+      # Quite frequent translation import because of businezz.
+      schedule: "M/2 * * * *"
+      command: drush locale-check && drush locale-update
+      service: cli

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-design-system",
                 "type": "drupal-library",
-                "version": "v1.7.0-rc23",
+                "version": "v1.7.0-rc24",
                 "dist": {
-                    "url": "https://github.com/reload/dpl-design-system/releases/download/release-DDFDPDEL-215-semi-sticky-headers-pa-mobil/dist.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-develop/dist.zip",
                     "type": "zip"
                 }
             }

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-design-system",
                 "type": "drupal-library",
-                "version": "v1.7.0-rc22",
+                "version": "v1.7.0-rc23",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-develop/dist.zip",
+                    "url": "https://github.com/reload/dpl-design-system/releases/download/release-DDFDPDEL-215-semi-sticky-headers-pa-mobil/dist.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4a52c30b26fc390bfbe0244392a3603",
+    "content-hash": "c1caaed061913ec0bc9e547f4adc411a",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1077,10 +1077,10 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-design-system",
-            "version": "v1.7.0-rc23",
+            "version": "v1.7.0-rc24",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/reload/dpl-design-system/releases/download/release-DDFDPDEL-215-semi-sticky-headers-pa-mobil/dist.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-develop/dist.zip"
             },
             "type": "drupal-library"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "46c291a7932ddf96eecb7f6210512ab3",
+    "content-hash": "b4a52c30b26fc390bfbe0244392a3603",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1077,10 +1077,10 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-design-system",
-            "version": "v1.7.0-rc22",
+            "version": "v1.7.0-rc23",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/release-develop/dist.zip"
+                "url": "https://github.com/reload/dpl-design-system/releases/download/release-DDFDPDEL-215-semi-sticky-headers-pa-mobil/dist.zip"
             },
             "type": "drupal-library"
         },

--- a/web/themes/custom/novel/novel.libraries.yml
+++ b/web/themes/custom/novel/novel.libraries.yml
@@ -5,7 +5,8 @@ base:
       assets/dpl-design-system/css/base.css: {}
       css/novel.css: {}
   js:
-    assets/dpl-design-system/js/initheader.js: {}
+    assets/dpl-design-system/js/header-toggle.js: {}
+    assets/dpl-design-system/js/header-sticky.js: {}
     assets/dpl-design-system/js/initaccordion.js: {}
   dependencies:
     - core/drupal


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFDPDEL-215

#### Description

Sticky header js and css from design system is added to dpl-cms

#### See it in action
https://varnish.pr-384.dpl-cms.dplplat01.dpl.reload.dk/search?q=harry+potter&x=0&y=0

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This PR relates to this [PR](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/244)