### PR TITLE
DDFLSBP-150 - Changed the 'threshold_config' textfield into 'expirati…

### DIFF
--- a/config/sync/dpl_library_agency.general_settings.yml
+++ b/config/sync/dpl_library_agency.general_settings.yml
@@ -1,5 +1,5 @@
 reservation_sms_notifications_disabled: 0
-threshold_config: '{ "colorThresholds": { "danger": "0", "warning": "6" } }'
+expiration_warning_days_before_config: 6
 interest_periods_config: '[
     {
         "value": "30",

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -85,7 +85,7 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
       // Config.
       'page-size-desktop' => $dashboardSettings->get('page_size_desktop') ?? DplDashboardSettings::PAGE_SIZE_DESKTOP,
       'page-size-mobile' => $dashboardSettings->get('page_size_mobile') ?? DplDashboardSettings::PAGE_SIZE_MOBILE,
-      'expiration-warning-days-before' => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
+      'expiration-warning-days-before-config' => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
       'interest-periods-config' => DplReactAppsController::getInterestPeriods(),
       'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS,
       'blacklisted-pickup-branches-config' => DplReactAppsController::buildBranchesListProp($this->branchSettings->getExcludedReservationBranches()),

--- a/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
+++ b/web/modules/custom/dpl_dashboard/src/Plugin/Block/DashboardBlock.php
@@ -85,7 +85,7 @@ class DashboardBlock extends BlockBase implements ContainerFactoryPluginInterfac
       // Config.
       'page-size-desktop' => $dashboardSettings->get('page_size_desktop') ?? DplDashboardSettings::PAGE_SIZE_DESKTOP,
       'page-size-mobile' => $dashboardSettings->get('page_size_mobile') ?? DplDashboardSettings::PAGE_SIZE_MOBILE,
-      'threshold-config' => $this->configFactory->get('dpl_library_agency.general_settings')->get('threshold_config') ?? GeneralSettingsForm::THRESHOLD_CONFIG,
+      'expiration-warning-days-before' => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
       'interest-periods-config' => DplReactAppsController::getInterestPeriods(),
       'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations') ?? GeneralSettingsForm::RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS,
       'blacklisted-pickup-branches-config' => DplReactAppsController::buildBranchesListProp($this->branchSettings->getExcludedReservationBranches()),

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -20,7 +20,7 @@ use function Safe\usort as usort;
  */
 class GeneralSettingsForm extends ConfigFormBase {
   // @todo These constants should be defined in a general settings class like we do it in eg dpl_dashboard.
-  const THRESHOLD_CONFIG = "{ 'colorThresholds': { 'danger': '0', 'warning': '6' } }";
+  const EXPIRATION_WARNING_DAYS_BEFORE_CONFIG = 6;
   const RESERVATION_DETAIL_ALLOW_REMOVE_READY_RESERVATIONS = FALSE;
   const INTEREST_PERIODS_CONFIG = '';
   const RESERVATION_SMS_NOTIFICATIONS_ENABLED = TRUE;
@@ -194,17 +194,18 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('blocked_patron_e_link_url') ?? self::BLOCKED_PATRON_E_LINK_URL,
     ];
 
