### PR TITLE
Exclude all Drupal packages from Dependabot Composer packages group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
           - "minor"
           - "patch"
         exclude-patterns:
-          - "drupal/core*"
+          - "drupal/*"
       drupal-core-minor-major-releases:
         patterns:
           - "drupal/core*"


### PR DESCRIPTION
#### Description

With this update with now both exclude both Drupal Core and Contrib. It was not excluded before as shown in #422 

Experience shows that it is not a good idea to do automatic updates of contrib when we do not have sufficient test coverage.