### PR TITLE
Add Date/Dates in Event

### DIFF
--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -1,0 +1,30 @@
+uuid: 28652de7-8cc2-44ba-b572-392734827ea0
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.full
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_state
+    - node.type.event
+  module:
+    - datetime_range
+    - user
+id: node.event.full
+targetEntityType: node
+bundle: event
+mode: full
+content:
+  field_event_date:
+    type: daterange_plain
+    label: hidden
+    settings:
+      timezone_override: ''
+      separator: '-'
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_event_state: true
+  langcode: true
+  links: true

--- a/web/themes/custom/novel/templates/fields/field--node--field-event-date.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-event-date.html.twig
@@ -1,0 +1,27 @@
+{% for item in items %}
+	{% set start_date = item.content.start_date["#markup"]|date("U") %}
+	{% set end_date = item.content.end_date["#markup"]|date("U") %}
+
+	{% set start_day = start_date|date("j.") %}
+	{% set start_month = start_date|date("M") %}
+	{% set start_year = start_date|date("Y") %}
+	{% set end_day = end_date|date("j.") %}
+	{% set end_month = end_date|date("M") %}
+	{% set end_year = end_date|date("Y") %}
+
+	<time{{item.attributes.addClass(["event-header__date"])}}>
+		{% if start_day == end_day and start_month == end_month and start_year == end_year %}
+			{# Same day #}
+			{{ start_day ~ ' ' ~ start_month ~ ' ' ~ start_year }}
+		{% elseif start_month == end_month and start_year == end_year %}
+			{# Same month #}
+			{{ start_day ~ ' - ' ~ end_day ~ ' ' ~ start_month ~ ' ' ~ start_year }}
+		{% elseif start_year == end_year %}
+			{# Different months, same year #}
+			{{ start_day ~ ' ' ~ start_month ~ ' - ' ~ end_day ~ ' ' ~ end_month ~ ' ' ~ start_year }}
+		{% else %}
+			{# Different years #}
+			{{ start_date|date("j. M Y") ~ ' - ' ~ end_date|date("j. M Y") }}
+		{% endif %}
+	</time>
+{% endfor %}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -1,0 +1,14 @@
+<article{{ attributes.addClass('event-page') }}>
+  <header class="event-header">
+    <section class="event-header__content">
+        <!-- Tag -->
+        <!-- dates -->
+        <h1 class="event-header__title">{{ label }}</h1>
+      <!-- button -->
+    </section>
+    <section class="event-header__visual">
+      <!-- image -->
+    </section>
+  </header>
+  {{ content }}
+</article>

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -2,7 +2,7 @@
   <header class="event-header">
     <section class="event-header__content">
         <!-- Tag -->
-        <!-- dates -->
+       {{content.field_event_date}}
         <h1 class="event-header__title">{{ label }}</h1>
       <!-- button -->
     </section>
@@ -10,5 +10,5 @@
       <!-- image -->
     </section>
   </header>
-  {{ content }}
+  {{ content|without('field_event_date') }}
 </article>


### PR DESCRIPTION
> [!WARNING]  
> Depend on: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/512
> Check only this commit: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/518/commits/098404bf4b13919977e785a9bb73ed31c3958611

#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-16

#### Description

This pull request introduces updates to the way event dates are displayed within event nodes. 

The following changes have been implemented:

**Event Date Formatting Template:**
* Developed a new Twig template (`web/themes/custom/novel/templates/fields/field--node--field-event-date.html.twig`) to improve how dates are shown on event nodes. This template offers a more readable and visually appealing date format.
* It is designed to handle various date scenarios, such as events on the same day or in the same month, ensuring a comprehensive approach to date display.

These updates aim to provide users with a clearer, more intuitive way to view event dates. By enhancing the display of dates, this pull request seeks to make event information more accessible and easier to understand.



#### Screenshot of the result
**Same start and end date**
<img width="401" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/7580ba47-4925-4151-b92e-891af7a6f288">

**Same month and year**
<img width="401" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/7732e8ac-5de4-453e-9cb2-9dcbb0fb2a00">

**Different year**
<img width="401" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/5c57abbc-d1f7-41c9-bd09-d19266485ed3">
