### PR TITLE
Add 'Description' Field and Necessary Markup to `event` Content-Type

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -41,11 +41,13 @@ ignored_config_entities:
   - ~field.field.node.article.field_override_author
   - ~field.field.node.article.field_show_override_author
   - ~field.field.node.article.field_subtitle
+  - ~field.field.node.event.field_event_description
   - ~field.settings
   - ~field.storage.node.body
   - ~field.storage.node.field_campaign_image
   - ~field.storage.node.field_campaign_rules
   - ~field.storage.node.field_campaign_text
+  - ~field.storage.node.field_event_description
   - ~field.storage.node.field_override_author
   - ~field.storage.node.field_show_override_author
   - ~field.storage.node.field_subtitle

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -4,10 +4,12 @@ status: true
 dependencies:
   config:
     - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_description
     - field.field.node.event.field_event_state
     - node.type.event
   module:
     - datetime_range
+    - text
 id: node.event.default
 targetEntityType: node
 bundle: event
@@ -18,6 +20,14 @@ content:
     weight: 27
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_event_description:
+    type: text_textarea
+    weight: 28
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   field_event_state:
     type: options_select

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -4,15 +4,24 @@ status: true
 dependencies:
   config:
     - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_description
     - field.field.node.event.field_event_state
     - node.type.event
   module:
+    - text
     - user
 id: node.event.default
 targetEntityType: node
 bundle: event
 mode: default
 content:
+  field_event_description:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_description
     - field.field.node.event.field_event_state
     - node.type.event
   module:
     - datetime_range
+    - text
     - user
 id: node.event.full
 targetEntityType: node
@@ -23,6 +25,13 @@ content:
       separator: '-'
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_event_description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_event_state: true

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -1,0 +1,30 @@
+uuid: 28652de7-8cc2-44ba-b572-392734827ea0
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.full
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_state
+    - node.type.event
+  module:
+    - datetime_range
+    - user
+id: node.event.full
+targetEntityType: node
+bundle: event
+mode: full
+content:
+  field_event_date:
+    type: daterange_plain
+    label: hidden
+    settings:
+      timezone_override: ''
+      separator: '-'
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_event_state: true
+  langcode: true
+  links: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_description
     - field.field.node.event.field_event_state
     - node.type.event
   module:
@@ -21,5 +22,6 @@ content:
     region: content
 hidden:
   field_event_date: true
+  field_event_description: true
   field_event_state: true
   langcode: true

--- a/config/sync/field.field.node.event.field_event_description.yml
+++ b/config/sync/field.field.node.event.field_event_description.yml
@@ -1,0 +1,21 @@
+uuid: 25c94419-61d0-467d-ac68-6d763a31f1b4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_description
+    - node.type.event
+  module:
+    - text
+id: node.event.field_event_description
+field_name: field_event_description
+entity_type: node
+bundle: event
+label: 'Event description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.storage.node.field_event_description.yml
+++ b/config/sync/field.storage.node.field_event_description.yml
@@ -1,0 +1,19 @@
+uuid: 09fe33bc-0760-43d8-a179-8f6faea14d95
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_event_description
+field_name: field_event_description
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/da/views.view.files.yml
+++ b/config/sync/language/da/views.view.files.yml
@@ -26,6 +26,8 @@ display:
           label: Ændringsdato
         count:
           label: 'Brugt i'
+          alter:
+            path: 'admin/content/files/usage/{{ fid }}'
       pager:
         options:
           tags:

--- a/config/sync/language/da/views.view.user_admin_people.yml
+++ b/config/sync/language/da/views.view.user_admin_people.yml
@@ -19,8 +19,14 @@ display:
           label: Roller
         created:
           label: 'Medlem i'
+          settings:
+            future_format: '@interval'
+            past_format: '@interval'
         access:
           label: 'Seneste tilgang'
+          settings:
+            future_format: 'om @interval'
+            past_format: '@interval siden'
         operations:
           label: Handlinger
         mail:

