### PR TITLE
Disable preprocessing of JavaScript from React component libraries

### DIFF
--- a/web/modules/custom/dpl_react/dpl_react.libraries.yml
+++ b/web/modules/custom/dpl_react/dpl_react.libraries.yml
@@ -5,7 +5,7 @@ hello-world:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/hello-world.js: {}
+    /libraries/dpl-react/hello-world.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -17,7 +17,7 @@ search-header:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/search-header.js: {}
+    /libraries/dpl-react/search-header.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -29,7 +29,7 @@ search-result:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/search-result.js: {}
+    /libraries/dpl-react/search-result.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -41,7 +41,7 @@ patron-page:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/PatronPage.js: {}
+    /libraries/dpl-react/PatronPage.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -53,7 +53,7 @@ create-patron:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/CreatePatron.js: {}
+    /libraries/dpl-react/CreatePatron.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -65,7 +65,7 @@ material:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/material.js: {}
+    /libraries/dpl-react/material.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -77,7 +77,7 @@ loan-list:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/loan-list.js: {}
+    /libraries/dpl-react/loan-list.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -89,7 +89,7 @@ recommender:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/Recommender.js: {}
+    /libraries/dpl-react/Recommender.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -101,7 +101,7 @@ something-similar:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/SomethingSimilar.js: {}
+    /libraries/dpl-react/SomethingSimilar.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -113,7 +113,7 @@ fee-list:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/FeeList.js: {}
+    /libraries/dpl-react/FeeList.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -125,7 +125,8 @@ favorites-list-material-component:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/FavoritesListMaterialComponent.js: {}
+    /libraries/dpl-react/FavoritesListMaterialComponent.js:
+      { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -137,7 +138,7 @@ reservation-list:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/reservation-list.js: {}
+    /libraries/dpl-react/reservation-list.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -149,7 +150,7 @@ DashBoard:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/dashboard.js: {}
+    /libraries/dpl-react/dashboard.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -161,7 +162,7 @@ favorites-list:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/FavoritesList.js: {}
+    /libraries/dpl-react/FavoritesList.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -173,7 +174,7 @@ menu:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/menu.js: {}
+    /libraries/dpl-react/menu.js: { preprocess: false }
   dependencies:
     - dpl_react/base
     - dpl_react/handler
@@ -185,9 +186,9 @@ base:
     url: https://github.com/danskernesdigitalebibliotek/dpl-react/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dpl-react/runtime.js: { weight: -19 }
-    /libraries/dpl-react/bundle.js: { weight: -18 }
-    /libraries/dpl-react/mount.js: { weight: -16 }
+    /libraries/dpl-react/runtime.js: { preprocess: false, weight: -19 }
+    /libraries/dpl-react/bundle.js: { preprocess: false, weight: -18 }
+    /libraries/dpl-react/mount.js: { preprocess: false, weight: -16 }
   css:
     theme:
       /libraries/dpl-react/components.css: {}


### PR DESCRIPTION
#### Description

Preprocessing means that the files will be aggregated if enabled. Aggregation disables sourcemaps which makes JavaScript errors significantly harder to debug.

We could toggle this through configuration but we do not want to  disable aggregation for other JavaScript files.

This may degrade performance because multiple files will have to be downloaded. On the other hand features like HTTP/2 and browser caching should make this less of a problem in practice. Not using aggregation should also enable browsers to cache the files once downloaded as they will not change across pages.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
