### PR TITLE
Feature/ddflsbp 194/mapp id should be have default value

### DIFF
--- a/config/sync/dpl_mapp.settings.yml
+++ b/config/sync/dpl_mapp.settings.yml
@@ -1,2 +1,2 @@
 domain: responder.wt-safetag.com
-id: ''
+id: 476651662471322


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-194

#### Description

The ID field in MAPP settings, should always be filled with the value "476651662471322". Right now, each library have to go in and add that value. This PR adds the value as part of the configuration in dpl_mapp.settings.yml.

#### Screenshot of the result

<img width="1436" alt="Screenshot 2023-11-28 at 23 12 35" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/6142323/a1fefda5-fbf1-480d-9bdc-4c2ff89a398d">

#### Additional comments or questions

N/A