### PR TITLE
Fix syntax for Dependabot Drupal Core groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,13 +21,13 @@ updates:
   open-pull-requests-limit: 3
   groups:
     drupal-core-minor-major-releases:
-      include-patterns:
+      patterns:
         - "drupal/core*"
       update-types:
         - "major"
         - "minor"
     drupal-core-patch-releases:
-      include-patterns:
+      patterns:
         - "drupal/core*"
       update-types:
         - "patch"


### PR DESCRIPTION
#### Description

There is no include-patterns option. It is just called patterns.

The problem causes other PRs to fail e.g. https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/374/checks?check_run_id=17258750091