### PR TITLE
Add address field to event content-type + Improve HTML structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
         "danskernesdigitalebibliotek/fbs-client": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "deoliveiralucas/array-keys-case-transform": "^1.1",
+        "drupal/address": "~1.0",
         "drupal/admin_toolbar": "^3.4",
         "drupal/config_ignore": "^2.4",
         "drupal/core-composer-scaffold": "~10.0.11",

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "danskernesdigitalebibliotek/fbs-client": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "deoliveiralucas/array-keys-case-transform": "^1.1",
-        "drupal/address": "~1.0",
+        "drupal/address": "^1.0",
         "drupal/admin_toolbar": "^3.4",
         "drupal/config_ignore": "^2.4",
         "drupal/core-composer-scaffold": "~10.0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a661702657f4dcbc6cbbf258035c8f82",
+    "content-hash": "203dcb226355d137c5b22c30f5396b57",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -176,6 +176,70 @@
                 "source": "https://github.com/Chi-teck/drupal-code-generator/tree/3.0.0"
             },
             "time": "2023-03-26T07:06:55+00:00"
+        },
+        {
+            "name": "commerceguys/addressing",
+            "version": "v1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/commerceguys/addressing.git",
+                "reference": "406c7b5f0fbe4f6a64155c0fe03b1adb34d01308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/commerceguys/addressing/zipball/406c7b5f0fbe4f6a64155c0fe03b1adb34d01308",
+                "reference": "406c7b5f0fbe4f6a64155c0fe03b1adb34d01308",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/collections": "^1.2 || ^2.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "mikey179/vfsstream": "^1.6.10",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/validator": "^4.4 || ^5.4 || ^6.0"
+            },
+            "suggest": {
+                "symfony/validator": "to validate addresses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CommerceGuys\\Addressing\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bojan Zivanovic"
+                },
+                {
+                    "name": "Damien Tournoud"
+                }
+            ],
+            "description": "Addressing library powered by CLDR and Google's address data.",
+            "keywords": [
+                "address",
+                "internationalization",
+                "localization",
+                "postal"
+            ],
+            "support": {
+                "issues": "https://github.com/commerceguys/addressing/issues",
+                "source": "https://github.com/commerceguys/addressing/tree/v1.4.2"
+            },
+            "time": "2023-02-15T10:11:14+00:00"
         },
         {
             "name": "composer/installers",
@@ -2087,6 +2151,79 @@
             },
             "abandoned": "roave/better-reflection",
             "time": "2023-07-27T18:11:59+00:00"
