### PR TITLE
fix/ereol-pickup-indication

### DIFF
--- a/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
+++ b/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
@@ -130,6 +130,7 @@ class ReservationListBlock extends BlockBase implements ContainerFactoryPluginIn
       'reservation-list-available-in-text' => $this->t('Available in @count days', [], ['context' => 'Reservation list']),
       'reservation-list-day-text' => $this->t('day', [], ['context' => 'Reservation list']),
       'reservation-list-days-text' => $this->t('days', [], ['context' => 'Reservation list']),
+      'reservation-list-digital-pickup-text' => $this->t('Online access', [], ['context' => 'Reservation list']),
       'reservation-list-digital-reservations-empty-text' => $this->t('At the moment you have 0 reservations on digital items', [], ['context' => 'Reservation list']),
       'reservation-list-digital-reservations-header-text' => $this->t('Digital reservations', [], ['context' => 'Reservation list']),
       'reservation-list-first-in-queue-text' => $this->t('You are at the front of the queue', [], ['context' => 'Reservation list']),


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-213

#### Description
Added a translation for generic text shown on digital reservation cards in the list of user reservations.

#### Screenshot of the result
n/a

#### Additional comments or questions
You can disregard the failing Lagoon integration test - there are currently problems with Lagoon.