### PR TITLE
Create clear difference between what is dashboard and what is user profile links (don't merge b4 dpl-react)

### DIFF
--- a/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
+++ b/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
@@ -95,7 +95,7 @@ class PatronMenuBlock extends BlockBase implements ContainerFactoryPluginInterfa
     // generated menu. A place for further improvements.
     $menu = [
       [
-        "name" => $this->t("My account", ["context" => 'Patron menu']),
+        "name" => $this->t("Dashboard", ["context" => 'Patron menu']),
         "link" => dpl_react_apps_ensure_url_is_string(
           Url::fromRoute('dpl_dashboard.list', [], ['absolute' => TRUE])->toString()
         ),
@@ -155,7 +155,7 @@ class PatronMenuBlock extends BlockBase implements ContainerFactoryPluginInterfa
       ),
       "menu-sign-up-url" => Url::fromRoute('dpl_patron_reg.information', [], ['absolute' => TRUE])->toString(),
       'ereolen-my-page-url' => $generalSettings->get('ereolen_my_page_url'),
-      'menu-view-your-profile-text-url' => Url::fromRoute('dpl_patron_page.profile', [], ['absolute' => TRUE])->toString(),
+      'user-profile-url' => Url::fromRoute('dpl_patron_page.profile', [], ['absolute' => TRUE])->toString(),
 
       // Texts.
       'dashboard-number-in-line-text' => $this->t('Number @count in line', [], ['context' => 'Patron menu']),
@@ -216,7 +216,7 @@ class PatronMenuBlock extends BlockBase implements ContainerFactoryPluginInterfa
       'menu-profile-links-aria-label-text' => $this->t('Profile links', [], ['context' => 'Patron menu (aria)']),
       'menu-sign-up-text' => $this->t('Sign up', [], ['context' => 'Patron menu']),
       'menu-user-icon-aria-label-text' => $this->t('Open user menu', [], ['context' => 'Patron menu (aria)']),
-      'menu-view-your-profile-text' => $this->t('My Account', [], ['context' => 'Patron menu']),
+      'menu-user-profile-url-text' => $this->t('My Account', [], ['context' => 'Patron menu']),
       'physical-reservations-header-text' => $this->t('Physical reservations', [], ['context' => 'Patron menu']),
       'pick-up-latest-text' => $this->t('Pick up before @date', [], ['context' => 'Patron menu']),
       'ready-for-loan-counter-label-text' => $this->t('Ready', [], ['context' => 'Patron menu']),


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-237

#### Description

Create clear difference between what is dashboard and what is user profile links.



#### Additional comments or questions

Don't merge befor this has been merged:
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/702