### PR TITLE
Canonical

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "drupal/default_content": "^2.0@alpha",
         "drupal/devel": "~5.0.2",
         "drupal/enum_field": "^1.0",
+        "drupal/field_group": "^3.4",
         "drupal/gin": "^3.0@RC",
         "drupal/gin_toolbar": "^1.0@RC",
         "drupal/handy_cache_tags": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
         "drupal/jsonlog": "^4.0",
         "drupal/libraries": "^4.0",
         "drupal/linkit": "^6.0",
+        "drupal/metatag": "^2.0",
         "drupal/openapi": "^2.1",
         "drupal/openapi_rest": "^2.0@RC",
         "drupal/openid_connect": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "974ac704d4602bc6f334f3d5d754009a",
+    "content-hash": "370f8b73e84dadf387344d60cfe0d60b",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2933,6 +2933,71 @@
             "homepage": "https://www.drupal.org/project/enum_field",
             "support": {
                 "source": "https://git.drupalcode.org/project/enum_field"
+            }
+        },
+        {
+            "name": "drupal/field_group",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/field_group.git",
+                "reference": "8.x-3.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/field_group-8.x-3.4.zip",
+                "reference": "8.x-3.4",
+                "shasum": "80b937e1a11f8b29c69d853fc4bf798c057c6f94"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.4",
+                    "datestamp": "1667241979",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Anybody",
+                    "homepage": "https://www.drupal.org/user/291091"
+                },
+                {
+                    "name": "Hydra",
+                    "homepage": "https://www.drupal.org/user/647364"
+                },
+                {
+                    "name": "jyve",
+                    "homepage": "https://www.drupal.org/user/591438"
+                },
+                {
+                    "name": "nils.destoop",
+                    "homepage": "https://www.drupal.org/user/361625"
+                },
+                {
+                    "name": "Stalski",
+                    "homepage": "https://www.drupal.org/user/322618"
+                },
+                {
+                    "name": "swentel",
+                    "homepage": "https://www.drupal.org/user/107403"
+                }
+            ],
+            "description": "Provides the field_group module.",
+            "homepage": "https://www.drupal.org/project/field_group",
+            "support": {
+                "source": "https://git.drupalcode.org/project/field_group",
+                "issues": "https://www.drupal.org/project/issues/field_group"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca5f7282f4ebf1fa97091a846e16dc26",
+    "content-hash": "974ac704d4602bc6f334f3d5d754009a",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -3363,6 +3363,73 @@
             }
         },
         {
+            "name": "drupal/metatag",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/metatag.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/metatag-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "2966c854d982b7069b1c0111519427990ebbad40"
+            },
+            "require": {
+                "drupal/core": "^9.4 || ^10",
+                "drupal/token": "^1.0",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "drupal/devel": "^4.0 || ^5.0",
+                "drupal/hal": "^9 || ^1 || ^2",
+                "drupal/metatag_dc": "*",
+                "drupal/metatag_open_graph": "*",
+                "drupal/page_manager": "^4.0",
+                "drupal/redirect": "^1.0",
+                "drupal/webprofiler": "^9 || ^10",
+                "mpyw/phpunit-patch-serializable-comparison": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1692368265",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "See contributors",
+                    "homepage": "https://www.drupal.org/node/640498/committers",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                }
+            ],
+            "description": "Manage meta tags for all entities.",
+            "homepage": "https://www.drupal.org/project/metatag",
+            "keywords": [
+                "Drupal",
+                "seo"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/metatag",
+                "issues": "https://www.drupal.org/project/issues/metatag",
+                "docs": "https://www.drupal.org/docs/8/modules/metatag"
+            }
+        },
+        {
             "name": "drupal/openapi",
             "version": "2.1.0",
             "source": {
@@ -4122,6 +4189,75 @@
             "homepage": "https://www.drupal.org/project/schemata",
             "support": {
                 "source": "https://git.drupalcode.org/project/schemata"
+            }
+        },
+        {
+            "name": "drupal/token",
+            "version": "1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/token.git",
+                "reference": "8.x-1.13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/token-8.x-1.13.zip",
+                "reference": "8.x-1.13",
+                "shasum": "f2a074b51726de3727c1d900237d6d471806a4d2"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.13",
+                    "datestamp": "1697885927",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": ">=9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "eaton",
+                    "homepage": "https://www.drupal.org/user/16496"
+                },
+                {
+                    "name": "fago",
+                    "homepage": "https://www.drupal.org/user/16747"
+                },
+                {
+                    "name": "greggles",
+                    "homepage": "https://www.drupal.org/user/36762"
+                },
+                {
+                    "name": "mikeryan",
+                    "homepage": "https://www.drupal.org/user/4420"
+                }
+            ],
+            "description": "Provides a user interface for the Token API, some missing core tokens.",
+            "homepage": "https://www.drupal.org/project/token",
+            "support": {
+                "source": "https://git.drupalcode.org/project/token"
             }
         },
         {

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -25,10 +25,13 @@ ignored_config_entities:
   - '~core.entity_view_display.node.campaign.*'
   - '~core.entity_view_display.node.event.*'
   - '~core.entity_view_display.paragraph.campaign_rule.*'
+  - '~core.entity_view_mode.block.*'
   - '~core.entity_view_mode.display.*'
+  - '~core.entity_view_mode.file.*'
   - '~core.entity_view_mode.node.*'
   - '~core.entity_view_mode.paragraph.*'
-  - ~core.date_format.date_full_month
+  - '~core.entity_view_mode.path_alias.*'
+  - '~core.entity_view_mode.user.*'
   - ~core.menu.static_menu_link_overrides
   - ~dblog.settings
   - '~dpl_library_agency.general_settings:reservation_sms_notifications_disabled'
@@ -72,6 +75,8 @@ ignored_config_entities:
   - ~language.content_settings.node.article
   - ~language.types
   - ~locale.settings
+  - '~metatag.metatag_defaults.*'
+  - '~metatag.settings.*'
   - ~node.settings
   - ~node.type.campaign
   - ~node.type.article

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -10,10 +10,29 @@ dependencies:
     - field.field.node.article.field_subtitle
     - node.type.article
   module:
+    - field_group
     - link
     - paragraphs
     - paragraphs_ee
     - paragraphs_features
+third_party_settings:
+  field_group:
+    group_article_meta_tags:
+      children:
+        - field_canonical_url
+      label: 'Meta tags'
+      region: content
+      parent_name: ''
+      weight: 7
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+        weight: 0
 id: node.article.default
 targetEntityType: node
 bundle: article

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -3,12 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.article.field_canonical_url
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
     - field.field.node.article.field_subtitle
     - node.type.article
   module:
+    - link
     - paragraphs
     - paragraphs_ee
     - paragraphs_features
@@ -17,6 +19,14 @@ targetEntityType: node
 bundle: article
 mode: default
 content:
+  field_canonical_url:
+    type: link_default
+    weight: 6
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   field_override_author:
     type: string_textfield
     weight: 5

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -45,5 +45,6 @@ content:
     weight: 100
     region: content
 hidden:
+  field_canonical_url: true
   field_paragraphs: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.article.full.yml
+++ b/config/sync/core.entity_view_display.node.article.full.yml
@@ -39,6 +39,7 @@ content:
     weight: 1
     region: content
 hidden:
+  field_canonical_url: true
   field_override_author: true
   field_show_override_author: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -21,6 +21,7 @@ content:
     weight: 100
     region: content
 hidden:
+  field_canonical_url: true
   field_override_author: true
   field_paragraphs: true
   field_show_override_author: true

--- a/config/sync/core.entity_view_mode.block.token.yml
+++ b/config/sync/core.entity_view_mode.block.token.yml
@@ -1,0 +1,10 @@
+uuid: de5d9c01-e7eb-40c7-9865-60d6735d2953
+langcode: en
+status: true
+dependencies:
+  module:
+    - block
+id: block.token
+label: Token
+targetEntityType: block
+cache: true

--- a/config/sync/core.entity_view_mode.file.token.yml
+++ b/config/sync/core.entity_view_mode.file.token.yml
@@ -1,0 +1,10 @@
+uuid: 2bceed1c-7923-402e-8148-5af808b2184d
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.token
+label: Token
+targetEntityType: file
+cache: true

--- a/config/sync/core.entity_view_mode.node.token.yml
+++ b/config/sync/core.entity_view_mode.node.token.yml
@@ -1,0 +1,10 @@
+uuid: 057a2691-b2d3-4b86-ab7e-7e40c7d52804
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.token
+label: Token
+targetEntityType: node
+cache: true

--- a/config/sync/core.entity_view_mode.paragraph.token.yml
+++ b/config/sync/core.entity_view_mode.paragraph.token.yml
@@ -1,0 +1,10 @@
+uuid: 57e6c650-f516-4607-9372-93df112f3f04
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.token
+label: Token
+targetEntityType: paragraph
+cache: true

--- a/config/sync/core.entity_view_mode.path_alias.token.yml
+++ b/config/sync/core.entity_view_mode.path_alias.token.yml
@@ -1,0 +1,10 @@
+uuid: 4b6af08f-f060-487b-9e45-3380ea2da032
+langcode: en
+status: true
+dependencies:
+  module:
+    - path_alias
+id: path_alias.token
+label: Token
+targetEntityType: path_alias
+cache: true

--- a/config/sync/core.entity_view_mode.user.token.yml
+++ b/config/sync/core.entity_view_mode.user.token.yml
@@ -1,0 +1,10 @@
+uuid: e79f737a-8035-43ee-bd26-01ac9d2891d1
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.token
+label: Token
+targetEntityType: user
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -51,6 +51,7 @@ module:
   link: 0
   linkit: 0
   locale: 0
+  metatag: 0
   mysql: 0
   node: 0
   openapi: 0
@@ -72,6 +73,7 @@ module:
   serialization: 0
   system: 0
   text: 0
+  token: 0
   toolbar: 0
   twig_tweak: 0
   update: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -40,6 +40,7 @@ module:
   entity_reference_revisions: 0
   enum_field: 0
   field: 0
+  field_group: 0
   file: 0
   filter: 0
   gin_toolbar: 0

--- a/config/sync/field.field.node.article.field_canonical_url.yml
+++ b/config/sync/field.field.node.article.field_canonical_url.yml
@@ -1,0 +1,23 @@
+uuid: 1fc91541-e90f-40ae-b7c3-826de8bdd1f2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_canonical_url
+    - node.type.article
+  module:
+    - link
+id: node.article.field_canonical_url
+field_name: field_canonical_url
+entity_type: node
+bundle: article
+label: 'Canonical url'
+description: 'Please provide a canonical URL if this content has been duplicated from other websites. This helps signal to search engines that the preferred source of this content is the specified canonical URL, preventing potential duplicate content issues and ensuring proper attribution to the original source.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/config/sync/field.storage.node.field_canonical_url.yml
+++ b/config/sync/field.storage.node.field_canonical_url.yml
@@ -1,0 +1,19 @@
+uuid: 814bd3f2-e513-4080-9c0b-23a52e2ce6c6
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_canonical_url
+field_name: field_canonical_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/da/metatag.metatag_defaults.front.yml
+++ b/config/sync/language/da/metatag.metatag_defaults.front.yml
@@ -1,0 +1,1 @@
+label: Forside

--- a/config/sync/language/da/metatag.metatag_defaults.global.yml
+++ b/config/sync/language/da/metatag.metatag_defaults.global.yml
@@ -1,0 +1,1 @@
+label: Global

--- a/config/sync/language/da/metatag.metatag_defaults.node.yml
+++ b/config/sync/language/da/metatag.metatag_defaults.node.yml
@@ -1,0 +1,1 @@
+label: Indhold

--- a/config/sync/language/da/metatag.metatag_defaults.taxonomy_term.yml
+++ b/config/sync/language/da/metatag.metatag_defaults.taxonomy_term.yml
@@ -1,0 +1,1 @@
+label: 'Ord i ordforråd'

--- a/config/sync/language/da/metatag.metatag_defaults.user.yml
+++ b/config/sync/language/da/metatag.metatag_defaults.user.yml
@@ -1,0 +1,1 @@
+label: Bruger

--- a/config/sync/metatag.metatag_defaults.403.yml
+++ b/config/sync/metatag.metatag_defaults.403.yml
@@ -1,0 +1,12 @@
+uuid: 28ed9023-6163-4f78-b596-6063b224b9ea
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: RDCkFL0NDt75Gwioooxo1iuA1S50xTVsBOgX__c6wTw
+id: '403'
+label: '403 access denied'
+tags:
+  robots: noindex
+  canonical_url: '[site:url]'
+  shortlink: '[site:url]'

--- a/config/sync/metatag.metatag_defaults.404.yml
+++ b/config/sync/metatag.metatag_defaults.404.yml
@@ -1,0 +1,11 @@
+uuid: 5190f9f0-dbe9-4875-8736-47afb27c2221
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: puBstSLDz8mbaWU357zaqQDBGMGsJzG0j-TQNQkjg20
+id: '404'
+label: '404 page not found'
+tags:
+  canonical_url: '[site:url]'
+  shortlink: '[site:url]'

--- a/config/sync/metatag.metatag_defaults.front.yml
+++ b/config/sync/metatag.metatag_defaults.front.yml
@@ -1,0 +1,11 @@
+uuid: dd01ba9d-d442-4183-a32d-cc593998aac5
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: 1noCXlegCr5HFehQRF1ViXy1jhU1jZ_sNN99a8Sj5jo
+id: front
+label: 'Front page'
+tags:
+  canonical_url: '[site:url]'
+  shortlink: '[site:url]'

--- a/config/sync/metatag.metatag_defaults.global.yml
+++ b/config/sync/metatag.metatag_defaults.global.yml
@@ -1,0 +1,11 @@
+uuid: 754a659e-d83f-4420-a5b1-84c3fa9bbffb
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: sL588ui1E_8-2c_UupwyYxcqX2OVyMFp3HTLbbFqvPc
+id: global
+label: Global
+tags:
+  canonical_url: '[current-page:url]'
+  title: '[current-page:title] | [site:name]'

--- a/config/sync/metatag.metatag_defaults.node.yml
+++ b/config/sync/metatag.metatag_defaults.node.yml
@@ -7,6 +7,6 @@ _core:
 id: node
 label: Content
 tags:
-  title: '[node:title] | [site:name]'
+  canonical_url: '[node:field_canonical_url:uri]'
   description: '[node:summary]'
-  canonical_url: '[node:url]'
+  title: '[node:title] | [site:name]'

--- a/config/sync/metatag.metatag_defaults.node.yml
+++ b/config/sync/metatag.metatag_defaults.node.yml
@@ -1,0 +1,12 @@
+uuid: 51dde779-23be-4b75-bb05-791c8b94c9b0
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: rpwvgyEURXLz_JjgMCrkS1rUv-0k3L79BpO-ReN7fDI
+id: node
+label: Content
+tags:
+  title: '[node:title] | [site:name]'
+  description: '[node:summary]'
+  canonical_url: '[node:url]'

--- a/config/sync/metatag.metatag_defaults.taxonomy_term.yml
+++ b/config/sync/metatag.metatag_defaults.taxonomy_term.yml
@@ -1,0 +1,12 @@
+uuid: d5544dad-e445-487f-9448-30b10db54e00
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: 92bXZdyYJ5xqukdfmGRr_CYcwm1vfuS8b8aJ7X_G7E0
+id: taxonomy_term
+label: 'Taxonomy term'
+tags:
+  canonical_url: '[term:url]'
+  description: '[term:description]'
+  title: '[term:name] | [site:name]'

--- a/config/sync/metatag.metatag_defaults.user.yml
+++ b/config/sync/metatag.metatag_defaults.user.yml
@@ -1,0 +1,12 @@
+uuid: 685a5406-a296-4725-9a1b-75f48f27afee
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: MvQPTbQx0Vxwy0ordSHyixdZmLCMpvMdLD69dlwkrKc
+id: user
+label: User
+tags:
+  canonical_url: '[user:url]'
+  description: '[site:name]'
+  title: '[user:display-name] | [site:name]'

--- a/config/sync/metatag.settings.yml
+++ b/config/sync/metatag.settings.yml
@@ -1,0 +1,8 @@
+_core:
+  default_config_hash: tKLBW2GXZVLFXqS9QgLyfTuxCLc1u_quKPQLtCia-Bw
+entity_type_groups: {  }
+separator: ''
+tag_trim_method: beforeValue
+tag_trim_maxlength: {  }
+tag_scroll_max_height: ''
+use_maxlength: true


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-12

#### Description

This PR adds a new field to articles for managing the canonical url metatag.

In this process the following modules are enabled and configured: Metatag, Token and Field group.

I suggest going commit by commit for additional commentary. [c2384a4](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/498/commits/c2384a457b84e311188cf77aa1f0aa067599fbb8) is key here.

#### Screenshot of the result

<img width="1392" alt="Monosnap Create Article | DPL CMS | Logged in 2023-11-27 13-51-54" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/25f43b10-31ad-4296-9e9f-bf7cf0a10d60">

<img width="1392" alt="Monosnap Iste sint pariatur Non suscipit duis ad commodi similique earum quis in | DPL CMS 2023-11-27 13-52-50" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/f5f889b1-7ef2-4e07-b188-6a7e1d5ae97c">
