### PR TITLE
Defaults in dpl-react configuration (review but do not merge, DDF needs it for testing)

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -72,7 +72,7 @@ environments:
       schedule: "M/30 * * * *"
       command: drush locale-check && drush locale-update
       service: cli
-  pr-413:
+  pr-436:
     cronjobs:
     - name: drush cron
       schedule: "M/15 * * * *"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
             "type": "package",
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-react",
-                "version": "0.3.0-rc42",
+                "version": "0.3.0-rc43",
                 "type": "drupal-library",
                 "dist": {
                     "url": "https://github.com/reload/dpl-react/releases/download/release-DDFLSBP-246-vi-skal-sorge-for-at-vi-har-defaults-pa-al-configuration-af-dpl-react-apps/dist.zip",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
                 "version": "0.3.0-rc42",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-develop/dist.zip",
+                    "url": "https://github.com/reload/dpl-react/releases/download/release-DDFLSBP-246-vi-skal-sorge-for-at-vi-har-defaults-pa-al-configuration-af-dpl-react-apps/dist.zip",
                     "type": "zip"
                 },
                 "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "296da9d08b56fde911c90ffd77cd8258",
+    "content-hash": "d43960d811720f942dd4fa26fa6ed3c8",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1015,7 +1015,7 @@
             "version": "0.3.0-rc42",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/release-develop/dist.zip"
