### PR TITLE
Fix permissions for translation workflows

### DIFF
--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     # Validate the format of the tag. We only want to react on a precise pattern.

--- a/.github/workflows/translate-source.yml
+++ b/.github/workflows/translate-source.yml
@@ -19,7 +19,7 @@ jobs:
       # added or changed files to the repository.
       contents: write
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.AUTOCOMMIT_GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
       # Pages.
       contents: write
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Publish translations to GitHub Pages

--- a/.github/workflows/translate-source.yml
+++ b/.github/workflows/translate-source.yml
@@ -51,8 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.head_commit.message, 'POEditor.com') }}
     permissions:
-      # Give the default GITHUB_TOKEN permission to update GitHub Pages.
-      pages: write
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository which also contain GitHub
+      # Pages.
+      contents: write
     steps:
     - uses: actions/checkout@master
       with:


### PR DESCRIPTION
#### Description

Publishing to GitHub Pages using with peaceiris/actions-gh-pages requires general permission to commit to git - not specifically for Pages.

See https://github.com/peaceiris/actions-gh-pages#user-content-%EF%B8%8F-first-deployment-with-github_token

The current setup causes GitHub Actions to fail.

#### Screenshot of the result

![dpl-cms@a1d1e6b 2023-10-19 14-35-00](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/7fe0ea39-1355-4917-a6d7-2de7f67fb4d3)

See example of failing action with the current setup.