### PR TITLE
Implement 'Buy Tickets' Link in `Event` with Dynamic Title Based on `Event_State`

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
+    - field.field.node.event.field_event_link
     - field.field.node.event.field_event_state
     - node.type.event
   module:
     - datetime_range
+    - link
     - text
 id: node.event.default
 targetEntityType: node
@@ -28,6 +30,14 @@ content:
     settings:
       rows: 5
       placeholder: ''
+    third_party_settings: {  }
+  field_event_link:
+    type: link_default
+    weight: 30
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
     third_party_settings: {  }
   field_event_state:
     type: options_select

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -5,9 +5,11 @@ dependencies:
   config:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
+    - field.field.node.event.field_event_link
     - field.field.node.event.field_event_state
     - node.type.event
   module:
+    - link
     - text
     - user
 id: node.event.default
@@ -21,6 +23,18 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_event_link:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 3
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -6,10 +6,12 @@ dependencies:
     - core.entity_view_mode.node.full
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
+    - field.field.node.event.field_event_link
     - field.field.node.event.field_event_state
     - node.type.event
   module:
     - datetime_range
+    - link
     - text
     - user
 id: node.event.full
@@ -32,6 +34,18 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_event_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
     region: content
 hidden:
   field_event_state: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
+    - field.field.node.event.field_event_link
     - field.field.node.event.field_event_state
     - node.type.event
   module:
@@ -23,5 +24,6 @@ content:
 hidden:
   field_event_date: true
   field_event_description: true
+  field_event_link: true
   field_event_state: true
   langcode: true

--- a/config/sync/field.field.node.event.field_event_link.yml
+++ b/config/sync/field.field.node.event.field_event_link.yml
@@ -1,0 +1,23 @@
+uuid: 5eeb3890-1d17-4a2f-b37a-1278cb6da48c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_link
+    - node.type.event
+  module:
+    - link
+id: node.event.field_event_link
+field_name: field_event_link
+entity_type: node
+bundle: event
+label: 'Event link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/config/sync/field.storage.node.field_event_link.yml
+++ b/config/sync/field.storage.node.field_event_link.yml
@@ -1,0 +1,19 @@
+uuid: 449c09e9-66b7-4a30-bf0a-c2ba7c271aaf
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_event_link
+field_name: field_event_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -117,3 +117,57 @@ function dpl_event_set_occurred_callback(JobSchedule $job): void {
     $event->save();
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK() for field templates.
+ *
+ * Preprocesses the 'field_event_link' for Drupal entities to alter its display
+ * based on the event's state. It updates the button title and sets an
+ * 'event_is_active' flag depending on the event state.
+ */
+function dpl_event_preprocess_field(array &$variables): void {
+  // Get the field name from the variables array. Default to NULL if not set.
+  $field_name = $variables['field_name'] ?? NULL;
+
+  // Return early if 'field_event_link' is present without a title.
+  if ($field_name !== 'field_event_link' ||
+    empty($variables['items'][0]['content']['#title'])) {
+    return;
+  }
+
+  // Return if the element lacks a NodeInterface or an entity object.
+  $node = $variables['element']['#object'] ?? NULL;
+  if (!($node instanceof NodeInterface)) {
+    return;
+  }
+
+  // Get the event states from the 'field_event_state' field.
+  /** @var \Drupal\enum_field\Plugin\Field\FieldType\EnumItemList $event_state_field */
+  $event_state_field = $node->get('field_event_state');
+  $event_states = $event_state_field->enums();
+  // Select the first event state or NULL if not available.
+  $event_state = $event_states[0] ?? NULL;
+
+  // Check if the event state is valid. If not, return early.
+  if (!($event_state instanceof EventState)) {
+    return;
+  }
+
+  // Set 'event_is_active' flag if event state is neither of the following.
+  $variables['event_is_active'] = !in_array($event_state, [
+    EventState::Occurred,
+    EventState::Cancelled,
+    EventState::SoldOut,
+    EventState::TicketSaleNotOpen,
+  ]);
+
+  // After determining the 'event_is_active' flag, check if the event is active.
+  if ($variables['event_is_active']) {
+    // If active, set a translatable string as the title.
+    $variables['items'][0]['content']['#title'] = t('Buy tickets');
+    return;
+  }
+
+  // Update the title of the button to the label of the current event state.
+  $variables['items'][0]['content']['#title'] = $event_state->label();
+}

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -167,7 +167,8 @@ function dpl_event_preprocess_field(array &$variables): void {
     $variables['items'][0]['content']['#title'] = t('Buy tickets');
     return;
   }
-
-  // Update the title of the button to the label of the current event state.
-  $variables['items'][0]['content']['#title'] = $event_state->label();
+  else {
+    // Update the title of the button to the label of the current event state.
+    $variables['items'][0]['content']['#title'] = $event_state->label();
+  }
 }

--- a/web/themes/custom/novel/templates/fields/field--node--field-event-link.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-event-link.html.twig
@@ -11,7 +11,7 @@
 
 
 	{% if event_is_active %}
-		<a {{ item.attributes.setAttribute('href', url).addClass(classes) }} target="_blank">
+		<a {{ item.attributes.setAttribute('href', url).addClass(classes).setAttribute('target', '_blank') }}>
 			{{ title }}
 		</a>
 	{% else %}

--- a/web/themes/custom/novel/templates/fields/field--node--field-event-link.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-event-link.html.twig
@@ -1,0 +1,22 @@
+{% for item in items %}
+	{% set url = item.content['#url'].toString() %}
+	{% set title = item.content['#title'] %}
+
+	{% set classes = [
+    "btn-primary",
+    "btn-filled",
+    "btn-large",
+    "event-header__button"
+    ]%}
+
+
+	{% if event_is_active %}
+		<a {{ item.attributes.setAttribute('href', url).addClass(classes) }} target="_blank">
+			{{ title }}
+		</a>
+	{% else %}
+		<span {{ item.attributes.addClass(classes).setAttribute('disabled', true) }}>
+			{{ title }}
+		</span>
+	{% endif %}
+{% endfor %}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -4,7 +4,7 @@
       <!-- Tag -->
       {{content.field_event_date}}
       <h1 class="event-header__title">{{ label }}</h1>
-      <!-- button -->
+      {{ content.field_event_link }}
     </section>
     <section class="event-header__visual">
       <!-- image -->
@@ -23,5 +23,5 @@
       <!-- list-description__item -->
     </dl>
   </section>
-  {{ content|without('field_event_date', 'field_event_description') }}
+  {{ content|without('field_event_date', 'field_event_description', 'field_event_link') }}
 </article>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-17

#### Description
This pull request introduces a new feature in the `Event` content type, adding a dynamic 'Buy Tickets' link. 
The highlight of this addition is its adaptability to the `event_state`. When the event is not accessible, the link tag switches to a span tag


#### Screenshot of the result
<img width="1027" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/9a2e1655-db4d-43fc-bb99-ada9dd509c54">

<img width="1027" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/5aaf6154-d873-46fd-a9d3-64a772117442">

<img width="1027" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/c1147f5f-a52c-4405-a143-d7b54a5bff04">

<img width="1027" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/5ee60ab3-8332-4742-9928-26598b3fb96e">

<img width="1027" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/f7cbe976-dcf7-4abe-8693-99653e3ef9a9">
