### PR TITLE
Show login status in page title

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,8 @@ parameters:
     # Drupal Form API makes extensive use for arrays which we cannot provide
     # more detailed typing of.
     - '#.*\:\:(buildForm|getEditableConfigNames|submitForm|validateForm)\(\) .* no value type specified in iterable type array\.#'
+    # Drupal preprocess functions uses variables array which we cannot provide more detailed typing of.
+    - '#Function .*_preprocess_.*\(\) has parameter \$variables with no value type specified in iterable type array\.#'
     # Drupal has many different iterable interfaces we do not want to provide
     # iterable typing for.
     - '#no value type specified in iterable type Drupal\\.*Interface#'

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -101,3 +101,12 @@ function _dpl_login_user_has_been_processed(array $openid_connect_context): bool
 function dpl_login_dpl_react_apps_data(array &$data): void {
   $data['urls'] += ["logout" => Url::fromRoute('dpl_login.logout', [], ['absolute' => TRUE])->toString()];
 }
+
+/**
+ * Implements hook_preprocess_html().
+ */
+function dpl_login_preprocess_html(array &$variables): void {
+  if (\Drupal::currentUser()->isAuthenticated()) {
+    $variables['head_title'][] = t('Logged in', [], ['context' => 'dpl_login']);
+  }
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-86

#### Description

Add "Logged in" suffix in the HTML head title when users are logged in.

This applies for all users - both patrons and library staff.

This assumes that patrons will be logged in as both Drupal users and
with Adgangsplatformen tokens as is currently the case.

Update our PHPStan setup to not complain about typing for preprocess variable arrays.

#### Screenshot of the result

<img width="1392" alt="Monosnap admin | DPL CMS | Logged in 2023-10-12 10-03-22" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/385cc1ff-7c3a-4cb3-8008-ff70802b9956">