### PR TITLE
Fix cookies in cypress

### DIFF
--- a/cypress/e2e/adgangsplatformen.cy.ts
+++ b/cypress/e2e/adgangsplatformen.cy.ts
@@ -1,7 +1,5 @@
 describe("Adgangsplatformen", () => {
-  // Test is failing because of an "access denied" error after end authentication.
-  // TODO: Fix this test.
-  it.skip("supports login", () => {
+  it("supports login", () => {
     const authorizationCode = "7c5e3213aea6ef42ec97dfeaa6f5b1d454d856dc";
     const accessToken = "447131b0a03fe0421204c54e5c21a60d70030fd1";
     const userGuid = "19a4ae39-be07-4db9-a8b7-8bbb29f03da6";

--- a/cypress/e2e/campaign.cy.ts
+++ b/cypress/e2e/campaign.cy.ts
@@ -6,9 +6,7 @@ const campaigns = {
   rankingOrCampaign: "An OR campaign for testing ranking matching",
 } as const;
 
-// Tests are failing because of an "access denied" error after end authentication.
-// TODO: Fix this tests.
-describe.skip("Campaign creation and endpoint", () => {
+describe("Campaign creation and endpoint", () => {
   it("Select the expected campaign based on OR rules", () => {
     cy.api("POST", "/dpl_campaign/match", [
       {

--- a/cypress/e2e/dpl-react-apps.cy.ts
+++ b/cypress/e2e/dpl-react-apps.cy.ts
@@ -1,7 +1,5 @@
 describe("DPL React Apps", () => {
-  // Test is failing because of an "access denied" error after end authentication.
-  // TODO: Fix this test.
-  it.skip("exposes tokens", () => {
+  it("exposes tokens", () => {
     // These dummy values resemble what is used in production scenarios.
     const libraryAccessToken = "447131b0a03fe0421204c54e5c21a60d70030fd2";
     const authorizationCode = "7c5e3213aea6ef42ec97dfeaa6f5b1d454d856dc";

--- a/cypress/e2e/mapp-tracking.cy.ts
+++ b/cypress/e2e/mapp-tracking.cy.ts
@@ -1,7 +1,5 @@
 describe("Mapp Tracking", () => {
-  // Test is failing because of an "access denied" error after end authentication.
-  // TODO: Fix this test.
-  it.skip("tracks page views", () => {
+  it("tracks page views", () => {
     const customerId = "1234";
 
     // Mapp will not perform requests if wt_r cookie is set so clear it before

--- a/cypress/e2e/withMappings/user-journey.cy.ts
+++ b/cypress/e2e/withMappings/user-journey.cy.ts
@@ -41,9 +41,7 @@ describe("User journey", () => {
     );
   });
 
-  // Test is failing because of an "access denied" error after end authentication.
-  // TODO: Fix this test.
-  it.skip("Can open reservation modal & reserve a material", () => {
+  it("Can open reservation modal & reserve a material", () => {
     const authorizationCode = "7c5e3213aea6ef42ec97dfeaa6f5b1d454d856dc";
     const accessToken = "447131b0a03fe0421204c54e5c21a60d70030fd1";
     const userGuid = "19a4ae39-be07-4db9-a8b7-8bbb29f03da6";

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -166,6 +166,28 @@ Cypress.Commands.add(
       },
     });
 
+    cy.createMapping({
+      request: {
+        method: "GET",
+        urlPath: "/external/agencyid/patrons/patronid/v2",
+        headers: {
+          Authorization: {
+            equalTo: `Bearer ${accessToken}`,
+          },
+        },
+      },
+      response: {
+        jsonBody: {
+          authenticateStatus: "VALID",
+          patron: {
+            // This is not a complete patron object but with regards to login we only need to ensure an empty blocked
+            // status so we leave out all other information.
+            blockStatus: [],
+          },
+        },
+      },
+    });
+
     cy.visit("/user/login");
     cy.contains("Log in with Adgangsplatformen").click();
   }

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,7 +14,7 @@ services:
       YARN_CACHE_FOLDER: '/app/.cache/yarn'
 
   cypress:
-    image: cypress/included:10.8.0
+    image: cypress/included:13.5.0
     volumes:
       - 'projectroot:/app'
       - './cypress/tsconfig.json:/app/tsconfig.json'


### PR DESCRIPTION
#### Description

Previously we had disabled some Cypress tests because we could not get login to work because of an issue with Cypress.

I took another look at it and as I see it it works again now:

1. I could just reenable a couple of the CMS tests and they ran locally
2. By tailing the Wiremock logs I could see that there was an unmatched request to FBS when logging in with Adgangsplatformen. This causes the login to fail - probably because of #410. I added a mock to fix this. Now tests which require login with Adgangsplatformen also runs locally.

I wonder why this change occurs. Perhaps it has something to do with the upgrade to Cypress 13.5.0 in #468. Anyway it is nice to have more Cypress tests working again.