### PR TITLE
Setup local environments for development but ensure performant environments for CI

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -127,6 +127,8 @@ tasks:
       # packages may change without composer package version changes so ensure
       # we have the latest version.
       - task dev:cli -- composer reinstall danskernesdigitalebibliotek/dpl-design-system danskernesdigitalebibliotek/dpl-react --no-cache
+      # (Re)run Drupal scaffolding.
+      - task dev:cli -- composer drupal:scaffold
       # Build dev scripts
       - task dev:cli -- $(cd dev-scripts/dpl-react; composer install)
       # Pull the images (necessary for the first reset)

--- a/assets/local.services.yml
+++ b/assets/local.services.yml
@@ -1,0 +1,6 @@
+parameters:
+  twig.config:
+    debug: true
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/assets/local.settings.php
+++ b/assets/local.settings.php
@@ -1,0 +1,11 @@
+<?php
+
+# Enable verbose error reporting.
+$config['system.logging']['error_level'] = 'verbose';
+
+# Disable preprocessing
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+
+# Disable caching.
+$settings['cache']['default'] = 'cache.backend.null';

--- a/composer.json
+++ b/composer.json
@@ -186,6 +186,8 @@
             "file-mapping": {
                 "[web-root]/sites/default/all.settings.php": "assets/all.settings.php",
                 "[web-root]/sites/default/development.settings.php": "assets/development.settings.php",
+                "[web-root]/sites/default/local.services.yml": "assets/local.services.yml",
+                "[web-root]/sites/default/local.settings.php": "assets/local.settings.php",
                 "[web-root]/.eslintrc.json": false,
                 "[project-root]/.gitattributes": {
                     "append": "assets/.gitattributes"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dcec061077652a1daed1cbd8765384ed",
+    "content-hash": "2c4f64130d06cfc592361366edad5c1b",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -57,6 +57,7 @@ services:
   cli:
     environment:
       CI: true
+      LAGOON_ENVIRONMENT_TYPE: ci
 
   php:
     depends_on:
@@ -65,3 +66,4 @@ services:
       http_proxy: http://wiremock:80
       https_proxy: https://wiremock:443
       CI: true
+      LAGOON_ENVIRONMENT_TYPE: ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ x-environment:
     # Environment variables which mimic what will be set in a Lagoon cluster locally
     LAGOON_PROJECT: 'dplcms'
     LAGOON_ENVIRONMENT: 'local'
+    LAGOON_ENVIRONMENT_TYPE: 'local'
     WEBROOT: web
     # Uncomment if you like to have the system behave like in production
     #LAGOON_ENVIRONMENT_TYPE: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ x-environment:
     # Environment variables which mimic what will be set in a Lagoon cluster locally
     LAGOON_PROJECT: 'dplcms'
     LAGOON_ENVIRONMENT: 'local'
-    LAGOON_ENVIRONMENT_TYPE: 'local'
+    LAGOON_ENVIRONMENT_TYPE: ${LAGOON_ENVIRONMENT_TYPE:-local}
     WEBROOT: web
     # Uncomment if you like to have the system behave like in production
     #LAGOON_ENVIRONMENT_TYPE: production

--- a/web/sites/default/.gitignore
+++ b/web/sites/default/.gitignore
@@ -2,4 +2,6 @@
 /development.settings.php
 /default.development.services.yml
 /default.services.yml
+/local.settings.php
+/local.services.yml
 /settings.lagoon.php


### PR DESCRIPTION
#### Description

Developers would like their local environment to behave in certain ways to improve the development experience and speed. This includes:

- Adding Twig debug information to HTML output
- Be verbose about errors
- Not preprocessing JS and CSS assets
- Disabling cache

We can enable this by defining a new [Lagoon environment type](https://docs.lagoon.sh/using-lagoon-advanced/environment-types/), `local` and [using Lagoons environment type loading feature](https://github.com/danskernesdigitalebibliotek/dpl-cms/tree/develop/assets) to load settings and services for this type.

However some of these features have a negative impact on performance. Not preprocessing frontend assets hurts Lighthouse scores. This makes our CI tests fail.

To address this we only use the `local` environment as a fallback but use different environment types when setting up a site for continuous integration testing - and on Lagoon.

To test this do the following:

1. Checkout the PR, run `task dev:reset` and see that JS and CSS files are not aggregated. This is a sign that the settings for the `local` type is enabled.
2. Observe that Lighthouse tests are not failing. This is a sign that `local` settings for the environment are not enabled.
3. Go to the Lagoon environment for this PR and see that JS and CSS files are ~~not~~ aggregated. This is a sign that `local` settings for the environment are not enabled.