### PR TITLE
Correct translation for result-pager-status-text for advanced search app

### DIFF
--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -225,7 +225,7 @@ class DplReactAppsController extends ControllerBase {
       'no-search-result-text' => $this->t('your search has 0 results', [], ['context' => 'advanced search']),
       'number-description-text' => $this->t('nr.', [], ['context' => 'advanced search']),
       'remove-from-favorites-aria-label-text' => $this->t('remove @title from favorites list', [], ['context' => 'advanced search']),
-      'result-pager-status-text' => $this->t('showing @items-shown out of @hitcount results', [], ['context' => 'advanced search']),
+      'result-pager-status-text' => $this->t('Showing @itemsShown out of @hitcount elements', [], ['context' => 'advanced search']),
       'show-more-text' => $this->t('show more', [], ['context' => 'advanced search']),
       'showing-materials-text' => $this->t('showing materials', [], ['context' => 'advanced search']),
       'to-advanced-search-button-text' => $this->t('Back to advanced search', [], ['context' => 'advanced search']),


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-79

#### Description
Internal variable for "items shown" was misspelled, so the number of items shown wasn't being shown.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/28546954/819bbd27-eacd-4b0a-bba5-a0c861a7fd0e)


#### Additional comments or questions
n/a