### PR TITLE
XDebug improvements

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -157,6 +157,12 @@ tasks:
     cmds:
       - task dev:cli -- drush install -y field_ui views_ui
 
+  dev:enable-xdebug:
+    cmds:
+      - XDEBUG_ENABLE=true task dev:start
+      - read -p "Press enter to disable Xdebug"
+      - task dev:start
+
   dev:phpunit:
     desc: Run PHPUnit tests with code coverage
     cmds:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,8 +109,7 @@ services:
     <<: [*default-volumes, *default-user]
     environment:
       << : *default-environment # loads the defined environment variables from the top
-      # Uncomment to enable xdebug for web requests and then restart via `docker-compose up -d`
-      #XDEBUG_ENABLE: "true"
+      XDEBUG_ENABLE: ${XDEBUG_ENABLE:-false}
     labels:
       lagoon.type: nginx-php-persistent
       lagoon.name: nginx # we want this service be part of the nginx pod in Lagoon

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -31,6 +31,24 @@ volumes  in docker-compose, to speed up the containers.
 
 ## Howtos
 
+### Enable XDebug
+
+Prerequisites:
+
+* An IDE with support for XDebug e.g. JetBrains PhpStorm
+* Optionally: [A browser extension to activate XDebug](https://xdebug.org/docs/step_debug#browser-extensions)
+
+For performance reasons XDebug is disabled by default. It can be enabled
+temporarily through a task:
+
+1. Run `task dev:enable-xdebug`
+2. Validate that XDebug is enabled by inspecting <http://dpl-cms.docker/admin/reports/status/php>.
+   It should contain extended information about XDebug
+3. Debug the application by setting breakpoints, listen for incoming
+   connections in your IDE and [activate XDebug from you client/browser](https://xdebug.org/docs/step_debug#web-application)
+4. When you are finished, hit `enter` in the terminal where you enabled XDebug.
+   This will disable XDebug
+
 ### Copy database from Lagoon environment to local setup
 
 Prerequisites:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -29,7 +29,9 @@ volumes  in docker-compose, to speed up the containers.
 
 ![OSX preference pane providing access to VirtioFS](docs/images/virtiofs.png)
 
-## Copy database from Lagoon environment to local setup
+## Howtos
+
+### Copy database from Lagoon environment to local setup
 
 Prerequisites:
 
@@ -48,7 +50,7 @@ database, not any files from the site.
 3. Start a local environment using `task dev:reset`
 4. Import the database by running `task dev:restore:database`
 
-## Copy files from Lagoon environment to local setup
+### Copy files from Lagoon environment to local setup
 
 Prerequisites:
 


### PR DESCRIPTION
#### Description

This PR adds a task to enable XDebug temporarily for the PHP container and documents it.

[According to the documentation XDebug is only enabled if the `XDEBUG_ENABLE` environment variable for the PHP container is true](https://docs.lagoon.sh/using-lagoon-advanced/setting-up-xdebug-with-lagoon/
). Having to uncomment a line is a bit inelegant as it requires file changes and hard to discover.

Instead of doing this we instead allow `XDEBUG_ENABLE` to be set from the outside and fall back to `false` if not. This ensures that XDebug is still disabled by default.

Now we can create a new task which sets `XDEBUG_ENABLE` to `true` while recreating the containers and waiting for further input.

When the developer is done containers are recreated without the environment variable set and thus without XDebug enabled.

#### Additional comments or questions

You should be able to test whether this works by following the documentation :smile:

The PR environment does not have XDebug enabled which should ensure that this only affects local environments.