-    $form['thresholds'] = [
+    $form['expiration_warning'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Thresholds', [], ['context' => 'Library Agency Configuration']),
+      '#title' => $this->t('Expiration warning', [], ['context' => 'Library Agency Configuration']),
       '#collapsible' => FALSE,
       '#collapsed' => FALSE,
     ];
 
-    $form['thresholds']['threshold_config'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Set thresholds', [], ['context' => 'Library Agency Configuration']),
-      '#default_value' => $config->get('threshold_config') ?? self::THRESHOLD_CONFIG,
+    $form['expiration_warning']['expiration_warning_days_before_config'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Set expiration warning', [], ['context' => 'Library Agency Configuration']),
+      '#default_value' => $config->get('expiration_warning_days_before_config') ?? self::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
+      '#description' => $this->t('Insert the number of days before the expiration of the material, when the reminder "Expires soon" should appear.', [], ['context' => 'Library Agency Configuration']),
     ];
 
     $form['branches'] = [
@@ -256,7 +257,7 @@ class GeneralSettingsForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->config('dpl_library_agency.general_settings')
-      ->set('threshold_config', $form_state->getValue('threshold_config'))
+      ->set('expiration_warning_days_before_config', $form_state->getValue('expiration_warning_days_before_config'))
       ->set('reservation_detail_allow_remove_ready_reservations', $form_state->getValue('reservation_detail_allow_remove_ready_reservations'))
       ->set('interest_periods_config', $form_state->getValue('interest_periods_config'))
       ->set('reservation_sms_notifications_enabled', $form_state->getValue('reservation_sms_notifications_enabled'))

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -87,7 +87,7 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       "page-size-mobile" => $loanListSettings->get('page_size_mobile') ?? DplLoansSettings::PAGE_SIZE_MOBILE,
 
       // Config.
-      "expiration-warning-days-before" => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
+      "expiration-warning-days-before-config" => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
 
       // Urls.
       'ereolen-my-page-url' => dpl_react_apps_format_app_url($generalSettings->get('ereolen_my_page_url'), GeneralSettingsForm::EREOLEN_MY_PAGE_URL),

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -72,17 +72,6 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
   }
 
   /**
-   * Gets threshold config.
-   *
-   * @return string
-   *   Returns the threshold config.
-   */
-  public function getThresholdConfig(): string {
-    $generalSettings = $this->configFactory->get('dpl_library_agency.general_settings');
-    return $generalSettings->get('threshold_config') ?? GeneralSettingsForm::THRESHOLD_CONFIG;
-  }
-
-  /**
    * {@inheritDoc}
    *
    * @return mixed[]
@@ -98,7 +87,7 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       "page-size-mobile" => $loanListSettings->get('page_size_mobile') ?? DplLoansSettings::PAGE_SIZE_MOBILE,
 
       // Config.
-      "threshold-config" => $this->getThresholdConfig(),
+      "expiration-warning-days-before" => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
 
       // Urls.
       'ereolen-my-page-url' => dpl_react_apps_format_app_url($generalSettings->get('ereolen_my_page_url'), GeneralSettingsForm::EREOLEN_MY_PAGE_URL),

--- a/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
+++ b/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
@@ -6,6 +6,7 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
+use Drupal\dpl_library_agency\Form\GeneralSettingsForm;
 use Drupal\dpl_react_apps\Controller\DplReactAppsController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\dpl_library_agency\Branch\BranchRepositoryInterface;
@@ -126,7 +127,7 @@ class PatronMenuBlock extends BlockBase implements ContainerFactoryPluginInterfa
       'page-size-mobile' => $menuSettings->get('page_size_mobile'),
       'blacklisted-pickup-branches-config' => DplReactAppsController::buildBranchesListProp($this->branchSettings->getExcludedReservationBranches()),
       'branches-config' => DplReactAppsController::buildBranchesJsonProp($this->branchRepository->getBranches()),
-      "threshold-config" => $this->configFactory->get('dpl_library_agency.general_settings')->get('threshold_config'),
+      "expiration-warning-days-before-config" => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
       "menu-navigation-data-config" => json_encode($menu, JSON_THROW_ON_ERROR),
       'reservation-detail-allow-remove-ready-reservations-config' => $generalSettings->get('reservation_detail_allow_remove_ready_reservations'),
       'interest-periods-config' => DplReactAppsController::getInterestPeriods(),

--- a/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
+++ b/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
@@ -100,7 +100,7 @@ class ReservationListBlock extends BlockBase implements ContainerFactoryPluginIn
       'reservation-details-config' => json_encode([
         'allowRemoveReadyReservations' => $allow_remove_ready_reservations,
       ]),
-      'threshold-config' => $generalSettings->get('threshold_config') ?? GeneralSettingsForm::THRESHOLD_CONFIG,
+      'expiration-warning-days-before' => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
 
       // Texts.
       'material-and-author-text' => $this->t('and', [], ['context' => 'Reservation list']),

--- a/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
+++ b/web/modules/custom/dpl_reservations/src/Plugin/Block/ReservationListBlock.php
@@ -100,7 +100,7 @@ class ReservationListBlock extends BlockBase implements ContainerFactoryPluginIn
       'reservation-details-config' => json_encode([
         'allowRemoveReadyReservations' => $allow_remove_ready_reservations,
       ]),
-      'expiration-warning-days-before' => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
+      'expiration-warning-days-before-config' => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettingsForm::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
 
       // Texts.
       'material-and-author-text' => $this->t('and', [], ['context' => 'Reservation list']),

--- a/web/profiles/dpl_cms/translations/da.po
+++ b/web/profiles/dpl_cms/translations/da.po
@@ -1822,14 +1822,16 @@ msgstr ""
 "vises dette link i beskeden til brugeren"
 
 msgctxt "Library Agency Configuration"
-msgid "Thresholds"
-msgstr "Varsler"
+msgid "Expiration warning"
+msgstr "Udløbsadvarsel"
 
 msgctxt "Library Agency Configuration"
-msgid "Set thresholds"
-msgstr ""
-"Angivelse af hvor mange dage før udløb bruger skal modtage et varsel "
-""
+msgid "Set expiration warning"
+msgstr "Påmindelse om snarligt udløb"
+
+msgctxt "Library Agency Configuration"
+msgid "Insert the number of days before the expiration of the material, when the reminder \"Expires soon\" should appear."
+msgstr "Indsæt antallet af dage, før udløb af materialet, hvor påmindelsen \"Udløber snart\" skal dukke op."
 
 msgctxt "Library Agency Configuration"
 msgid "Excluded branches"


### PR DESCRIPTION
…on_warning_days_before_config' number field. Also did some refactoring where the field is being used.

#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-150

#### Description

This PR is only for a smaller part of DDFLSBP-150 (the threshold changes). 

I have changed the "threshold_config" textfield form field into "expiration_warning_days_before_config" numbers field. This mean that we no longer set both a danger and warning configuration, but only the warning configuration. The changes for the react apps have already been done and merged in this issue: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/669 

#### Screenshot of the result
![Screenshot 2023-11-15 at 09 24 12](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/6142323/2b9647c0-3195-4a1f-bff8-66746e5b5e47)
