### PR TITLE
Add renewal feedback texts

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -65,7 +65,7 @@ environments:
       schedule: "M/30 * * * *"
       command: drush locale-check && drush locale-update
       service: cli
-  pr-396:
+  pr-399:
     cronjobs:
     - name: drush cron
       schedule: "M/15 * * * *"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "type": "package",
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-react",
-                "version": "0.3.0-rc33",
+                "version": "0.3.0-rc34",
                 "type": "drupal-library",
                 "dist": {
                     "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-develop/dist.zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "577439e3f385a93571fa0efdab4fe4ca",
+    "content-hash": "60a7a2789e6ebad975199d5ff95d4c80",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1086,7 +1086,7 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-react",
-            "version": "0.3.0-rc33",
+            "version": "0.3.0-rc34",
             "dist": {
                 "type": "zip",
                 "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-develop/dist.zip"

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -183,7 +183,7 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
       'accept-modal-cancel-button-text' => $this->t("Cancel renewal", [], ['context' => 'Dashboard']),
       'accept-modal-aria-description-text' => $this->t("accept modal aria description text", [], ['context' => 'Dashboard (Aria)']),
       'accept-modal-aria-label-text' => $this->t("accept modal aria label text", [], ['context' => 'Dashboard (Aria)']),
-    ] + DplReactAppsController::externalApiBaseUrls();
+    ] + dpl_react_apps_texts_renewal() + DplReactAppsController::externalApiBaseUrls();
 
     return [
       '#theme' => 'dpl_react_app',

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -174,7 +174,7 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       'accept-modal-cancel-button-text' => $this->t("Cancel renewal", [], ['context' => 'Loan list']),
       'accept-modal-aria-description-text' => $this->t("accept modal aria description text", [], ['context' => 'Loan list (Aria)']),
       'accept-modal-aria-label-text' => $this->t("accept modal aria label text", [], ['context' => 'Loan list (Aria)']),
-    ] + DplReactAppsController::externalApiBaseUrls() + DplReactAppsController::getBlockedSettings();
+    ] + dpl_react_apps_texts_renewal() + DplReactAppsController::externalApiBaseUrls() + DplReactAppsController::getBlockedSettings();
 
     return [
       '#theme' => 'dpl_react_app',

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -63,3 +63,33 @@ function dpl_react_apps_preprocess_dpl_react_app(array &$variables): void {
     'data-alert-error-message-text' => t('An error occurred', [], ['context' => 'React apps (Global error handling)']),
   ];
 }
+
+/**
+ * Renew texts for multiple apps.
+ *
+ * @return mixed[]
+ *   Texts props.
+ */
+function dpl_react_apps_texts_renewal(): array {
+  // These texts are shared between multiple apps.
+  // Instead of defing them in each app we define them here.
+  return [
+    'renew-button-text' => t('Renew', [], ['context' => 'Renew loan']),
+    'renew-cannot-be-renewed-text' => t('Cannot be renewed', [], ['context' => 'Renew loan']),
+    'renew-group-modal-loans-button-text' => t('Ok', [], ['context' => 'Renew loan (group modal)']),
+    'renew-group-modal-loans-error-status-text' => t('Something went wrong renewing your loans. Please try again.', [], ['context' => 'Renew loan (group modal)']),
+    'renew-group-modal-loans-error-title-text' => t('Renewing your loans failed', [], ['context' => 'Renew loan (group modal)']),
+    'renew-group-modal-loans-no-renewals-possible-error-status-text' => t('For some reason, no one of your loans could be renewed.', [], ['context' => 'Renew loan (group modal)']),
+    'renew-group-modal-loans-no-renewals-possible-error-title-text' => t('No loans could be renewed', [], ['context' => 'Renew loan (group modal)']),
+    'renew-group-modal-loans-success-status-text' => t('{"type":"plural","text":["1 loan has been renewed.","@count loans have been renewed."]}', [], ['context' => 'Renew loan (group modal)']),
+    'renew-group-modal-loans-success-title-text' => t('You have renewed your loans', [], ['context' => 'Renew loan (group modal)']),
+    'renew-material-loan-button-text' => t('Ok', [], ['context' => 'Renew loan (material)']),
+    'renew-material-loan-error-status-text' => t('omething went wrong renewing your loan. Please try again.', [], ['context' => 'Renew loan (material)']),
+    'renew-material-loan-error-title-text' => t('Renewal of your loan failed', [], ['context' => 'Renew loan (material)']),
+    'renew-material-loan-no-renewals-possible-error-status-text' => t('For some reason, your loan could not be renewed.', [], ['context' => 'Renew loan (material)']),
+    'renew-material-loan-no-renewals-possible-error-title-text' => t('The loan could not be renewed', [], ['context' => 'Renew loan (material)']),
+    'renew-material-loan-success-status-text' => t('1 loan was renewed.', [], ['context' => 'Renew loan (material)']),
+    'renew-material-loan-success-title-text' => t('You have renewed your loan', [], ['context' => 'Renew loan (material)']),
+    'renew-processing-text' => t('Processing...', [], ['context' => 'Renew loan']),
+  ];
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-167

#### Description
Adds renewal feedback texts to apps.
It is a mess what belongs where with all the text props. This is an attempt to make sure that all the renewal response texts are being available for the corresponding apps.


#### Additional comments or questions

Things to remmeber for myself:
* Switch back dpl-react dep to develop
* Make sure this has been approved before merge of this PR: https://reload.atlassian.net/browse/DDFSOEG-553