### PR TITLE
DDFLSBP-188 - Added translate function for huskeliste alt string

### DIFF
--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -52,7 +52,7 @@
       {{ patron_menu }}
 			<div class="header__menu-bookmarked header__button">
 				<a href="{{ url('dpl_favorites_list.list') }}">
-					<img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt="List of bookmarks"/>
+					<img src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt={{ 'List of bookmarks'|t({}, {'context' : 'Header'}) }}/>
 				</a>
 			</div>
 		</nav>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-188

#### Description

Added translation function to the farorites (huskeliste) icon alt text in the header.

#### Screenshot of the result

<img width="1909" alt="Screenshot 2023-11-29 at 15 01 20" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/6142323/cecb7c9a-673f-494c-8093-1b2bac35aa88">


#### Additional comments or questions

The above screenshot shows the translated alt string (locally, needs to be translated in poeditor.
