### PR TITLE
Ddflsbp 229 brugeroprettelse laner der er oprettet i forvejen vises en fejlside

### DIFF
--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -11,7 +11,6 @@ use DanskernesDigitaleBibliotek\FBS\ApiException;
 use DanskernesDigitaleBibliotek\FBS\Model\BlockStatus;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
-use Drupal\Core\Url;
 use Drupal\dpl_fbs\Patron\BlockedReason;
 use Drupal\dpl_login\AccessToken;
 use Drupal\dpl_login\DplLoginInterface;

--- a/web/modules/custom/dpl_patron_page/src/Plugin/Block/PatronPageBlock.php
+++ b/web/modules/custom/dpl_patron_page/src/Plugin/Block/PatronPageBlock.php
@@ -163,4 +163,5 @@ class PatronPageBlock extends BlockBase implements ContainerFactoryPluginInterfa
       '#data' => $data,
     ];
   }
+
 }

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.info.yml
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.info.yml
@@ -7,6 +7,7 @@ dependencies:
   - dpl_react_apps:dpl_react_apps
   - dpl_library_agency:dpl_library_agency
   - dpl_instant_loan:dpl_instant_loan
+  - dpl_dashboard:dpl_dashboard
 
 type: module
 core_version_requirement: ^9

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -78,6 +78,9 @@ function dpl_react_apps_dpl_react_apps_data(array &$data): void {
     'auth' => dpl_react_apps_ensure_url_is_string(
       Url::fromRoute('dpl_login.login')->toString()
     ),
+    'dashboard' => dpl_react_apps_ensure_url_is_string(
+      Url::fromRoute('dpl_dashboard.list')->toString()
+    ),
   ];
 }
 

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -12,6 +12,7 @@
 use Drupal\Core\GeneratedUrl;
 use Drupal\Core\Url;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
+use function Safe\json_encode;
 
 /**
  * Implements template_preprocess_page().
@@ -53,6 +54,16 @@ function dpl_react_apps_preprocess_page(array &$variables): void {
  * Implements hook_dpl_react_apps_data().
  */
 function dpl_react_apps_dpl_react_apps_data(array &$data): void {
+  $adgangsplatformen_config = \Drupal::service('dpl_login.adgangsplatformen.config');
+
+  // @todo We should use the adgabngsplatform config everywhere we handle data that it can provide,
+  // eg. login/logout urls.
+  $data['configs'] += [
+    'agency' => json_encode([
+      'id' => $adgangsplatformen_config->getAgencyId(),
+    ]),
+  ];
+
   $data['texts'] += [
     'alert-error-close' => t('Close', [], ['context' => 'React apps (Global error handling)']),
     'alert-error-message' => t('An error occurred', [], ['context' => 'React apps (Global error handling)']),


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-229

#### Description

Users that already have been created should be redirected to the dashboard.
This PR adds a handover of the dashboard and userinfo urls to the react applications

#### Additional comments or questions

This can be merged when it's [sibling](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/653) have been merged.