### PR TITLE
Use ARM-compatible Docker images for better support on new Macs

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -34,7 +34,7 @@ services:
     # We use wiremock-gui as it exposes a UI for inspecting the state of
     # WireMock. This can make debugging easier. It can seamlessly be replaced
     # with the official wiremock/wiremock image.
-    image: wiremock/wiremock:2.32.0-alpine
+    image: wiremock/wiremock:2.32.0
     # The following options are used:
     # --enable-browser-proxying: Allows Wiremock to intercept all traffic from
     # services  with HTTP(s)_PROXY pointing at it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
 
   mariadb: # Main site database.
     # https://docs.lagoon.sh/lagoon/docker-images/mariadb/mariadb-drupal
-    image: uselagoon/mariadb-drupal:latest
+    image: uselagoon/mariadb-10.6-drupal:latest
     labels:
       lagoon.type: mariadb
     # Do a periodic healthcheck. This is mainly used to block the php service


### PR DESCRIPTION
#### Description

Docker will issue warnings when starting database and Wiremock images because they are not available for ARM architecture.

To address this we update to images which are.

For Wiremock the change matches what we already want to do for the React components.

For the database image we explicitly have to change to a different image as Lagoon for whatever reason does not provide an ARM-compatible build  for uselagoon/mariadb-drupal. 

Switching to an image that is, uselagoon/mariadb-10.6-drupal, seems to be a good idea, so we are aware of what version of mariadb we are actually using.
