### PR TITLE
Make sure that every build has unique assets.

### DIFF
--- a/lagoon/cli.dockerfile
+++ b/lagoon/cli.dockerfile
@@ -1,5 +1,9 @@
 FROM uselagoon/php-8.1-cli-drupal:latest
 
+# Make sure that every build has unique assets.
+# By setting the build name as an ARG the following layers are not cached.
+ARG LAGOON_BUILD_NAME
+
 COPY composer.* /app/
 COPY assets /app/assets
 COPY packages /app/packages


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-328

#### Description

By setting the build name as an ARG in cli.docker the following layers are not cached and therefor composer install is run everytime.

That ensures that the composer dependencies always are fresh 🥗...