--- a/web/themes/custom/novel/templates/fields/field--node--field-event-date.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-event-date.html.twig
@@ -1,0 +1,27 @@
+{% for item in items %}
+	{% set start_date = item.content.start_date["#markup"]|date("U") %}
+	{% set end_date = item.content.end_date["#markup"]|date("U") %}
+
+	{% set start_day = start_date|date("j.") %}
+	{% set start_month = start_date|date("M") %}
+	{% set start_year = start_date|date("Y") %}
+	{% set end_day = end_date|date("j.") %}
+	{% set end_month = end_date|date("M") %}
+	{% set end_year = end_date|date("Y") %}
+
+	<time{{item.attributes.addClass(["event-header__date"])}}>
+		{% if start_day == end_day and start_month == end_month and start_year == end_year %}
+			{# Same day #}
+			{{ start_day ~ ' ' ~ start_month ~ ' ' ~ start_year }}
+		{% elseif start_month == end_month and start_year == end_year %}
+			{# Same month #}
+			{{ start_day ~ ' - ' ~ end_day ~ ' ' ~ start_month ~ ' ' ~ start_year }}
+		{% elseif start_year == end_year %}
+			{# Different months, same year #}
+			{{ start_day ~ ' ' ~ start_month ~ ' - ' ~ end_day ~ ' ' ~ end_month ~ ' ' ~ start_year }}
+		{% else %}
+			{# Different years #}
+			{{ start_date|date("j. M Y") ~ ' - ' ~ end_date|date("j. M Y") }}
+		{% endif %}
+	</time>
+{% endfor %}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -1,0 +1,14 @@
+<article{{ attributes.addClass('event-page') }}>
+  <header class="event-header">
+    <section class="event-header__content">
+        <!-- Tag -->
+        <!-- dates -->
+        <h1 class="event-header__title">{{ label }}</h1>
+      <!-- button -->
+    </section>
+    <section class="event-header__visual">
+      <!-- image -->
+    </section>
+  </header>
+  {{ content }}
+</article>

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -1,14 +1,27 @@
-<article{{ attributes.addClass('event-page') }}>
+<article {{ attributes.addClass('event-page') }}>
   <header class="event-header">
     <section class="event-header__content">
-        <!-- Tag -->
-       {{content.field_event_date}}
-        <h1 class="event-header__title">{{ label }}</h1>
+      <!-- Tag -->
+      {{content.field_event_date}}
+      <h1 class="event-header__title">{{ label }}</h1>
       <!-- button -->
     </section>
     <section class="event-header__visual">
       <!-- image -->
     </section>
   </header>
-  {{ content|without('field_event_date') }}
+
+  <section class="event-description">
+    <h2 class="event-description__title">{{ "Description" | trans }}</h2>
+    <div className="event-description__content">
+      <p class="event-description__description">{{content.field_event_description}}</p>
+      <div class="event-description__links">
+        <!-- horizontal-term-line -->
+      </div>
+    </div>
+    <dl class="list-description event-description__info list-description--event">
+      <!-- list-description__item -->
+    </dl>
+  </section>
+  {{ content|without('field_event_date', 'field_event_description') }}
 </article>

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -2,7 +2,7 @@
   <header class="event-header">
     <section class="event-header__content">
         <!-- Tag -->
-        <!-- dates -->
+       {{content.field_event_date}}
         <h1 class="event-header__title">{{ label }}</h1>
       <!-- button -->
     </section>
@@ -10,5 +10,5 @@
       <!-- image -->
     </section>
   </header>
-  {{ content }}
+  {{ content|without('field_event_date') }}
 </article>


### PR DESCRIPTION

#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-17
> [!CAUTION]
> **Depend on:** https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/518
> Check only this commit: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/530/commits/98aa7ecbbb440f8b8e124df0d25ec388d8eb975d

#### Description
This pull request introduces a new 'Description' field to the event content-type, along with necessary markup in the event-page article structure. 

#### Screenshot of the result
<img width="1027" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/8d7fd5c3-18c5-44b7-8298-695f34f5f914">