+                "url": "https://github.com/reload/dpl-react/releases/download/release-DDFLSBP-246-vi-skal-sorge-for-at-vi-har-defaults-pa-al-configuration-af-dpl-react-apps/dist.zip"
             },
             "require": {
                 "composer/installers": "^1.2.0"
@@ -13449,8 +13449,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "danskernesdigitalebibliotek/dpl-design-system": 5,
-        "danskernesdigitalebibliotek/dpl-react": 5,
         "drupal/customerror": 10,
         "drupal/default_content": 15,
         "drupal/inline_all_css": 5,
@@ -13462,5 +13460,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d43960d811720f942dd4fa26fa6ed3c8",
+    "content-hash": "0acbfeb565ec6fb5ce0d3974dc1d95d1",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1012,7 +1012,7 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-react",
-            "version": "0.3.0-rc42",
+            "version": "0.3.0-rc43",
             "dist": {
                 "type": "zip",
                 "url": "https://github.com/reload/dpl-react/releases/download/release-DDFLSBP-246-vi-skal-sorge-for-at-vi-har-defaults-pa-al-configuration-af-dpl-react-apps/dist.zip"

--- a/web/modules/custom/dpl_dashboard/dpl_dashboard.info.yml
+++ b/web/modules/custom/dpl_dashboard/dpl_dashboard.info.yml
@@ -5,5 +5,8 @@ dependencies:
   - drupal:block
   - dpl_fbs:dpl_fbs
   - dpl_publizon:dpl_publizon
+  - dpl_library_agency:dpl_library_agency
+  - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_dashboard/src/DplDashboardSettings.php
+++ b/web/modules/custom/dpl_dashboard/src/DplDashboardSettings.php
@@ -9,6 +9,9 @@ use Drupal\dpl_react\DplReactConfigBase;
  */
 class DplDashboardSettings extends DplReactConfigBase {
 
+  const PAGE_SIZE_DESKTOP = 25;
+  const PAGE_SIZE_MOBILE = 25;
+
   /**
    * Gets the configuration key for dashboard settings.
    */

--- a/web/modules/custom/dpl_dashboard/src/Form/DashboardSettingsForm.php
+++ b/web/modules/custom/dpl_dashboard/src/Form/DashboardSettingsForm.php
@@ -5,6 +5,7 @@ namespace Drupal\dpl_dashboard\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\dpl_dashboard\DplDashboardSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -69,7 +70,7 @@ class DashboardSettingsForm extends ConfigFormBase {
     $form['settings']['page_size_mobile'] = [
       '#type' => 'number',
       '#title' => $this->t('Page size mobile', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('page_size_mobile') ?? 25,
+      '#default_value' => $config->get('page_size_mobile') ?? DplDashboardSettings::PAGE_SIZE_MOBILE,
       '#min' => 0,
       '#step' => 1,
     ];
@@ -77,7 +78,7 @@ class DashboardSettingsForm extends ConfigFormBase {
     $form['settings']['page_size_desktop'] = [
       '#type' => 'number',
       '#title' => $this->t('Page size desktop', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('page_size_desktop') ?? 25,
+      '#default_value' => $config->get('page_size_desktop') ?? DplDashboardSettings::PAGE_SIZE_DESKTOP,
       '#min' => 0,
       '#step' => 1,
     ];

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -93,7 +93,7 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
       // Urls.
       // Cannot find that route. Does it exist?
       'intermediate-url' => '/user/me/intermediates',
-      'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url') ?? GeneralSettingsForm::EREOLEN_MY_PAGE_URL,
+      'ereolen-my-page-url' => dpl_react_apps_format_app_url($generalSettings->get('ereolen_my_page_url'), GeneralSettingsForm::EREOLEN_MY_PAGE_URL),
 
       // Texts.
       'reservation-details-others-in-queue-text' => $this->t('Others are queueing for this material', [], ['context' => 'Dashboard']),

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -5,6 +5,9 @@ namespace Drupal\dpl_dashboard\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
+use Drupal\dpl_dashboard\DplDashboardSettings;
+use Drupal\dpl_library_agency\Form\GeneralSettingsForm;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -79,22 +82,18 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
 
     $data = [
       // Config.
-      'page-size-desktop' => $dashboardSettings->get('page_size_desktop'),
-      'page-size-mobile' => $dashboardSettings->get('page_size_mobile'),
-      'threshold-config' => $this->configFactory->get('dpl_library_agency.general_settings')->get('threshold_config'),
+      'page-size-desktop' => $dashboardSettings->get('page_size_desktop') ?? DplDashboardSettings::PAGE_SIZE_DESKTOP,
+      'page-size-mobile' => $dashboardSettings->get('page_size_mobile') ?? DplDashboardSettings::PAGE_SIZE_MOBILE,
+      'threshold-config' => $this->configFactory->get('dpl_library_agency.general_settings')->get('threshold_config') ?? GeneralSettingsForm::THRESHOLD_CONFIG,
       'interest-periods-config' => DplReactAppsController::getInterestPeriods(),
-      'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations_config'),
+      'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations_config') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG,
       'blacklisted-pickup-branches-config' => DplReactAppsController::buildBranchesListProp($this->branchSettings->getExcludedReservationBranches()),
       'branches-config' => DplReactAppsController::buildBranchesJsonProp($this->branchRepository->getBranches()),
 
       // Urls.
-      'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
-      'fees-page-url' => '/user/me/fees',
+      // Cannot find that route. Does it exist?
       'intermediate-url' => '/user/me/intermediates',
-      'reservations-url' => '/user/me/reservations',
-      'physical-loans-url' => '/user/me/loans',
-      'search-url' => DplReactAppsController::searchResultUrl(),
-      'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url'),
+      'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url') ?? GeneralSettingsForm::EREOLEN_MY_PAGE_URL,
 
       // Texts.
       'reservation-details-others-in-queue-text' => $this->t('Others are queueing for this material', [], ['context' => 'Dashboard']),

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -5,7 +5,6 @@ namespace Drupal\dpl_dashboard\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Url;
 use Drupal\dpl_dashboard\DplDashboardSettings;
 use Drupal\dpl_library_agency\Form\GeneralSettingsForm;
 use Drupal\dpl_react\DplReactConfigInterface;

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -12,6 +12,7 @@ use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\dpl_library_agency\Branch\BranchRepositoryInterface;
 use Drupal\dpl_library_agency\BranchSettings;
+use function Safe\json_encode as json_encode;
 
 /**
  * Provides user intermediate list.
@@ -78,6 +79,7 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
   public function build(): array {
     $dashboardSettings = $this->dashboardSettings->loadConfig();
     $generalSettings = $this->configFactory->get('dpl_library_agency.general_settings');
+    $allow_remove_ready_reservations = $generalSettings->get('reservation_detail_allow_remove_ready_reservations') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS;
 
     $data = [
       // Config.
@@ -88,6 +90,9 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
       'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS,
       'blacklisted-pickup-branches-config' => DplReactAppsController::buildBranchesListProp($this->branchSettings->getExcludedReservationBranches()),
       'branches-config' => DplReactAppsController::buildBranchesJsonProp($this->branchRepository->getBranches()),
+      'reservation-details-config' => json_encode([
+        'allowRemoveReadyReservations' => $allow_remove_ready_reservations,
+      ]),
 
       // Urls.
       // Cannot find that route. Does it exist?

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -86,7 +86,7 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
       'page-size-mobile' => $dashboardSettings->get('page_size_mobile') ?? DplDashboardSettings::PAGE_SIZE_MOBILE,
       'threshold-config' => $this->configFactory->get('dpl_library_agency.general_settings')->get('threshold_config') ?? GeneralSettingsForm::THRESHOLD_CONFIG,
       'interest-periods-config' => DplReactAppsController::getInterestPeriods(),
-      'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations_config') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG,
+      'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS,
       'blacklisted-pickup-branches-config' => DplReactAppsController::buildBranchesListProp($this->branchSettings->getExcludedReservationBranches()),
       'branches-config' => DplReactAppsController::buildBranchesJsonProp($this->branchRepository->getBranches()),
 

--- a/web/modules/custom/dpl_favorites_list/dpl_favorites_list.info.yml
+++ b/web/modules/custom/dpl_favorites_list/dpl_favorites_list.info.yml
@@ -6,5 +6,6 @@ dependencies:
   - dpl_fbs:dpl_fbs
   - dpl_publizon:dpl_publizon
   - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_favorites_list/src/DplFavoritesListSettings.php
+++ b/web/modules/custom/dpl_favorites_list/src/DplFavoritesListSettings.php
@@ -9,6 +9,9 @@ use Drupal\dpl_react\DplReactConfigBase;
  */
 class DplFavoritesListSettings extends DplReactConfigBase {
 
+  const PAGE_SIZE_DESKTOP = 25;
+  const PAGE_SIZE_MOBILE = 25;
+
   /**
    * Gets the configuration key for favorites list settings.
    */

--- a/web/modules/custom/dpl_favorites_list/src/Form/FavoritesListSettingsForm.php
+++ b/web/modules/custom/dpl_favorites_list/src/Form/FavoritesListSettingsForm.php
@@ -5,6 +5,7 @@ namespace Drupal\dpl_favorites_list\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\dpl_favorites_list\DplFavoritesListSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -69,7 +70,7 @@ class FavoritesListSettingsForm extends ConfigFormBase {
     $form['settings']['page_size_mobile'] = [
       '#type' => 'number',
       '#title' => $this->t('Page size mobile'),
-      '#default_value' => $config->get('page_size_mobile') ?? 25,
+      '#default_value' => $config->get('page_size_mobile') ?? DplFavoritesListSettings::PAGE_SIZE_MOBILE,
       '#min' => 1,
       '#step' => 1,
     ];
@@ -77,7 +78,7 @@ class FavoritesListSettingsForm extends ConfigFormBase {
     $form['settings']['page_size_desktop'] = [
       '#type' => 'number',
       '#title' => $this->t('Page size desktop'),
-      '#default_value' => $config->get('page_size_desktop') ?? 25,
+      '#default_value' => $config->get('page_size_desktop') ?? DplFavoritesListSettings::PAGE_SIZE_DESKTOP,
       '#min' => 1,
       '#step' => 1,
     ];

--- a/web/modules/custom/dpl_favorites_list/src/Plugin/Block/FavoritesListBlock.php
+++ b/web/modules/custom/dpl_favorites_list/src/Plugin/Block/FavoritesListBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\dpl_favorites_list\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\dpl_favorites_list\DplFavoritesListSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -79,8 +80,8 @@ class FavoritesListBlock extends BlockBase implements ContainerFactoryPluginInte
       'branches-config' => DplReactAppsController::buildBranchesJsonProp($this->branchRepository->getBranches()),
 
       // Page size.
-      "page-size-desktop" => $favoritesListSettings->get('page_size_desktop'),
-      "page-size-mobile" => $favoritesListSettings->get('page_size_mobile'),
+      "page-size-desktop" => $favoritesListSettings->get('page_size_desktop') ?? DplFavoritesListSettings::PAGE_SIZE_DESKTOP,
+      "page-size-mobile" => $favoritesListSettings->get('page_size_mobile') ?? DplFavoritesListSettings::PAGE_SIZE_MOBILE,
 
       // Texts.
       "by-author-text" => $this->t("By", [], ['context' => 'Favorites list']),

--- a/web/modules/custom/dpl_favorites_list_material_component/dpl_favorites_list_material_component.info.yml
+++ b/web/modules/custom/dpl_favorites_list_material_component/dpl_favorites_list_material_component.info.yml
@@ -4,5 +4,6 @@ package: DPL
 dependencies:
   - drupal:block
   - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_favorites_list_material_component/src/Plugin/Block/FavoritesListMaterialComponentBlock.php
+++ b/web/modules/custom/dpl_favorites_list_material_component/src/Plugin/Block/FavoritesListMaterialComponentBlock.php
@@ -74,7 +74,6 @@ class FavoritesListMaterialComponentBlock extends BlockBase implements Container
   public function build() {
     $data = [
       // Urls.
-      'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
       'favorites-list-material-component-go-to-list-url' => Url::fromRoute('dpl_favorites_list.list', [], ['absolute' => TRUE])->toString(),
 
       // Texts.

--- a/web/modules/custom/dpl_fees/dpl_fees.info.yml
+++ b/web/modules/custom/dpl_fees/dpl_fees.info.yml
@@ -6,6 +6,7 @@ dependencies:
   - dpl_fbs:dpl_fbs
   - dpl_publizon:dpl_publizon
   - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps
   - dpl_library_agency:dpl_library_agency
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_fees/dpl_fees.module
+++ b/web/modules/custom/dpl_fees/dpl_fees.module
@@ -8,14 +8,13 @@
  */
 
 use Drupal\Core\Url;
-use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 
 /**
  * Implements hook_dpl_react_apps_data().
  */
 function dpl_fees_dpl_react_apps_data(array &$data): void {
   $data['urls'] += [
-    'fee-page' => DplReactAppsController::ensureUrlIsString(
+    'fee-page' => dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('dpl_fees.list', [], ['absolute' => TRUE])->toString()
     ),
   ];

--- a/web/modules/custom/dpl_fees/dpl_fees.module
+++ b/web/modules/custom/dpl_fees/dpl_fees.module
@@ -6,3 +6,17 @@
  *
  * Renders the fees list.
  */
+
+use Drupal\Core\Url;
+use Drupal\dpl_react_apps\Controller\DplReactAppsController;
+
+/**
+ * Implements hook_dpl_react_apps_data().
+ */
+function dpl_fees_dpl_react_apps_data(array &$data): void {
+  $data['urls'] += [
+    'fee-page' => DplReactAppsController::ensureUrlIsString(
+      Url::fromRoute('dpl_fees.list', [], ['absolute' => TRUE])->toString()
+    ),
+  ];
+}

--- a/web/modules/custom/dpl_fees/src/DplFeesSettings.php
+++ b/web/modules/custom/dpl_fees/src/DplFeesSettings.php
@@ -8,14 +8,14 @@ use Drupal\dpl_react\DplReactConfigBase;
  * Class that handles instant loan settings.
  */
 class DplFeesSettings extends DplReactConfigBase {
-  const FEE_AND_REPLACEMENT_COSTS_URL = '<front>';
+  const FEES_AND_REPLACEMENT_COSTS_URL = '';
   const TERMS_OF_TRADE_TEXT = '';
-  const TERMS_OF_TRADE_URL = '<front>';
-  const PAYMENT_OVERVIEW_URL = '<front>';
+  const TERMS_OF_TRADE_URL = '';
+  const PAYMENT_OVERVIEW_URL = '';
   const FEE_LIST_BODY_TEXT = '';
   const PAGE_SIZE_DESKTOP = 25;
   const PAGE_SIZE_MOBILE = 25;
-  const AVAILABLE_PAYMENT_TYPES_URL = '<front>';
+  const AVAILABLE_PAYMENT_TYPES_URL = '';
 
   /**
    * Gets the configuration key for the instant loan settings.

--- a/web/modules/custom/dpl_fees/src/DplFeesSettings.php
+++ b/web/modules/custom/dpl_fees/src/DplFeesSettings.php
@@ -8,6 +8,14 @@ use Drupal\dpl_react\DplReactConfigBase;
  * Class that handles instant loan settings.
  */
 class DplFeesSettings extends DplReactConfigBase {
+  const FEE_AND_REPLACEMENT_COSTS_URL = '<front>';
+  const TERMS_OF_TRADE_TEXT = '';
+  const TERMS_OF_TRADE_URL = '<front>';
+  const PAYMENT_OVERVIEW_URL = '<front>';
+  const FEE_LIST_BODY_TEXT = '';
+  const PAGE_SIZE_DESKTOP = 25;
+  const PAGE_SIZE_MOBILE = 25;
+  const AVAILABLE_PAYMENT_TYPES_URL = '<front>';
 
   /**
    * Gets the configuration key for the instant loan settings.

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -5,6 +5,7 @@ namespace Drupal\dpl_fees\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\dpl_fees\DplFeesSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -70,32 +71,32 @@ class FeesListSettingsForm extends ConfigFormBase {
       '#type' => 'url',
       '#title' => $this->t('Fees and Replacement costs URL'),
       '#description' => $this->t('File or URL containing the fees and replacement costs'),
-      '#default_value' => $config->get('fees_and_replacement_costs_url') ?? '',
+      '#default_value' => $config->get('fees_and_replacement_costs_url') ?? DplFeesSettings::FEES_AND_REPLACEMENT_COSTS_URL,
     ];
 
     $form['settings']['available_payment_types_url'] = [
       '#type' => 'url',
       '#title' => $this->t('Available payment types url'),
-      '#default_value' => $config->get('available_payment_types_url') ?? '',
+      '#default_value' => $config->get('available_payment_types_url') ?? DplFeesSettings::AVAILABLE_PAYMENT_TYPES_URL,
     ];
 
     $form['settings']['terms_of_trade_text'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Terms of trade text'),
       '#description' => $this->t('Terms of trade text'),
-      '#default_value' => $config->get('terms_of_trade_text') ?? '',
+      '#default_value' => $config->get('terms_of_trade_text') ?? DplFeesSettings::TERMS_OF_TRADE_TEXT,
     ];
 
     $form['settings']['terms_of_trade_url'] = [
       '#type' => 'url',
       '#title' => $this->t('Terms of trade redirect url'),
-      '#default_value' => $config->get('terms_of_trade_url') ?? '',
+      '#default_value' => $config->get('terms_of_trade_url') ?? DplFeesSettings::TERMS_OF_TRADE_URL,
     ];
 
     $form['settings']['page_size_mobile'] = [
       '#type' => 'number',
       '#title' => $this->t('Page size mobile', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('page_size_mobile') ?? 25,
+      '#default_value' => $config->get('page_size_mobile') ?? DplFeesSettings::PAGE_SIZE_MOBILE,
       '#min' => 0,
       '#step' => 1,
     ];
@@ -103,7 +104,7 @@ class FeesListSettingsForm extends ConfigFormBase {
     $form['settings']['page_size_desktop'] = [
       '#type' => 'number',
       '#title' => $this->t('Page size desktop', [], ['context' => 'Dashboard (settings)']),
-      '#default_value' => $config->get('page_size_desktop') ?? 25,
+      '#default_value' => $config->get('page_size_desktop') ?? DplFeesSettings::PAGE_SIZE_DESKTOP,
       '#min' => 0,
       '#step' => 1,
     ];
@@ -119,7 +120,7 @@ class FeesListSettingsForm extends ConfigFormBase {
     $form['settings']['payment_overview_url'] = [
       '#type' => 'url',
       '#title' => $this->t('Payment overview url'),
-      '#default_value' => $config->get('payment_overview_url') ?? '',
+      '#default_value' => $config->get('payment_overview_url') ?? DplFeesSettings::PAYMENT_OVERVIEW_URL,
     ];
 
     $form['settings']['fee_list_body_text'] = [

--- a/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
+++ b/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\dpl_fees\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\dpl_fees\DplFeesSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -63,8 +64,8 @@ class FeesListBlock extends BlockBase implements ContainerFactoryPluginInterface
 
     $data = [
       // Config.
-      "page-size-desktop" => $feesConfig->get('page_size_desktop'),
-      "page-size-mobile" => $feesConfig->get('page_size_mobile'),
+      "page-size-desktop" => $feesConfig->get('page_size_desktop') ?? DplFeesSettings::PAGE_SIZE_DESKTOP,
+      "page-size-mobile" => $feesConfig->get('page_size_mobile') ?? DplFeesSettings::PAGE_SIZE_MOBILE,
 
       // Urls.
       // @todo images to be done in future tender.

--- a/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
+++ b/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
@@ -69,7 +69,6 @@ class FeesListBlock extends BlockBase implements ContainerFactoryPluginInterface
       // Urls.
       // @todo images to be done in future tender.
       'available-payment-types-url' => $feesConfig->get('available_payment_types_url'),
-      'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
       'search-url' => DplReactAppsController::searchResultUrl(),
 
       // Texts.

--- a/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
+++ b/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
@@ -69,7 +69,7 @@ class FeesListBlock extends BlockBase implements ContainerFactoryPluginInterface
 
       // Urls.
       // @todo images to be done in future tender.
-      'available-payment-types-url' => $feesConfig->get('available_payment_types_url'),
+      'available-payment-types-url' => dpl_react_apps_format_app_url($feesConfig->get('available_payment_types_url'), DplFeesSettings::AVAILABLE_PAYMENT_TYPES_URL),
 
       // Texts.
       'already-paid-text' => $this->t("Please note that paid fees are not registered up until 72 hours after your payment after which your debt is updated and your user unblocked if it has been blocked.", [], ['context' => 'Fees list']),
@@ -78,7 +78,7 @@ class FeesListBlock extends BlockBase implements ContainerFactoryPluginInterface
       'fee-details-modal-close-modal-aria-label-text' => $this->t("Close fee details modal", [], ['context' => 'Fees list (Aria)']),
       'fee-details-modal-description-text' => $this->t("Modal containing information about this element or group of elements fees", [], ['context' => 'Fees list']),
       'fee-details-modal-screen-reader-text' => $this->t("A modal containing details about a fee", [], ['context' => 'Fees list']),
-      'fee-list-body-text' => $feesConfig->get('fee_list_body_text'),
+      'fee-list-body-text' => $feesConfig->get('fee_list_body_text') ?? DplFeesSettings::FEE_LIST_BODY_TEXT,
       'fee-list-days-text' => $this->t("Days", [], ['context' => 'Fees list']),
       'fee-list-headline-text' => $this->t("Fees & replacement costs", [], ['context' => 'Fees list']),
       'fee-payment-modal-body-text' => $this->t("You will be redirected to Mit Betalingsoverblik.", [], ['context' => 'Fees list']),
@@ -92,19 +92,19 @@ class FeesListBlock extends BlockBase implements ContainerFactoryPluginInterface
       'material-by-author-text' => $this->t("By", [], ['context' => 'Fees list']),
       'other-materials-text' => $this->t("Other materials", [], ['context' => 'Fees list']),
       'pay-text' => $this->t("Pay", [], ['context' => 'Fees list']),
-      'payment-overview-url' => $feesConfig->get('payment_overview_url'),
+      'payment-overview-url' => dpl_react_apps_format_app_url($feesConfig->get('payment_overview_url'), DplFeesSettings::PAYMENT_OVERVIEW_URL),
       'plus-x-other-materials-text' => $this->t("+ @amount other materials", [], ['context' => 'Fees list']),
       'post-payment-type-change-date-text' => $this->t("AFTER 27/10 2020", [], ['context' => 'Fees list']),
       'pre-payment-type-change-date-text' => $this->t("BEFORE 27/10 2020", [], ['context' => 'Fees list']),
-      'terms-of-trade-text' => $feesConfig->get('terms_of_trade_text'),
-      'terms-of-trade-url' => $feesConfig->get('terms_of_trade_url'),
+      'terms-of-trade-text' => $feesConfig->get('terms_of_trade_text') ?? DplFeesSettings::TERMS_OF_TRADE_TEXT,
+      'terms-of-trade-url' => dpl_react_apps_format_app_url($feesConfig->get('terms_of_trade_url'), DplFeesSettings::TERMS_OF_TRADE_URL),
       'total-fee-amount-text' => $this->t("Fee", [], ['context' => 'Fees list']),
       'total-text' => $this->t("Total", [], ['context' => 'Fees list']),
       'turned-in-text' => $this->t("Turned in @date", [], ['context' => 'Fees list']),
       'unpaid-fees-text' => $this->t("Unsettled debt", [], ['context' => 'Fees list']),
       'material-and-author-text' => $this->t('and', [], ['context' => 'Fees list']),
       'view-fees-and-compensation-rates-text' => $this->t("see our fees and replacement costs", [], ['context' => 'Fees list']),
-      'view-fees-and-compensation-rates-url' => $feesConfig->get('fees_and_replacement_costs_url'),
+      'view-fees-and-compensation-rates-url' => dpl_react_apps_format_app_url($feesConfig->get('fees_and_replacement_costs_url'), DplFeesSettings::FEES_AND_REPLACEMENT_COSTS_URL),
     ] + DplReactAppsController::externalApiBaseUrls();
 
     return [

--- a/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
+++ b/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
@@ -70,7 +70,6 @@ class FeesListBlock extends BlockBase implements ContainerFactoryPluginInterface
       // Urls.
       // @todo images to be done in future tender.
       'available-payment-types-url' => $feesConfig->get('available_payment_types_url'),
-      'search-url' => DplReactAppsController::searchResultUrl(),
 
       // Texts.
       'already-paid-text' => $this->t("Please note that paid fees are not registered up until 72 hours after your payment after which your debt is updated and your user unblocked if it has been blocked.", [], ['context' => 'Fees list']),

--- a/web/modules/custom/dpl_library_agency/src/BranchSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/BranchSettings.php
@@ -10,6 +10,9 @@ use Drupal\Core\Config\ConfigManagerInterface;
  * Object for managing branch related settings.
  */
 class BranchSettings implements CacheableDependencyInterface {
+  public const EXCLUDED_RESERVATION_BRANCHES = [];
+  public const EXCLUDED_SEARCH_BRANCHES = [];
+  public const EXCLUDED_AVAILABILITY_BRANCHES = [];
 
   /**
    * The name of the configuration entry containing the settings.
@@ -63,7 +66,7 @@ class BranchSettings implements CacheableDependencyInterface {
    *   The ids of the excluded branches.
    */
   public function getExcludedReservationBranches() : array {
-    return $this->getBranchConfig()->get(self::RESERVATION_KEY) ?? [];
+    return $this->getBranchConfig()->get(self::RESERVATION_KEY) ?? self::EXCLUDED_RESERVATION_BRANCHES;
   }
 
   /**
@@ -83,7 +86,7 @@ class BranchSettings implements CacheableDependencyInterface {
    *   The ids of the excluded branches.
    */
   public function getExcludedSearchBranches(): array {
-    return $this->getBranchConfig()->get(self::SEARCH_KEY) ?? [];
+    return $this->getBranchConfig()->get(self::SEARCH_KEY) ?? self::EXCLUDED_SEARCH_BRANCHES;
   }
 
   /**
@@ -103,7 +106,7 @@ class BranchSettings implements CacheableDependencyInterface {
    *   The ids of the excluded branches.
    */
   public function getExcludedAvailabilityBranches(): array {
-    return $this->getBranchConfig()->get(self::AVAILABILITY_KEY) ?? [];
+    return $this->getBranchConfig()->get(self::AVAILABILITY_KEY) ?? self::EXCLUDED_AVAILABILITY_BRANCHES;
   }
 
   /**

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -19,6 +19,16 @@ use function Safe\usort as usort;
  * General Settings form for a library agency.
  */
 class GeneralSettingsForm extends ConfigFormBase {
+  // @todo These constants should be defined in a general settings class like we do it in eg dpl_dashboard.
+  const THRESHOLD_CONFIG = '';
+  const RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG = FALSE;
+  const INTEREST_PERIODS_CONFIG = '';
+  const RESERVATION_SMS_NOTIFICATIONS_DISABLED = FALSE;
+  const PAUSE_RESERVATION_INFO_URL = '<front>';
+  const REDIRECT_ON_BLOCKED_URL = '<front>';
+  const BLOCKED_PATRON_E_LINK_URL = '<front>';
+  const EREOLEN_MY_PAGE_URL = '<front>';
+  const PAUSE_RESERVATION_START_DATE_CONFIG = '';
 
   /**
    * GeneralSettingsForm constructor.
@@ -133,20 +143,20 @@ class GeneralSettingsForm extends ConfigFormBase {
     $form['reservations']['reservation_sms_notifications_disabled'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Disable SMS notifications for reservations', [], ['context' => 'Library Agency Configuration']),
-      '#default_value' => $config->get('reservation_sms_notifications_disabled'),
+      '#default_value' => $config->get('reservation_sms_notifications_disabled') ?? self::RESERVATION_SMS_NOTIFICATIONS_DISABLED,
       '#description' => $this->t('If checked, SMS notifications for patrons will be disabled.', [], ['context' => 'Library Agency Configuration']),
     ];
 
     $form['reservations']['interest_periods_config'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Interest periods for reservation', [], ['context' => 'Library Agency Configuration']),
-      '#default_value' => $config->get('interest_periods_config'),
+      '#default_value' => $config->get('interest_periods_config') ?? self::INTEREST_PERIODS_CONFIG,
     ];
 
     $form['reservations']['reservation_detail_allow_remove_ready_reservations_config'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Allow removing ready reservations', [], ['context' => 'Library Agency Configuration']),
-      '#default_value' => $config->get('reservation_detail_allow_remove_ready_reservations_config'),
+      '#default_value' => $config->get('reservation_detail_allow_remove_ready_reservations_config') ?? self::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG,
     ];
 
     $form['reservations']['ereolen_my_page_url'] = [
@@ -160,14 +170,14 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#type' => 'url',
       '#title' => $this->t('Pause reservation link', [], ['context' => 'Library Agency Configuration']),
       '#description' => $this->t('The link with infomation about reservations', [], ['context' => 'Library Agency Configuration']),
-      '#default_value' => $config->get('pause_reservation_info_url') ?? '',
+      '#default_value' => $config->get('pause_reservation_info_url') ?? self::PAUSE_RESERVATION_INFO_URL,
     ];
 
     $form['reservations']['pause_reservation_start_date_config'] = [
       '#type' => 'date',
       '#title' => $this->t('Start date', [], ['context' => 'Library Agency Configuration']),
       '#description' => $this->t('Pause reservation start date', [], ['context' => 'Library Agency Configuration']),
-      '#default_value' => $config->get('pause_reservation_start_date_config'),
+      '#default_value' => $config->get('pause_reservation_start_date_config') ?? self::PAUSE_RESERVATION_START_DATE_CONFIG,
     ];
 
     $form['settings']['blocked_user'] = [
@@ -181,14 +191,14 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#type' => 'url',
       '#title' => $this->t('Redirect blocked user link'),
       '#description' => $this->t('The link to redirect the blocked user to'),
-      '#default_value' => $config->get('redirect_on_blocked_url') ?? '',
+      '#default_value' => $config->get('redirect_on_blocked_url') ?? self::REDIRECT_ON_BLOCKED_URL,
     ];
 
     $form['settings']['blocked_user']['blocked_patron_e_link_url'] = [
       '#type' => 'url',
       '#title' => $this->t('Blocked user link for modal'),
       '#description' => $this->t('If a user has blocked status e, this link appears in the modal'),
-      '#default_value' => $config->get('blocked_patron_e_link_url') ?? '',
+      '#default_value' => $config->get('blocked_patron_e_link_url') ?? self::BLOCKED_PATRON_E_LINK_URL,
     ];
 
     $form['thresholds'] = [
@@ -201,7 +211,7 @@ class GeneralSettingsForm extends ConfigFormBase {
     $form['thresholds']['threshold_config'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Set thresholds', [], ['context' => 'Library Agency Configuration']),
-      '#default_value' => $config->get('threshold_config'),
+      '#default_value' => $config->get('threshold_config') ?? self::THRESHOLD_CONFIG,
     ];
 
     $form['branches'] = [

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -23,7 +23,7 @@ class GeneralSettingsForm extends ConfigFormBase {
   const THRESHOLD_CONFIG = "{ 'colorThresholds': { 'danger': '0', 'warning': '6' } }";
   const RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG = FALSE;
   const INTEREST_PERIODS_CONFIG = '';
-  const RESERVATION_SMS_NOTIFICATIONS_DISABLED = FALSE;
+  const RESERVATION_SMS_NOTIFICATIONS_ENABLED = TRUE;
   const PAUSE_RESERVATION_INFO_URL = '';
   const REDIRECT_ON_BLOCKED_URL = '';
   const BLOCKED_PATRON_E_LINK_URL = '';
@@ -140,11 +140,11 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#collapsed' => FALSE,
     ];
 
-    $form['reservations']['reservation_sms_notifications_disabled'] = [
+    $form['reservations']['reservation_sms_notifications_enabled'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Disable SMS notifications for reservations', [], ['context' => 'Library Agency Configuration']),
-      '#default_value' => $config->get('reservation_sms_notifications_disabled') ?? self::RESERVATION_SMS_NOTIFICATIONS_DISABLED,
-      '#description' => $this->t('If checked, SMS notifications for patrons will be disabled.', [], ['context' => 'Library Agency Configuration']),
+      '#title' => $this->t('Enable SMS notifications for reservations', [], ['context' => 'Library Agency Configuration']),
+      '#default_value' => $config->get('reservation_sms_notifications_enabled') ?? self::RESERVATION_SMS_NOTIFICATIONS_ENABLED,
+      '#description' => $this->t('If checked, SMS notifications for patrons are enabled.', [], ['context' => 'Library Agency Configuration']),
     ];
 
     $form['reservations']['interest_periods_config'] = [
@@ -266,7 +266,7 @@ class GeneralSettingsForm extends ConfigFormBase {
       ->set('threshold_config', $form_state->getValue('threshold_config'))
       ->set('reservation_detail_allow_remove_ready_reservations_config', $form_state->getValue('reservation_detail_allow_remove_ready_reservations_config'))
       ->set('interest_periods_config', $form_state->getValue('interest_periods_config'))
-      ->set('reservation_sms_notifications_disabled', $form_state->getValue('reservation_sms_notifications_disabled'))
+      ->set('reservation_sms_notifications_enabled', $form_state->getValue('reservation_sms_notifications_enabled'))
       ->set('pause_reservation_info_url', $form_state->getValue('pause_reservation_info_url'))
       ->set('redirect_on_blocked_url', $form_state->getValue('redirect_on_blocked_url'))
       ->set('blocked_patron_e_link_url', $form_state->getValue('blocked_patron_e_link_url'))

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -20,7 +20,7 @@ use function Safe\usort as usort;
  */
 class GeneralSettingsForm extends ConfigFormBase {
   // @todo These constants should be defined in a general settings class like we do it in eg dpl_dashboard.
-  const THRESHOLD_CONFIG = '';
+  const THRESHOLD_CONFIG = "{ 'colorThresholds': { 'danger': '0', 'warning': '6' } }";
   const RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG = FALSE;
   const INTEREST_PERIODS_CONFIG = '';
   const RESERVATION_SMS_NOTIFICATIONS_DISABLED = FALSE;

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -24,10 +24,10 @@ class GeneralSettingsForm extends ConfigFormBase {
   const RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG = FALSE;
   const INTEREST_PERIODS_CONFIG = '';
   const RESERVATION_SMS_NOTIFICATIONS_DISABLED = FALSE;
-  const PAUSE_RESERVATION_INFO_URL = '<front>';
-  const REDIRECT_ON_BLOCKED_URL = '<front>';
-  const BLOCKED_PATRON_E_LINK_URL = '<front>';
-  const EREOLEN_MY_PAGE_URL = '<front>';
+  const PAUSE_RESERVATION_INFO_URL = '';
+  const REDIRECT_ON_BLOCKED_URL = '';
+  const BLOCKED_PATRON_E_LINK_URL = '';
+  const EREOLEN_MY_PAGE_URL = '';
   const PAUSE_RESERVATION_START_DATE_CONFIG = '';
 
   /**

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -21,7 +21,7 @@ use function Safe\usort as usort;
 class GeneralSettingsForm extends ConfigFormBase {
   // @todo These constants should be defined in a general settings class like we do it in eg dpl_dashboard.
   const THRESHOLD_CONFIG = "{ 'colorThresholds': { 'danger': '0', 'warning': '6' } }";
-  const RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG = FALSE;
+  const RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS = FALSE;
   const INTEREST_PERIODS_CONFIG = '';
   const RESERVATION_SMS_NOTIFICATIONS_ENABLED = TRUE;
   const PAUSE_RESERVATION_INFO_URL = '';
@@ -153,10 +153,10 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('interest_periods_config') ?? self::INTEREST_PERIODS_CONFIG,
     ];
 
-    $form['reservations']['reservation_detail_allow_remove_ready_reservations_config'] = [
+    $form['reservations']['reservation_detail_allow_remove_ready_reservations'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Allow removing ready reservations', [], ['context' => 'Library Agency Configuration']),
-      '#default_value' => $config->get('reservation_detail_allow_remove_ready_reservations_config') ?? self::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG,
+      '#default_value' => $config->get('reservation_detail_allow_remove_ready_reservations') ?? self::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS,
     ];
 
     $form['reservations']['ereolen_my_page_url'] = [
@@ -264,7 +264,7 @@ class GeneralSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->config('dpl_library_agency.general_settings')
       ->set('threshold_config', $form_state->getValue('threshold_config'))
-      ->set('reservation_detail_allow_remove_ready_reservations_config', $form_state->getValue('reservation_detail_allow_remove_ready_reservations_config'))
+      ->set('reservation_detail_allow_remove_ready_reservations', $form_state->getValue('reservation_detail_allow_remove_ready_reservations'))
       ->set('interest_periods_config', $form_state->getValue('interest_periods_config'))
       ->set('reservation_sms_notifications_enabled', $form_state->getValue('reservation_sms_notifications_enabled'))
       ->set('pause_reservation_info_url', $form_state->getValue('pause_reservation_info_url'))

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -126,13 +126,6 @@ class GeneralSettingsForm extends ConfigFormBase {
       $disabled = TRUE;
     }
 
-    $form['fee_page'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t('Fee page', [], ['context' => 'Library Agency Configuration']),
-      '#collapsible' => FALSE,
-      '#collapsed' => FALSE,
-    ];
-
     $form['reservations'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Reservations', [], ['context' => 'Library Agency Configuration']),

--- a/web/modules/custom/dpl_library_agency/src/ReservationSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/ReservationSettings.php
@@ -11,6 +11,8 @@ use Drupal\Core\Config\ConfigManagerInterface;
  */
 class ReservationSettings implements CacheableDependencyInterface {
 
+  const RESERVATION_SMS_NOTIFICATIONS_DISABLED = FALSE;
+
   /**
    * Constructs a new ReservationSettings object.
    */
@@ -33,7 +35,7 @@ class ReservationSettings implements CacheableDependencyInterface {
    */
   public function smsNotificationsIsEnabled(): bool {
     $config = $this->getConfig();
-    return ($config->get('reservation_sms_notifications_disabled')) ? FALSE : TRUE;
+    return $config->get('reservation_sms_notifications_disabled') ?? self::RESERVATION_SMS_NOTIFICATIONS_DISABLED;
   }
 
   /**

--- a/web/modules/custom/dpl_library_agency/src/ReservationSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/ReservationSettings.php
@@ -11,7 +11,7 @@ use Drupal\Core\Config\ConfigManagerInterface;
  */
 class ReservationSettings implements CacheableDependencyInterface {
 
-  const RESERVATION_SMS_NOTIFICATIONS_DISABLED = FALSE;
+  const RESERVATION_SMS_NOTIFICATIONS_ENABLED = TRUE;
 
   /**
    * Constructs a new ReservationSettings object.
@@ -35,7 +35,7 @@ class ReservationSettings implements CacheableDependencyInterface {
    */
   public function smsNotificationsIsEnabled(): bool {
     $config = $this->getConfig();
-    return $config->get('reservation_sms_notifications_disabled') ?? self::RESERVATION_SMS_NOTIFICATIONS_DISABLED;
+    return $config->get('reservation_sms_notifications_enabled') ?? self::RESERVATION_SMS_NOTIFICATIONS_ENABLED;
   }
 
   /**
@@ -46,7 +46,7 @@ class ReservationSettings implements CacheableDependencyInterface {
    */
   public function enableSmsNotifications(bool $enabled) : void {
     $this->getConfig()
-      ->set('reservation_sms_notifications_disabled', $enabled)
+      ->set('reservation_sms_notifications_enabled', $enabled)
       ->save();
   }
 

--- a/web/modules/custom/dpl_loans/dpl_loans.info.yml
+++ b/web/modules/custom/dpl_loans/dpl_loans.info.yml
@@ -6,5 +6,6 @@ dependencies:
   - dpl_fbs:dpl_fbs
   - dpl_publizon:dpl_publizon
   - dpl_react:dpl_react
+  - dpl_library_agency:dpl_library_agency
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_loans/dpl_loans.module
+++ b/web/modules/custom/dpl_loans/dpl_loans.module
@@ -6,3 +6,17 @@
  *
  * Renders the loan list.
  */
+
+use Drupal\Core\Url;
+use Drupal\dpl_react_apps\Controller\DplReactAppsController;
+
+/**
+ * Implements hook_dpl_react_apps_data().
+ */
+function dpl_loans_dpl_react_apps_data(array &$data): void {
+  $data['urls'] += [
+    'physical-loans' => DplReactAppsController::ensureUrlIsString(
+      Url::fromRoute('dpl_loans.list', [], ['absolute' => TRUE])->toString()
+    ),
+  ];
+}

--- a/web/modules/custom/dpl_loans/dpl_loans.module
+++ b/web/modules/custom/dpl_loans/dpl_loans.module
@@ -8,14 +8,13 @@
  */
 
 use Drupal\Core\Url;
-use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 
 /**
  * Implements hook_dpl_react_apps_data().
  */
 function dpl_loans_dpl_react_apps_data(array &$data): void {
   $data['urls'] += [
-    'physical-loans' => DplReactAppsController::ensureUrlIsString(
+    'physical-loans' => dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('dpl_loans.list', [], ['absolute' => TRUE])->toString()
     ),
   ];

--- a/web/modules/custom/dpl_loans/src/DplLoansSettings.php
+++ b/web/modules/custom/dpl_loans/src/DplLoansSettings.php
@@ -9,10 +9,9 @@ use Drupal\dpl_react\DplReactConfigBase;
  */
 class DplLoansSettings extends DplReactConfigBase {
 
-  const MATERIAL_OVERDUE_URL = '<front>';
+  const MATERIAL_OVERDUE_URL = '';
   const PAGE_SIZE_DESKTOP = 25;
   const PAGE_SIZE_MOBILE = 25;
-
 
   /**
    * Gets the configuration key for loans settings.

--- a/web/modules/custom/dpl_loans/src/DplLoansSettings.php
+++ b/web/modules/custom/dpl_loans/src/DplLoansSettings.php
@@ -9,6 +9,11 @@ use Drupal\dpl_react\DplReactConfigBase;
  */
 class DplLoansSettings extends DplReactConfigBase {
 
+  const MATERIAL_OVERDUE_URL = '<front>';
+  const PAGE_SIZE_DESKTOP = 25;
+  const PAGE_SIZE_MOBILE = 25;
+
+
   /**
    * Gets the configuration key for loans settings.
    */

--- a/web/modules/custom/dpl_loans/src/Form/LoanListSettingsForm.php
+++ b/web/modules/custom/dpl_loans/src/Form/LoanListSettingsForm.php
@@ -5,6 +5,7 @@ namespace Drupal\dpl_loans\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\dpl_loans\DplLoansSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -70,13 +71,13 @@ class LoanListSettingsForm extends ConfigFormBase {
       '#type' => 'url',
       '#title' => $this->t('Material overdue url', [], ['context' => 'Loan list (settings)']),
       '#description' => $this->t('The link to the material overdue page', [], ['context' => 'Loan list (settings)']),
-      '#default_value' => $config->get('material_overdue_url') ?? '',
+      '#default_value' => $config->get('material_overdue_url') ?? DplLoansSettings::MATERIAL_OVERDUE_URL,
     ];
 
     $form['settings']['page_size_mobile'] = [
       '#type' => 'number',
       '#title' => $this->t('Page size mobile', [], ['context' => 'Loan list (settings)']),
-      '#default_value' => $config->get('page_size_mobile') ?? 25,
+      '#default_value' => $config->get('page_size_mobile') ?? DplLoansSettings::PAGE_SIZE_MOBILE,
       '#min' => 0,
       '#step' => 1,
     ];
@@ -84,7 +85,7 @@ class LoanListSettingsForm extends ConfigFormBase {
     $form['settings']['page_size_desktop'] = [
       '#type' => 'number',
       '#title' => $this->t('Page size desktop', [], ['context' => 'Loan list (settings)']),
-      '#default_value' => $config->get('page_size_desktop') ?? 25,
+      '#default_value' => $config->get('page_size_desktop') ?? DplLoansSettings::PAGE_SIZE_DESKTOP,
       '#min' => 0,
       '#step' => 1,
     ];

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -5,6 +5,8 @@ namespace Drupal\dpl_loans\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\dpl_library_agency\Form\GeneralSettingsForm;
+use Drupal\dpl_loans\DplLoansSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -77,7 +79,7 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
    */
   public function getThresholdConfig(): string {
     $generalSettings = $this->configFactory->get('dpl_library_agency.general_settings');
-    return $generalSettings->get('threshold_config') ?? "{ 'colorThresholds': { 'danger': '0', 'warning': '6' } }";
+    return $generalSettings->get('threshold_config') ?? GeneralSettingsForm::THRESHOLD_CONFIG;
   }
 
   /**
@@ -92,16 +94,16 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
 
     $data = [
       // Page size.
-      "page-size-desktop" => $loanListSettings->get('page_size_desktop'),
-      "page-size-mobile" => $loanListSettings->get('page_size_mobile'),
+      "page-size-desktop" => $loanListSettings->get('page_size_desktop') ?? DplLoansSettings::PAGE_SIZE_DESKTOP,
+      "page-size-mobile" => $loanListSettings->get('page_size_mobile') ?? DplLoansSettings::PAGE_SIZE_MOBILE,
 
       // Config.
       "threshold-config" => $this->getThresholdConfig(),
 
       // Urls.
       'fees-page-url' => '/user/me/fees',
-      'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url'),
-      'material-overdue-url' => $loanListSettings->get('material_overdue_url'),
+      'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url') ?? GeneralSettingsForm::EREOLEN_MY_PAGE_URL,
+      'material-overdue-url' => $loanListSettings->get('material_overdue_url') ?? DplLoansSettings::MATERIAL_OVERDUE_URL,
 
       // Texts.
       'material-and-author-text' => $this->t('and', [], ['context' => 'Loan list']),

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -101,7 +101,6 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       "threshold-config" => $this->getThresholdConfig(),
 
       // Urls.
-      'fees-page-url' => '/user/me/fees',
       'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url') ?? GeneralSettingsForm::EREOLEN_MY_PAGE_URL,
       'material-overdue-url' => $loanListSettings->get('material_overdue_url') ?? DplLoansSettings::MATERIAL_OVERDUE_URL,
 

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -101,7 +101,6 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       // Urls.
       'fees-page-url' => '/user/me/fees',
       'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url'),
-      'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
       'material-overdue-url' => $loanListSettings->get('material_overdue_url'),
 
       // Texts.

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -101,8 +101,8 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       "threshold-config" => $this->getThresholdConfig(),
 
       // Urls.
-      'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url') ?? GeneralSettingsForm::EREOLEN_MY_PAGE_URL,
-      'material-overdue-url' => $loanListSettings->get('material_overdue_url') ?? DplLoansSettings::MATERIAL_OVERDUE_URL,
+      'ereolen-my-page-url' => dpl_react_apps_format_app_url($generalSettings->get('ereolen_my_page_url'), GeneralSettingsForm::EREOLEN_MY_PAGE_URL),
+      'material-overdue-url' => dpl_react_apps_format_app_url($loanListSettings->get('material_overdue_url'), DplLoansSettings::MATERIAL_OVERDUE_URL),
 
       // Texts.
       'material-and-author-text' => $this->t('and', [], ['context' => 'Loan list']),

--- a/web/modules/custom/dpl_login/dpl_login.info.yml
+++ b/web/modules/custom/dpl_login/dpl_login.info.yml
@@ -7,4 +7,3 @@ core_version_requirement: ^9
 
 dependencies:
   - openid_connect:openid_connect
-  - dpl_react_apps:dpl_react_apps

--- a/web/modules/custom/dpl_login/dpl_login.info.yml
+++ b/web/modules/custom/dpl_login/dpl_login.info.yml
@@ -7,3 +7,4 @@ core_version_requirement: ^9
 
 dependencies:
   - openid_connect:openid_connect
+  - dpl_react_apps:dpl_react_apps

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -12,7 +12,6 @@ use Drupal\dpl_login\AccessToken;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\dpl_login\DplLoginInterface;
-use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Drupal\user\UserInterface;
 use function Safe\sprintf as sprintf;
 
@@ -101,10 +100,10 @@ function _dpl_login_user_has_been_processed(array $openid_connect_context): bool
  */
 function dpl_login_dpl_react_apps_data(array &$data): void {
   $data['urls'] += [
-    "logout" => DplReactAppsController::ensureUrlIsString(
+    "logout" => dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('dpl_login.logout', [], ['absolute' => TRUE])->toString()
     ),
-    'auth' => DplReactAppsController::ensureUrlIsString(
+    'auth' => dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('dpl_login.login')->toString()
     ),
   ];

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -12,6 +12,7 @@ use Drupal\dpl_login\AccessToken;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\dpl_login\DplLoginInterface;
+use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Drupal\user\UserInterface;
 use function Safe\sprintf as sprintf;
 
@@ -99,5 +100,12 @@ function _dpl_login_user_has_been_processed(array $openid_connect_context): bool
  * Implements hook_dpl_react_apps_data().
  */
 function dpl_login_dpl_react_apps_data(array &$data): void {
-  $data['urls'] += ["logout" => Url::fromRoute('dpl_login.logout', [], ['absolute' => TRUE])->toString()];
+  $data['urls'] += [
+    "logout" => DplReactAppsController::ensureUrlIsString(
+      Url::fromRoute('dpl_login.logout', [], ['absolute' => TRUE])->toString()
+    ),
+    'auth' => DplReactAppsController::ensureUrlIsString(
+      Url::fromRoute('dpl_login.login')->toString()
+    ),
+  ];
 }

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -99,12 +99,9 @@ function _dpl_login_user_has_been_processed(array $openid_connect_context): bool
  * Implements hook_dpl_react_apps_data().
  */
 function dpl_login_dpl_react_apps_data(array &$data): void {
+  $openid_config = \Drupal::config('openid_connect.settings.adgangsplatformen');
+
   $data['urls'] += [
-    "logout" => dpl_react_apps_ensure_url_is_string(
-      Url::fromRoute('dpl_login.logout', [], ['absolute' => TRUE])->toString()
-    ),
-    'auth' => dpl_react_apps_ensure_url_is_string(
-      Url::fromRoute('dpl_login.login')->toString()
-    ),
+    'userinfo' => $openid_config->get('settings')['userinfo_endpoint'] ?? '/',
   ];
 }

--- a/web/modules/custom/dpl_patron_menu/dpl_patron_menu.info.yml
+++ b/web/modules/custom/dpl_patron_menu/dpl_patron_menu.info.yml
@@ -10,6 +10,7 @@ dependencies:
   - dpl_loans:dpl_loans
   - dpl_patron_reg:dpl_patron_reg
   - dpl_reservations:dpl_reservations
+  - dpl_react_apps:dpl_react_apps
 
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
+++ b/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
@@ -128,7 +128,7 @@ class PatronMenuBlock extends BlockBase implements ContainerFactoryPluginInterfa
       'branches-config' => DplReactAppsController::buildBranchesJsonProp($this->branchRepository->getBranches()),
       "threshold-config" => $this->configFactory->get('dpl_library_agency.general_settings')->get('threshold_config'),
       "menu-navigation-data-config" => json_encode($menu, JSON_THROW_ON_ERROR),
-      'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations_config'),
+      'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations'),
       'interest-periods-config' => DplReactAppsController::getInterestPeriods(),
 
       // Urls.

--- a/web/modules/custom/dpl_patron_page/dpl_patron_page.info.yml
+++ b/web/modules/custom/dpl_patron_page/dpl_patron_page.info.yml
@@ -5,5 +5,8 @@ dependencies:
   - drupal:block
   - dpl_fbs:dpl_fbs
   - dpl_publizon:dpl_publizon
+  - dpl_library_agency:dpl_library_agency
+  - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_patron_page/src/DplPatronPageSettings.php
+++ b/web/modules/custom/dpl_patron_page/src/DplPatronPageSettings.php
@@ -8,8 +8,8 @@ use Drupal\dpl_react\DplReactConfigBase;
  * Class that handles reservations settings.
  */
 class DplPatronPageSettings extends DplReactConfigBase {
-  const DELETE_PATRON_URL = '<front>';
-  const ALWAYS_AVAILABLE_EREOLEN = '<front>';
+  const DELETE_PATRON_URL = '';
+  const ALWAYS_AVAILABLE_EREOLEN = '';
   const PINCODE_LENGTH_MAX = 4;
   const PINCODE_LENGTH_MIN = 4;
 

--- a/web/modules/custom/dpl_patron_page/src/DplPatronPageSettings.php
+++ b/web/modules/custom/dpl_patron_page/src/DplPatronPageSettings.php
@@ -8,6 +8,8 @@ use Drupal\dpl_react\DplReactConfigBase;
  * Class that handles reservations settings.
  */
 class DplPatronPageSettings extends DplReactConfigBase {
+  const DELETE_PATRON_URL = '<front>';
+  const ALWAYS_AVAILABLE_EREOLEN = '<front>';
   const PINCODE_LENGTH_MAX = 4;
   const PINCODE_LENGTH_MIN = 4;
 

--- a/web/modules/custom/dpl_patron_page/src/Form/PatronPageSettingsForm.php
+++ b/web/modules/custom/dpl_patron_page/src/Form/PatronPageSettingsForm.php
@@ -77,7 +77,7 @@ class PatronPageSettingsForm extends ConfigFormBase {
     $form['settings']['always_available_ereolen'] = [
       '#type' => 'url',
       '#title' => $this->t('Ereolen always available'),
-      '#default_value' => $config->get('always_available_ereolen') ?? '',
+      '#default_value' => $config->get('always_available_ereolen') ?? DplPatronPageSettings::ALWAYS_AVAILABLE_EREOLEN,
     ];
 
     $form['settings']['pincode_length_min'] = [

--- a/web/modules/custom/dpl_patron_page/src/Plugin/Block/PatronPageBlock.php
+++ b/web/modules/custom/dpl_patron_page/src/Plugin/Block/PatronPageBlock.php
@@ -5,6 +5,8 @@ namespace Drupal\dpl_patron_page\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\dpl_library_agency\Form\GeneralSettingsForm;
+use Drupal\dpl_patron_page\DplPatronPageSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -84,10 +86,7 @@ class PatronPageBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $patron_page_settings = $this->patronPageSettings->loadConfig();
 
     $general_config = $this->configFactory->get('dpl_library_agency.general_settings');
-    $dateConfig = $general_config->get('pause_reservation_start_date_config');
-    if (is_null($dateConfig)) {
-      $dateConfig = "";
-    }
+    $dateConfig = $general_config->get('pause_reservation_start_date_config') ?? GeneralSettingsForm::PAUSE_RESERVATION_START_DATE_CONFIG;
 
     $data = [
       // Configuration.
@@ -95,14 +94,14 @@ class PatronPageBlock extends BlockBase implements ContainerFactoryPluginInterfa
       'blacklisted-pickup-branches-config' => DplReactAppsController::buildBranchesListProp($this->branchSettings->getExcludedReservationBranches()),
       'branches-config' => DplReactAppsController::buildBranchesJsonProp($this->branchRepository->getBranches()),
       'pause-reservation-start-date-config' => $dateConfig,
-      'pincode-length-max-config' => $patron_page_settings->get('pincode_length_max'),
-      'pincode-length-min-config' => $patron_page_settings->get('pincode_length_min'),
+      'pincode-length-max-config' => $patron_page_settings->get('pincode_length_max') ?? DplPatronPageSettings::PINCODE_LENGTH_MAX,
+      'pincode-length-min-config' => $patron_page_settings->get('pincode_length_min') ?? DplPatronPageSettings::PINCODE_LENGTH_MIN,
       'text-notifications-enabled-config' => (int) $this->reservationSettings->smsNotificationsIsEnabled(),
 
       // Urls.
-      'always-available-ereolen-url' => $patron_page_settings->get('always_available_ereolen'),
-      'delete-patron-url' => $patron_page_settings->get('delete_patron_url'),
-      'pause-reservation-info-url' => $general_config->get('pause_reservation_info_url'),
+      'always-available-ereolen-url' => $patron_page_settings->get('always_available_ereolen') ?? DplPatronPageSettings::ALWAYS_AVAILABLE_EREOLEN,
+      'delete-patron-url' => $patron_page_settings->get('delete_patron_url') ?? DplPatronPageSettings::DELETE_PATRON_URL,
+      'pause-reservation-info-url' => $general_config->get('pause_reservation_info_url') ?? GeneralSettingsForm::PAUSE_RESERVATION_INFO_URL,
 
       // Text strings.
       'date-inputs-end-date-label-text' => $this->t('To', [], ['context' => 'Patron page']),

--- a/web/modules/custom/dpl_patron_page/src/Plugin/Block/PatronPageBlock.php
+++ b/web/modules/custom/dpl_patron_page/src/Plugin/Block/PatronPageBlock.php
@@ -99,9 +99,9 @@ class PatronPageBlock extends BlockBase implements ContainerFactoryPluginInterfa
       'text-notifications-enabled-config' => (int) $this->reservationSettings->smsNotificationsIsEnabled(),
 
       // Urls.
-      'always-available-ereolen-url' => $patron_page_settings->get('always_available_ereolen') ?? DplPatronPageSettings::ALWAYS_AVAILABLE_EREOLEN,
-      'delete-patron-url' => $patron_page_settings->get('delete_patron_url') ?? DplPatronPageSettings::DELETE_PATRON_URL,
-      'pause-reservation-info-url' => $general_config->get('pause_reservation_info_url') ?? GeneralSettingsForm::PAUSE_RESERVATION_INFO_URL,
+      'always-available-ereolen-url' => dpl_react_apps_format_app_url($patron_page_settings->get('always_available_ereolen'), DplPatronPageSettings::ALWAYS_AVAILABLE_EREOLEN),
+      'delete-patron-url' => dpl_react_apps_format_app_url($patron_page_settings->get('delete_patron_url'), DplPatronPageSettings::DELETE_PATRON_URL),
+      'pause-reservation-info-url' => dpl_react_apps_format_app_url($patron_page_settings->get('pause_reservation_info_url'), GeneralSettingsForm::PAUSE_RESERVATION_INFO_URL),
 
       // Text strings.
       'date-inputs-end-date-label-text' => $this->t('To', [], ['context' => 'Patron page']),

--- a/web/modules/custom/dpl_patron_reg/dpl_patron_reg.info.yml
+++ b/web/modules/custom/dpl_patron_reg/dpl_patron_reg.info.yml
@@ -4,7 +4,6 @@ package: DPL
 type: module
 core_version_requirement: ^9
 dependencies:
-  - dpl_login:dpl_login
   - dpl_library_agency:dpl_library_agency
   - dpl_patron_page:dpl_patron_page
   - dpl_react:dpl_react

--- a/web/modules/custom/dpl_patron_reg/dpl_patron_reg.info.yml
+++ b/web/modules/custom/dpl_patron_reg/dpl_patron_reg.info.yml
@@ -5,3 +5,7 @@ type: module
 core_version_requirement: ^9
 dependencies:
   - dpl_login:dpl_login
+  - dpl_library_agency:dpl_library_agency
+  - dpl_patron_page:dpl_patron_page
+  - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps

--- a/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
+++ b/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
@@ -104,7 +104,7 @@ class PatronRegistrationBlock extends BlockBase implements ContainerFactoryPlugi
 
     // Get user info endpoint from OpenIdConnect configuration.
     $configuration = $this->configFactory->get('openid_connect.settings.adgangsplatformen');
-    $userInfoEndpoint = $configuration->get('settings')['userinfo_endpoint'];
+    $userInfoEndpoint = $configuration->get('settings')['userinfo_endpoint'] ?? '/';
 
     $data = [
       // Configuration.

--- a/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
+++ b/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
@@ -113,7 +113,7 @@ class PatronRegistrationBlock extends BlockBase implements ContainerFactoryPlugi
       'min-age-config' => $config->get('age_limit') ?? DplPatronRegSettings::AGE_LIMIT,
       'pincode-length-max-config' => $patron_page_settings->get('pincode_length_max') ?? DplPatronPageSettings::PINCODE_LENGTH_MAX,
       'pincode-length-min-config' => $patron_page_settings->get('pincode_length_min') ?? DplPatronPageSettings::PINCODE_LENGTH_MIN,
-      'redirect-on-user-created-url' => $config->get('redirect_on_user_created_url') ?? DplPatronRegSettings::REDIRECT_ON_USER_CREATED_URL,
+      'redirect-on-user-created-url' => dpl_react_apps_format_app_url($config->get('redirect_on_user_created_url'), DplPatronRegSettings::REDIRECT_ON_USER_CREATED_URL),
       'userinfo-url' => $userInfoEndpoint,
       'text-notifications-enabled-config' => (int) $this->reservationSettings->smsNotificationsIsEnabled(),
 

--- a/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
+++ b/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
@@ -3,7 +3,6 @@
 namespace Drupal\dpl_patron_reg\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dpl_library_agency\BranchSettings;
 use Drupal\dpl_library_agency\Branch\BranchRepositoryInterface;
@@ -33,8 +32,6 @@ class PatronRegistrationBlock extends BlockBase implements ContainerFactoryPlugi
    *   The plugin ID for the plugin instance.
    * @param array $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   *   Drupal config factory to get FBS and Publizon settings.
    * @param \Drupal\dpl_library_agency\BranchSettings $branchSettings
    *   The branch-settings for branch config.
    * @param \Drupal\dpl_library_agency\Branch\BranchRepositoryInterface $branchRepository
@@ -50,7 +47,6 @@ class PatronRegistrationBlock extends BlockBase implements ContainerFactoryPlugi
     array $configuration,
     string $plugin_id,
     array $plugin_definition,
-    private ConfigFactoryInterface $configFactory,
     private BranchSettings $branchSettings,
     private BranchRepositoryInterface $branchRepository,
     protected ReservationSettings $reservationSettings,
@@ -69,7 +65,6 @@ class PatronRegistrationBlock extends BlockBase implements ContainerFactoryPlugi
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('config.factory'),
       $container->get('dpl_library_agency.branch_settings'),
       $container->get('dpl_library_agency.branch.repository'),
       $container->get('dpl_library_agency.reservation_settings'),
@@ -102,10 +97,6 @@ class PatronRegistrationBlock extends BlockBase implements ContainerFactoryPlugi
     $config = $this->patronRegSettings->loadConfig();
     $patron_page_settings = $this->patronPageSettings->loadConfig();
 
-    // Get user info endpoint from OpenIdConnect configuration.
-    $configuration = $this->configFactory->get('openid_connect.settings.adgangsplatformen');
-    $userInfoEndpoint = $configuration->get('settings')['userinfo_endpoint'] ?? '/';
-
     $data = [
       // Configuration.
       'blacklisted-pickup-branches-config' => $this->buildBranchesListProp($this->branchSettings->getExcludedReservationBranches()),
@@ -114,7 +105,6 @@ class PatronRegistrationBlock extends BlockBase implements ContainerFactoryPlugi
       'pincode-length-max-config' => $patron_page_settings->get('pincode_length_max') ?? DplPatronPageSettings::PINCODE_LENGTH_MAX,
       'pincode-length-min-config' => $patron_page_settings->get('pincode_length_min') ?? DplPatronPageSettings::PINCODE_LENGTH_MIN,
       'redirect-on-user-created-url' => dpl_react_apps_format_app_url($config->get('redirect_on_user_created_url'), DplPatronRegSettings::REDIRECT_ON_USER_CREATED_URL),
-      'userinfo-url' => $userInfoEndpoint,
       'text-notifications-enabled-config' => (int) $this->reservationSettings->smsNotificationsIsEnabled(),
 
       // Texts.

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.info.yml
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.info.yml
@@ -3,6 +3,7 @@ description: For integration of dpl_react apps on the site.
 package: DPL
 dependencies:
   - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps
   - dpl_library_agency:dpl_library_agency
   - dpl_instant_loan:dpl_instant_loan
 

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.info.yml
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.info.yml
@@ -2,6 +2,7 @@ name: DPL React Apps
 description: For integration of dpl_react apps on the site.
 package: DPL
 dependencies:
+  - dpl_login:dpl_login
   - dpl_react:dpl_react
   - dpl_react_apps:dpl_react_apps
   - dpl_library_agency:dpl_library_agency

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -160,13 +160,15 @@ function dpl_react_apps_get_dpl_cms_base_url(): string {
 /**
  * Format urls used by the apps.
  *
- * @param string $url
+ * @param string|null $url
  *   Url to format.
+ * @param string $fallbackUrl
+ *   If the url param is not present.
  *
  * @return string
  *   Formatted url.
  */
-function dpl_react_apps_format_app_url(string $url, string $fallbackUrl = ''): string {
+function dpl_react_apps_format_app_url(string|NULL $url, string $fallbackUrl = ''): string {
   if (!empty($url)) {
     return $url;
   }

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -179,5 +179,7 @@ function dpl_react_apps_format_app_url(string|NULL $url, string $fallbackUrl = '
     return $url;
   }
 
+  // Use the fallback url that is provided and if that is not present use the
+  // dpl cms base url which is the absolute url to front page of the site.
   return $fallbackUrl ?: dpl_react_apps_get_dpl_cms_base_url();
 }

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -9,6 +9,7 @@
  * and various other tasks eg. providing rides and controllers for rendering.
  */
 
+use Drupal\Core\GeneratedUrl;
 use Drupal\Core\Url;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 
@@ -58,17 +59,17 @@ function dpl_react_apps_dpl_react_apps_data(array &$data): void {
   ];
 
   $data['urls'] += [
-    'dpl-cms-base' => rtrim(self::ensureUrlIsString(
+    'dpl-cms-base' => rtrim(dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString()
     ), "/"),
-    'search' => DplReactAppsController::ensureUrlIsString(
+    'search' => dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('dpl_react_apps.search_result')->toString()
     ),
     // React applications support variable replacement where variables are
     // prefixed with :. Specify the variable :workid as a parameter to let the
     // route build the url. Unfortunatly : will be encoded as %3A so we have to
     // decode the url again to make replacement work.
-    'material' => urldecode(self::ensureUrlIsString(
+    'material' => urldecode(dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('dpl_react_apps.work')
         ->setRouteParameter('wid', ':workid')
         ->toString()
@@ -130,4 +131,18 @@ function dpl_react_apps_texts_renewal(): array {
     'renew-material-loan-success-title-text' => t('You have renewed your loan', [], ['context' => 'Renew loan (material)']),
     'renew-processing-text' => t('Processing...', [], ['context' => 'Renew loan']),
   ];
+}
+
+/**
+ * Make sure that generated url is a string.
+ *
+ * @param string|\Drupal\Core\GeneratedUrl $url
+ *   Drupal generated Url object.
+ */
+function dpl_react_apps_ensure_url_is_string(string|GeneratedUrl $url): string {
+  if ($url instanceof GeneratedUrl) {
+    $url = $url->getGeneratedUrl();
+  }
+
+  return $url;
 }

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -59,9 +59,7 @@ function dpl_react_apps_dpl_react_apps_data(array &$data): void {
   ];
 
   $data['urls'] += [
-    'dpl-cms-base' => rtrim(dpl_react_apps_ensure_url_is_string(
-      Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString()
-    ), "/"),
+    'dpl-cms-base' => dpl_react_apps_get_dpl_cms_base_url(),
     'search' => dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('dpl_react_apps.search_result')->toString()
     ),
@@ -145,4 +143,33 @@ function dpl_react_apps_ensure_url_is_string(string|GeneratedUrl $url): string {
   }
 
   return $url;
+}
+
+/**
+ * Get the base url of the dpl cms.
+ *
+ * @return string
+ *   The base url of the dpl cms.
+ */
+function dpl_react_apps_get_dpl_cms_base_url(): string {
+  return rtrim(dpl_react_apps_ensure_url_is_string(
+    Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString()
+  ), "/");
+}
+
+/**
+ * Format urls used by the apps.
+ *
+ * @param string $url
+ *   Url to format.
+ *
+ * @return string
+ *   Formatted url.
+ */
+function dpl_react_apps_format_app_url(string $url, string $fallbackUrl = ''): string {
+  if (!empty($url)) {
+    return $url;
+  }
+
+  return $fallbackUrl ?: dpl_react_apps_get_dpl_cms_base_url();
 }

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -24,8 +24,6 @@ function dpl_react_apps_preprocess_page(array &$variables): void {
       '#theme' => 'dpl_react_app',
       '#name' => 'search-header',
       '#data' => [
-        'search-url' => DplReactAppsController::searchResultUrl(),
-        'material-url' => DplReactAppsController::materialUrl(),
         // Text.
         'autosuggest-animated-series-category-text' => t('Animated series', [], ['context' => 'Search Header']),
         'autosuggest-audio-book-category-text' => t('Audio books', [], ['context' => 'Search Header']),
@@ -60,12 +58,21 @@ function dpl_react_apps_dpl_react_apps_data(array &$data): void {
   ];
 
   $data['urls'] += [
-    'search' => DplReactAppsController::ensureUrlIsString(
-      Url::fromRoute('dpl_react_apps.search_result')->toString()
-    ),
     'dpl-cms-base' => rtrim(self::ensureUrlIsString(
       Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString()
     ), "/"),
+    'search' => DplReactAppsController::ensureUrlIsString(
+      Url::fromRoute('dpl_react_apps.search_result')->toString()
+    ),
+    // React applications support variable replacement where variables are
+    // prefixed with :. Specify the variable :workid as a parameter to let the
+    // route build the url. Unfortunatly : will be encoded as %3A so we have to
+    // decode the url again to make replacement work.
+    'material' => urldecode(self::ensureUrlIsString(
+      Url::fromRoute('dpl_react_apps.work')
+        ->setRouteParameter('wid', ':workid')
+        ->toString()
+    )),
   ];
 }
 

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -9,6 +9,7 @@
  * and various other tasks eg. providing rides and controllers for rendering.
  */
 
+use Drupal\Core\Url;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 
 /**
@@ -56,6 +57,15 @@ function dpl_react_apps_dpl_react_apps_data(array &$data): void {
   $data['texts'] += [
     'alert-error-close' => t('Close', [], ['context' => 'React apps (Global error handling)']),
     'alert-error-message' => t('An error occurred', [], ['context' => 'React apps (Global error handling)']),
+  ];
+
+  $data['urls'] += [
+    'search' => DplReactAppsController::ensureUrlIsString(
+      Url::fromRoute('dpl_react_apps.search_result')->toString()
+    ),
+    'dpl-cms-base' => rtrim(self::ensureUrlIsString(
+      Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString()
+    ), "/"),
   ];
 }
 

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -72,6 +72,12 @@ function dpl_react_apps_dpl_react_apps_data(array &$data): void {
         ->setRouteParameter('wid', ':workid')
         ->toString()
     )),
+    'logout' => dpl_react_apps_ensure_url_is_string(
+      Url::fromRoute('dpl_login.logout', [], ['absolute' => TRUE])->toString()
+    ),
+    'auth' => dpl_react_apps_ensure_url_is_string(
+      Url::fromRoute('dpl_login.login')->toString()
+    ),
   ];
 }
 

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -111,8 +111,6 @@ class DplReactAppsController extends ControllerBase {
       'branches-config' => $this->buildBranchesJsonProp($this->branchRepository->getBranches()),
       // Urls.
       'auth-url' => self::authUrl(),
-      'material-url' => self::materialUrl(),
-      'search-url' => self::searchResultUrl(),
       // Text.
       'add-more-filters-text' => $this->t('+ more filters', [], ['context' => 'Search Result']),
       'availability-available-text' => $this->t('Available', [], ['context' => 'Search Result']),
@@ -196,8 +194,6 @@ class DplReactAppsController extends ControllerBase {
       "interest-periods-config" => $this->getInterestPeriods(),
       // Urls.
       'auth-url' => self::authUrl(),
-      'material-url' => self::materialUrl(),
-      'search-url' => self::searchResultUrl(),
       // Text.
       'already-reserved-text' => $this->t('Already reserved', [], ['context' => 'Work Page']),
       'approve-reservation-text' => $this->t('Approve reservation', [], ['context' => 'Work Page']),
@@ -383,31 +379,6 @@ class DplReactAppsController extends ControllerBase {
     $this->renderer->addCacheableDependency($app, $this->instantLoanSettings);
 
     return $app;
-  }
-
-  /**
-   * Builds an url for the local search result route.
-   */
-  public static function searchResultUrl(): string {
-    return self::ensureUrlIsString(
-      Url::fromRoute('dpl_react_apps.search_result')->toString()
-    );
-  }
-
-  /**
-   * Builds an url for the material/work route.
-   */
-  public static function materialUrl(): string {
-    // React applications support variable replacement where variables are
-    // prefixed with :. Specify the variable :workid as a parameter to let the
-    // route build the url. Unfortunatly : will be encoded as %3A so we have to
-    // decode the url again to make replacement work.
-    $url = self::ensureUrlIsString(
-      Url::fromRoute('dpl_react_apps.work')
-        ->setRouteParameter('wid', ':workid')
-        ->toString()
-    );
-    return urldecode($url);
   }
 
   /**

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -10,6 +10,7 @@ use Drupal\dpl_instant_loan\DplInstantLoanSettings;
 use Drupal\dpl_library_agency\Branch\Branch;
 use Drupal\dpl_library_agency\Branch\BranchRepositoryInterface;
 use Drupal\dpl_library_agency\BranchSettings;
+use Drupal\dpl_library_agency\Form\GeneralSettingsForm;
 use Drupal\dpl_library_agency\ReservationSettings;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use function Safe\json_encode as json_encode;
@@ -110,7 +111,6 @@ class DplReactAppsController extends ControllerBase {
       'branches-config' => $this->buildBranchesJsonProp($this->branchRepository->getBranches()),
       // Urls.
       'auth-url' => self::authUrl(),
-      'dpl-cms-base-url' => self::dplCmsBaseUrl(),
       'material-url' => self::materialUrl(),
       'search-url' => self::searchResultUrl(),
       // Text.
@@ -168,7 +168,7 @@ class DplReactAppsController extends ControllerBase {
     // @todo the general setting should be converted into an settings object and
     // injected into the places it is needed and then remove thies static
     // functions.
-    return \Drupal::configFactory()->get('dpl_library_agency.general_settings')->get('interest_periods_config');
+    return \Drupal::configFactory()->get('dpl_library_agency.general_settings')->get('interest_periods_config') ?? GeneralSettingsForm::INTEREST_PERIODS_CONFIG;
   }
 
   /**
@@ -196,7 +196,6 @@ class DplReactAppsController extends ControllerBase {
       "interest-periods-config" => $this->getInterestPeriods(),
       // Urls.
       'auth-url' => self::authUrl(),
-      'dpl-cms-base-url' => self::dplCmsBaseUrl(),
       'material-url' => self::materialUrl(),
       'search-url' => self::searchResultUrl(),
       // Text.
@@ -418,18 +417,6 @@ class DplReactAppsController extends ControllerBase {
     return self::ensureUrlIsString(
       Url::fromRoute('dpl_login.login')->toString()
     );
-  }
-
-  /**
-   * Get the base url of the API exposed by this site.
-   */
-  public static function dplCmsBaseUrl(): string {
-    $url = self::ensureUrlIsString(
-      Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString()
-    );
-    // The url must not have a trailing slash. The generated client will append
-    // it. Double slashes can lead to all kinds of oddities.
-    return rtrim($url, "/");
   }
 
   /**

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -109,8 +109,7 @@ class DplReactAppsController extends ControllerBase {
       'blacklisted-availability-branches-config' => $this->buildBranchesListProp($this->branchSettings->getExcludedAvailabilityBranches()),
       'blacklisted-search-branches-config' => $this->buildBranchesListProp($this->branchSettings->getExcludedSearchBranches()),
       'branches-config' => $this->buildBranchesJsonProp($this->branchRepository->getBranches()),
-      // Urls.
-      'auth-url' => self::authUrl(),
+
       // Text.
       'add-more-filters-text' => $this->t('+ more filters', [], ['context' => 'Search Result']),
       'availability-available-text' => $this->t('Available', [], ['context' => 'Search Result']),
@@ -192,8 +191,7 @@ class DplReactAppsController extends ControllerBase {
       'sms-notifications-for-reservations-enabled-config' => (int) $this->reservationSettings->smsNotificationsIsEnabled(),
       'instant-loan-config' => $this->instantLoanSettings->getConfig(),
       "interest-periods-config" => $this->getInterestPeriods(),
-      // Urls.
-      'auth-url' => self::authUrl(),
+
       // Text.
       'already-reserved-text' => $this->t('Already reserved', [], ['context' => 'Work Page']),
       'approve-reservation-text' => $this->t('Approve reservation', [], ['context' => 'Work Page']),
@@ -379,15 +377,6 @@ class DplReactAppsController extends ControllerBase {
     $this->renderer->addCacheableDependency($app, $this->instantLoanSettings);
 
     return $app;
-  }
-
-  /**
-   * Builds an url for the react apps to use for authorization.
-   */
-  public static function authUrl(): string {
-    return self::ensureUrlIsString(
-      Url::fromRoute('dpl_login.login')->toString()
-    );
   }
 
   /**

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -186,7 +186,7 @@ class DplReactAppsController extends ControllerBase {
       // @todo Remove when instant loans branches are used.
       'blacklisted-instant-loan-branches-config' => "",
       'branches-config' => $this->buildBranchesJsonProp($this->branchRepository->getBranches()),
-      'sms-notifications-for-reservations-enabled-config' => (int) $this->reservationSettings->smsNotificationsIsEnabled(),
+      'sms-notifications-for-reservations-enabled-config' => (int) $this->reservationSettings->smsNotificationsIsEnabled() ?? ReservationSettings::RESERVATION_SMS_NOTIFICATIONS_ENABLED,
       'instant-loan-config' => $this->instantLoanSettings->getConfig(),
       "interest-periods-config" => $this->getInterestPeriods(),
 

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -410,20 +410,6 @@ class DplReactAppsController extends ControllerBase {
   }
 
   /**
-   * Make sure that generated url is a string.
-   *
-   * @param string|\Drupal\Core\GeneratedUrl $url
-   *   Drupal generated Url object.
-   */
-  public static function ensureUrlIsString(string|GeneratedUrl $url): string {
-    if ($url instanceof GeneratedUrl) {
-      $url = $url->getGeneratedUrl();
-    }
-
-    return $url;
-  }
-
-  /**
    * Get the strings and config for blocked user.
    *
    * @return mixed[]

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -3,9 +3,7 @@
 namespace Drupal\dpl_react_apps\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\GeneratedUrl;
 use Drupal\Core\Render\RendererInterface;
-use Drupal\Core\Url;
 use Drupal\dpl_instant_loan\DplInstantLoanSettings;
 use Drupal\dpl_library_agency\Branch\Branch;
 use Drupal\dpl_library_agency\Branch\BranchRepositoryInterface;
@@ -418,8 +416,8 @@ class DplReactAppsController extends ControllerBase {
   public static function getBlockedSettings(): array {
     $blockedSettings = \Drupal::configFactory()->get('dpl_library_agency.general_settings');
     $blockedData = [
-      'redirect-on-blocked-url' => $blockedSettings->get('redirect_on_blocked_url') ?? '',
-      'blocked-patron-e-link-url' => $blockedSettings->get('blocked_patron_e_link_url') ?? '',
+      'redirect-on-blocked-url' => dpl_react_apps_format_app_url($blockedSettings->get('redirect_on_blocked_url'), GeneralSettingsForm::REDIRECT_ON_BLOCKED_URL),
+      'blocked-patron-e-link-url' => dpl_react_apps_format_app_url($blockedSettings->get('blocked_patron_e_link_url'), GeneralSettingsForm::BLOCKED_PATRON_E_LINK_URL),
       'blocked-patron-d-title-text' => t('Blocked patron title text (d)', [], ['context' => 'Blocked user']),
       'blocked-patron-d-body-text' => t('Blocked patron body text (d)', [], ['context' => 'Blocked user']),
       'blocked-patron-s-title-text' => t('Blocked patron title text (s)', [], ['context' => 'Blocked user']),

--- a/web/modules/custom/dpl_recommender/dpl_recommender.info.yml
+++ b/web/modules/custom/dpl_recommender/dpl_recommender.info.yml
@@ -6,5 +6,6 @@ dependencies:
   - dpl_fbs:dpl_fbs
   - dpl_publizon:dpl_publizon
   - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_recommender/src/DplRecommenderSettings.php
+++ b/web/modules/custom/dpl_recommender/src/DplRecommenderSettings.php
@@ -9,6 +9,8 @@ use Drupal\dpl_react\DplReactConfigBase;
  */
 class DplRecommenderSettings extends DplReactConfigBase {
 
+  const SEARCH_TEXT = 'search_text';
+
   /**
    * Gets the configuration key for recommender settings.
    */

--- a/web/modules/custom/dpl_recommender/src/Plugin/Block/RecommenderBlock.php
+++ b/web/modules/custom/dpl_recommender/src/Plugin/Block/RecommenderBlock.php
@@ -6,6 +6,7 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
+use Drupal\dpl_recommender\DplRecommenderSettings;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -77,7 +78,7 @@ class RecommenderBlock extends BlockBase implements ContainerFactoryPluginInterf
       // Texts.
       'material-and-author-text' => $this->t('and', [], ['context' => 'Recommender']),
       'add-to-favorites-aria-label-text' => $this->t("Add @title to favorites list", [], ['context' => 'Recommender (Aria)']),
-      'empty-recommender-search-config' => $recommenderSettings->get('search_text'),
+      'empty-recommender-search-config' => $recommenderSettings->get('search_text') ?? DplRecommenderSettings::SEARCH_TEXT,
       'et-al-text' => $this->t("et al.", [], ['context' => 'Recommender']),
       'material-by-author-text' => $this->t("By", [], ['context' => 'Recommender']),
       'recommender-title-inspiration-text' => $this->t("For your inspiration", [], ['context' => 'Recommender']),

--- a/web/modules/custom/dpl_recommender/src/Plugin/Block/RecommenderBlock.php
+++ b/web/modules/custom/dpl_recommender/src/Plugin/Block/RecommenderBlock.php
@@ -75,7 +75,6 @@ class RecommenderBlock extends BlockBase implements ContainerFactoryPluginInterf
 
     $data = [
       // Urls.
-      'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
       'material-url' => DplReactAppsController::materialUrl(),
 
       // Texts.

--- a/web/modules/custom/dpl_recommender/src/Plugin/Block/RecommenderBlock.php
+++ b/web/modules/custom/dpl_recommender/src/Plugin/Block/RecommenderBlock.php
@@ -74,9 +74,6 @@ class RecommenderBlock extends BlockBase implements ContainerFactoryPluginInterf
     $recommenderSettings = $this->recommenderSettings->loadConfig();
 
     $data = [
-      // Urls.
-      'material-url' => DplReactAppsController::materialUrl(),
-
       // Texts.
       'material-and-author-text' => $this->t('and', [], ['context' => 'Recommender']),
       'add-to-favorites-aria-label-text' => $this->t("Add @title to favorites list", [], ['context' => 'Recommender (Aria)']),

--- a/web/modules/custom/dpl_reservations/dpl_reservations.info.yml
+++ b/web/modules/custom/dpl_reservations/dpl_reservations.info.yml
@@ -7,5 +7,6 @@ dependencies:
   - dpl_publizon:dpl_publizon
   - dpl_react:dpl_react
   - dpl_react_apps:dpl_react_apps
+  - dpl_library_agency:dpl_library_agency
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_reservations/dpl_reservations.info.yml
+++ b/web/modules/custom/dpl_reservations/dpl_reservations.info.yml
@@ -6,5 +6,6 @@ dependencies:
   - dpl_fbs:dpl_fbs
   - dpl_publizon:dpl_publizon
   - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_reservations/dpl_reservations.module
+++ b/web/modules/custom/dpl_reservations/dpl_reservations.module
@@ -8,14 +8,13 @@
  */
 
 use Drupal\Core\Url;
-use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 
 /**
  * Implements hook_dpl_react_apps_data().
  */
 function dpl_reservations_dpl_react_apps_data(array &$data): void {
   $data['urls'] += [
-    'reservations' => DplReactAppsController::ensureUrlIsString(
+    'reservations' => dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('dpl_reservations.list', [], ['absolute' => TRUE])->toString()
     ),
   ];

--- a/web/modules/custom/dpl_reservations/dpl_reservations.module
+++ b/web/modules/custom/dpl_reservations/dpl_reservations.module
@@ -6,3 +6,17 @@
  *
  * Shows the reservation list.
  */
+
+use Drupal\Core\Url;
+use Drupal\dpl_react_apps\Controller\DplReactAppsController;
+
+/**
+ * Implements hook_dpl_react_apps_data().
+ */
+function dpl_reservations_dpl_react_apps_data(array &$data): void {
+  $data['urls'] += [
+    'reservations' => DplReactAppsController::ensureUrlIsString(
+      Url::fromRoute('dpl_reservations.list', [], ['absolute' => TRUE])->toString()
+    ),
+  ];
+}

--- a/web/modules/custom/dpl_reservations/src/DplReservationsSettings.php
+++ b/web/modules/custom/dpl_reservations/src/DplReservationsSettings.php
@@ -8,6 +8,8 @@ use Drupal\dpl_react\DplReactConfigBase;
  * Class that handles reservations settings.
  */
 class DplReservationsSettings extends DplReactConfigBase {
+  const PAGE_SIZE_DESKTOP = 25;
+  const PAGE_SIZE_MOBILE = 25;
 
   /**
    * Gets the configuration key for reservation settings.

--- a/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
+++ b/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\dpl_library_agency\Branch\BranchRepositoryInterface;
 use Drupal\dpl_library_agency\BranchSettings;
 use Drupal\dpl_library_agency\Form\GeneralSettingsForm;
+use function Safe\json_encode as json_encode;
 
 /**
  * Provides user reservations list.
@@ -78,6 +79,7 @@ class ReservationListBlock extends BlockBase implements ContainerFactoryPluginIn
   public function build(): array {
     $config = $this->reservationListSettings->loadConfig();
     $generalSettings = $this->configFactory->get('dpl_library_agency.general_settings');
+    $allow_remove_ready_reservations = $generalSettings->get('reservation_detail_allow_remove_ready_reservations') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS;
 
     $data = [
       // Branches.
@@ -95,7 +97,9 @@ class ReservationListBlock extends BlockBase implements ContainerFactoryPluginIn
       'page-size-desktop' => $config->get('page_size_desktop') ?? DplReservationsSettings::PAGE_SIZE_DESKTOP,
       'page-size-mobile' => $config->get('page_size_mobile') ?? DplReservationsSettings::PAGE_SIZE_MOBILE,
       'pause-reservation-start-date-config' => $generalSettings->get('pause_reservation_start_date_config') ?? GeneralSettingsForm::PAUSE_RESERVATION_START_DATE_CONFIG,
-      'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations_config') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG,
+      'reservation-details-config' => json_encode([
+        'allowRemoveReadyReservations' => $allow_remove_ready_reservations,
+      ]),
       'threshold-config' => $generalSettings->get('threshold_config') ?? GeneralSettingsForm::THRESHOLD_CONFIG,
 
       // Texts.

--- a/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
+++ b/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
@@ -7,9 +7,11 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
+use Drupal\dpl_reservations\DplReservationsSettings;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\dpl_library_agency\Branch\BranchRepositoryInterface;
 use Drupal\dpl_library_agency\BranchSettings;
+use Drupal\dpl_library_agency\Form\GeneralSettingsForm;
 
 /**
  * Provides user reservations list.
@@ -85,16 +87,16 @@ class ReservationListBlock extends BlockBase implements ContainerFactoryPluginIn
       'branches-config' => DplReactAppsController::buildBranchesJsonProp($this->branchRepository->getBranches()),
 
       // Url.
-      'ereolen-my-page-url' => $config->get('ereolen_my_page_url'),
-      'pause-reservation-info-url' => $generalSettings->get('pause_reservation_info_url'),
+      'ereolen-my-page-url' => dpl_react_apps_format_app_url($config->get('ereolen_my_page_url'), GeneralSettingsForm::EREOLEN_MY_PAGE_URL),
+      'pause-reservation-info-url' => dpl_react_apps_format_app_url($generalSettings->get('pause_reservation_info_url'), GeneralSettingsForm::PAUSE_RESERVATION_INFO_URL),
 
       // Config.
       'interest-periods-config' => DplReactAppsController::getInterestPeriods(),
-      'page-size-desktop' => $config->get('page_size_desktop'),
-      'page-size-mobile' => $config->get('page_size_mobile'),
-      'pause-reservation-start-date-config' => $generalSettings->get('pause_reservation_start_date_config') ?? '',
-      'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations_config'),
-      'threshold-config' => $generalSettings->get('threshold_config'),
+      'page-size-desktop' => $config->get('page_size_desktop') ?? DplReservationsSettings::PAGE_SIZE_DESKTOP,
+      'page-size-mobile' => $config->get('page_size_mobile') ?? DplReservationsSettings::PAGE_SIZE_MOBILE,
+      'pause-reservation-start-date-config' => $generalSettings->get('pause_reservation_start_date_config') ?? GeneralSettingsForm::PAUSE_RESERVATION_START_DATE_CONFIG,
+      'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations_config') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS_CONFIG,
+      'threshold-config' => $generalSettings->get('threshold_config') ?? GeneralSettingsForm::THRESHOLD_CONFIG,
 
       // Texts.
       'material-and-author-text' => $this->t('and', [], ['context' => 'Reservation list']),
@@ -206,5 +208,5 @@ class ReservationListBlock extends BlockBase implements ContainerFactoryPluginIn
       '#data' => $data,
     ];
   }
-}
 
+}

--- a/web/modules/custom/dpl_something_similar/dpl_something_similar.info.yml
+++ b/web/modules/custom/dpl_something_similar/dpl_something_similar.info.yml
@@ -6,5 +6,6 @@ dependencies:
   - dpl_fbs:dpl_fbs
   - dpl_publizon:dpl_publizon
   - dpl_react:dpl_react
+  - dpl_react_apps:dpl_react_apps
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_something_similar/src/Plugin/Block/SomethingSimilarBlock.php
+++ b/web/modules/custom/dpl_something_similar/src/Plugin/Block/SomethingSimilarBlock.php
@@ -76,7 +76,6 @@ class SomethingSimilarBlock extends BlockBase implements ContainerFactoryPluginI
   public function build() {
     $data = [
       // Urls.
-      'dpl-cms-base-url' => DplReactAppsController::dplCmsBaseUrl(),
       'faust' => self::faustFromUrl(),
       'material-url' => DplReactAppsController::materialUrl(),
 

--- a/web/modules/custom/dpl_something_similar/src/Plugin/Block/SomethingSimilarBlock.php
+++ b/web/modules/custom/dpl_something_similar/src/Plugin/Block/SomethingSimilarBlock.php
@@ -77,7 +77,6 @@ class SomethingSimilarBlock extends BlockBase implements ContainerFactoryPluginI
     $data = [
       // Urls.
       'faust' => self::faustFromUrl(),
-      'material-url' => DplReactAppsController::materialUrl(),
 
       // Texts.
       'material-and-author-text' => $this->t('and', [], ['context' => 'Something similar']),

--- a/web/profiles/dpl_cms/dpl_cms.profile
+++ b/web/profiles/dpl_cms/dpl_cms.profile
@@ -90,7 +90,7 @@ function dpl_cms_locale_translation_batch_fetch_finished(bool $success, array $r
     _locale_refresh_translations($languages);
     \Drupal::logger('dpl_cms')->notice("New translations were imported and translation cache was cleared.");
   }
-  // TODO: remove this logging when we are sure that
+  // @todo remove this logging when we are sure that
   // the translation cache functionality works.
   else {
     \Drupal::logger('dpl_cms')->notice("No new translations were imported.");


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-246

#### Description

This PR is trying get rid of failing dpl-react apps when various data-props has not been configured.
* The urls that belongs to the various modules through their *.routing.yml files has been moved their corresponding modules via the `hook_dpl_react_apps_data()` hook.
* Defaults have been set as constants on settings objects so they can be used in both config forms and as rendering fallback data-props.
* App url handling functions have been moved to dpl_reat_apps.module. We could also create a service for it? But anyways, this is an attempt to try to handle urls passed to apps in a unified manner.
* Some naming/logic cleanup around `reservation_sms_notifications_enabled`. I think I have done it right, but it should be double checked with an (manual) integration test.

#### Additional comments or questions

[This](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/633) should be merged first.
Then the dpl-react dependency should point at develop.
When this PR has been approved it should NOT be merged! - because  DDF needs a testing environment
Then this PR can be merged.