+        },
+        {
+            "name": "drupal/address",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/address.git",
+                "reference": "8.x-1.12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/address-8.x-1.12.zip",
+                "reference": "8.x-1.12",
+                "shasum": "67dd4699040aabf0cd6169e437706fa6a39b0b3a"
+            },
+            "require": {
+                "commerceguys/addressing": "^1.4.2",
+                "drupal/core": "^9.2 || ^10",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "drupal/token": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.12",
+                    "datestamp": "1684710176",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bojanz",
+                    "homepage": "https://www.drupal.org/user/86106"
+                },
+                {
+                    "name": "Centarro",
+                    "homepage": "https://www.drupal.org/user/3661446"
+                },
+                {
+                    "name": "dww",
+                    "homepage": "https://www.drupal.org/user/46549"
+                },
+                {
+                    "name": "googletorp",
+                    "homepage": "https://www.drupal.org/user/386230"
+                },
+                {
+                    "name": "jsacksick",
+                    "homepage": "https://www.drupal.org/user/972218"
+                },
+                {
+                    "name": "mglaman",
+                    "homepage": "https://www.drupal.org/user/2416470"
+                },
+                {
+                    "name": "rszrama",
+                    "homepage": "https://www.drupal.org/user/49344"
+                }
+            ],
+            "description": "Provides functionality for storing, validating and displaying international postal addresses.",
+            "homepage": "http://drupal.org/project/address",
+            "support": {
+                "source": "https://git.drupalcode.org/project/address"
+            }
         },
         {
             "name": "drupal/admin_toolbar",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "203dcb226355d137c5b22c30f5396b57",
+    "content-hash": "1babfcd2e19a1e2b91bf46f98fe8056c",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -3,12 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_state
     - node.type.event
   module:
+    - address
     - datetime_range
     - link
     - text
@@ -17,6 +19,12 @@ targetEntityType: node
 bundle: event
 mode: default
 content:
+  field_event_address:
+    type: address_default
+    weight: 31
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_event_date:
     type: daterange_default
     weight: 27

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -3,12 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_state
     - node.type.event
   module:
+    - address
     - link
     - text
     - user
@@ -17,6 +19,13 @@ targetEntityType: node
 bundle: event
 mode: default
 content:
+  field_event_address:
+    type: address_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
   field_event_description:
     type: text_default
     label: above

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.full
+    - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_state
     - node.type.event
   module:
+    - address
     - datetime_range
     - link
     - text
@@ -19,6 +21,13 @@ targetEntityType: node
 bundle: event
 mode: full
 content:
+  field_event_address:
+    type: address_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
   field_event_date:
     type: daterange_plain
     label: hidden

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_link
@@ -22,6 +23,7 @@ content:
     weight: 100
     region: content
 hidden:
+  field_event_address: true
   field_event_date: true
   field_event_description: true
   field_event_link: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc
 module:
+  address: 0
   admin_toolbar: 0
   block: 0
   breakpoint: 0

--- a/config/sync/field.field.node.event.field_event_address.yml
+++ b/config/sync/field.field.node.event.field_event_address.yml
@@ -1,0 +1,59 @@
+uuid: 371f71ab-c760-4d2b-9d63-1259d2b67c83
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_address
+    - node.type.event
+  module:
+    - address
+id: node.event.field_event_address
+field_name: field_event_address
+entity_type: node
+bundle: event
+label: 'Event address'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    langcode: en
+    country_code: DK
+    administrative_area: null
+    locality: ''
+    dependent_locality: null
+    postal_code: ''
+    sorting_code: null
+    address_line1: ''
+    address_line2: null
+    organization: null
+    given_name: null
+    additional_name: null
+    family_name: null
+default_value_callback: ''
+settings:
+  available_countries:
+    DK: DK
+    FO: FO
+    DE: DE
+    GL: GL
+  langcode_override: ''
+  field_overrides:
+    givenName:
+      override: hidden
+    additionalName:
+      override: hidden
+    familyName:
+      override: hidden
+    organization:
+      override: hidden
+    addressLine2:
+      override: hidden
+    sortingCode:
+      override: hidden
+    dependentLocality:
+      override: hidden
+    administrativeArea:
+      override: hidden
+  fields: {  }
+field_type: address

--- a/config/sync/field.storage.node.field_event_address.yml
+++ b/config/sync/field.storage.node.field_event_address.yml
@@ -1,0 +1,19 @@
+uuid: 54acdf57-6368-4bef-8617-c48e97975a64
+langcode: en
+status: true
+dependencies:
+  module:
+    - address
+    - node
+id: node.field_event_address
+field_name: field_event_address
+entity_type: node
+type: address
+settings: {  }
+module: address
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -20,8 +20,15 @@
       </div>
     </div>
     <dl class="list-description event-description__info list-description--event">
-      <!-- list-description__item -->
+      <div class="list-description__item">
+        <dt class="list-description__key">
+          {{ "Adresse" | trans }}
+        </dt>
+        <dd class="list-description__value">
+          {{ content.field_event_address }}
+        </dd>
+      </div>
     </dl>
   </section>
-  {{ content|without('field_event_date', 'field_event_description', 'field_event_link') }}
+  {{ content|without('field_event_date', 'field_event_description', 'field_event_link', 'field_event_address') }}
 </article>

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -14,7 +14,7 @@
   <section class="event-description">
     <h2 class="event-description__title">{{ "Description" | trans }}</h2>
     <div className="event-description__content">
-      <p class="event-description__description">{{content.field_event_description}}</p>
+      <div class="event-description__description">{{content.field_event_description}}</div>
       <div class="event-description__links">
         <!-- horizontal-term-line -->
       </div>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-19

#### Description
This pull request includes two changes:

- Addition of Address Field to Event Content-Type: 
The Event content-type now includes an address field. This enhancement was achieved by integrating the `drupal/address` module. Additionally, front-end markup has been updated to accurately display the address field.

- HTML Structure Improvement in Event Description: 
The HTML structure within the event description has been optimized to adhere to HTML standards. This involved replacing `<p>` tags with `<div>` tags, ensuring better compliance with HTML best practices.

#### Screenshot of the result
<img width="1050" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/b48ae9df-a390-41ec-9b3e-b89cfdeabd44">
