### PR TITLE
Event price

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
     ],
     "require": {
         "amazeeio/drupal_integrations": "0.3.7",
+        "brick/math": "^0.12.1",
         "composer/installers": "1.12.0",
         "cweagans/composer-patches": "1.7.3",
         "danskernesdigitalebibliotek/dpl-design-system": "2023.51.0",

--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,7 @@
         "php-mock/php-mock": "^2.3",
         "phpspec/prophecy-phpunit": "^2",
         "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "9.5.10",
         "thecodingmachine/phpstan-safe-rule": "^1.0",
         "timeweb/phpstan-enum": "^3.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f351044a3009f1d7e5cf41b237e8584b",
+    "content-hash": "deaf94daf7114c6af27f5c6c1fa07100",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -12203,6 +12203,58 @@
                 "source": "https://github.com/phpstan/extension-installer/tree/1.3.1"
             },
             "time": "2023-05-24T08:59:17+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "1.3.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "70ecacc64fe8090d8d2a33db5a51fe8e88acd93a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/70ecacc64fe8090d8d2a33db5a51fe8e88acd93a",
+                "reference": "70ecacc64fe8090d8d2a33db5a51fe8e88acd93a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.15"
+            },
+            "time": "2023-10-09T18:58:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2b881c4d9c200a3c7e62d711613c965",
+    "content-hash": "f351044a3009f1d7e5cf41b237e8584b",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -115,6 +115,66 @@
                 "source": "https://github.com/asm89/stack-cors/tree/v2.1.1"
             },
             "time": "2022-01-18T09:12:03+00:00"
+        },
+        {
+            "name": "brick/math",
+            "version": "0.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "5.16.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "bignumber",
+                "brick",
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/0.12.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-29T23:19:16+00:00"
         },
         {
             "name": "chi-teck/drupal-code-generator",

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -9,11 +9,13 @@ dependencies:
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
+    - field.field.node.event.field_ticket_categories
     - node.type.event
   module:
     - address
     - datetime_range
     - link
+    - paragraphs
     - text
 id: node.event.default
 targetEntityType: node
@@ -61,6 +63,24 @@ content:
     weight: 26
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_ticket_categories:
+    type: paragraphs
+    weight: 29
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
     third_party_settings: {  }
   status:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.paragraph.event_ticket_category.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.event_ticket_category.default.yml
@@ -1,0 +1,31 @@
+uuid: 909f0a78-7a52-499c-ae02-454a6fdfc5fc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.event_ticket_category.field_ticket_category_name
+    - field.field.paragraph.event_ticket_category.field_ticket_category_price
+    - paragraphs.paragraphs_type.event_ticket_category
+id: paragraph.event_ticket_category.default
+targetEntityType: paragraph
+bundle: event_ticket_category
+mode: default
+content:
+  field_ticket_category_name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_ticket_category_price:
+    type: number
+    weight: 1
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_form_display.paragraph.event_ticket_category.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.event_ticket_category.default.yml
@@ -6,6 +6,31 @@ dependencies:
     - field.field.paragraph.event_ticket_category.field_ticket_category_name
     - field.field.paragraph.event_ticket_category.field_ticket_category_price
     - paragraphs.paragraphs_type.event_ticket_category
+  module:
+    - field_group
+third_party_settings:
+  field_group:
+    group_inline_fields:
+      children:
+        - field_ticket_category_name
+        - field_ticket_category_price
+      label: 'Inline fields'
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: 'style="display: grid; grid-template-columns: minmax(0,max-content) minmax(5rem,10rem); gap: var(--gin-spacing-m);"'
+        effect: none
+        speed: fast
+        required_fields: true
 id: paragraph.event_ticket_category.default
 targetEntityType: paragraph
 bundle: event_ticket_category
@@ -13,7 +38,7 @@ mode: default
 content:
   field_ticket_category_name:
     type: string_textfield
-    weight: 0
+    weight: 1
     region: content
     settings:
       size: 60
@@ -21,7 +46,7 @@ content:
     third_party_settings: {  }
   field_ticket_category_price:
     type: number
-    weight: 1
+    weight: 2
     region: content
     settings:
       placeholder: ''

--- a/config/sync/core.entity_form_display.paragraph.event_ticket_category.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.event_ticket_category.default.yml
@@ -20,14 +20,14 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: ''
+        classes: ticket-category-inline-fields
         show_empty_fields: false
         id: ''
         element: div
         show_label: false
         label_element: h3
         label_element_classes: ''
-        attributes: 'style="display: grid; grid-template-columns: minmax(0,max-content) minmax(5rem,10rem); gap: var(--gin-spacing-m);"'
+        attributes: ''
         effect: none
         speed: fast
         required_fields: true

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -36,7 +36,6 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
-<<<<<<< HEAD
   field_event_link:
     type: link
     label: above
@@ -56,7 +55,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 5
-=======
+    region: content
   field_ticket_categories:
     type: entity_reference_revisions_entity_view
     label: above
@@ -65,7 +64,6 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 2
->>>>>>> f7b548f1 (Add paragraph for handling event categories and prices)
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -9,9 +9,11 @@ dependencies:
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
+    - field.field.node.event.field_ticket_categories
     - node.type.event
   module:
     - address
+    - entity_reference_revisions
     - link
     - text
     - user
@@ -34,6 +36,7 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
+<<<<<<< HEAD
   field_event_link:
     type: link
     label: above
@@ -53,6 +56,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 5
+=======
+  field_ticket_categories:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 2
+>>>>>>> f7b548f1 (Add paragraph for handling event categories and prices)
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
+    - field.field.node.event.field_ticket_categories
     - node.type.event
   module:
     - address
@@ -67,5 +68,6 @@ content:
     region: content
 hidden:
   field_event_state: true
+  field_ticket_categories: true
   langcode: true
   links: true

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -15,6 +15,7 @@ dependencies:
   module:
     - address
     - datetime_range
+    - entity_reference_revisions
     - link
     - text
     - user
@@ -66,8 +67,16 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
+  field_ticket_categories:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
 hidden:
   field_event_state: true
-  field_ticket_categories: true
   langcode: true
   links: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
+    - field.field.node.event.field_ticket_categories
     - node.type.event
   module:
     - user
@@ -30,4 +31,5 @@ hidden:
   field_event_link: true
   field_event_place: true
   field_event_state: true
+  field_ticket_categories: true
   langcode: true

--- a/config/sync/core.entity_view_display.paragraph.event_ticket_category.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.event_ticket_category.default.yml
@@ -1,0 +1,33 @@
+uuid: 60e025b4-a718-4d6c-a4ad-ab7e024f633d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.event_ticket_category.field_ticket_category_name
+    - field.field.paragraph.event_ticket_category.field_ticket_category_price
+    - paragraphs.paragraphs_type.event_ticket_category
+id: paragraph.event_ticket_category.default
+targetEntityType: paragraph
+bundle: event_ticket_category
+mode: default
+content:
+  field_ticket_category_name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_ticket_category_price:
+    type: number_decimal
+    label: above
+    settings:
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.paragraph.event_ticket_category.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.event_ticket_category.default.yml
@@ -13,7 +13,7 @@ mode: default
 content:
   field_ticket_category_name:
     type: string
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -21,7 +21,7 @@ content:
     region: content
   field_ticket_category_price:
     type: number_decimal
-    label: above
+    label: hidden
     settings:
       thousand_separator: ''
       decimal_separator: .

--- a/config/sync/field.field.node.event.field_ticket_categories.yml
+++ b/config/sync/field.field.node.event.field_ticket_categories.yml
@@ -1,0 +1,37 @@
+uuid: bf5c7e8c-07e9-4128-b04c-b6bcfd8b369b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ticket_categories
+    - node.type.event
+    - paragraphs.paragraphs_type.event_ticket_category
+  module:
+    - entity_reference_revisions
+id: node.event.field_ticket_categories
+field_name: field_ticket_categories
+entity_type: node
+bundle: event
+label: 'Ticket categories'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      event_ticket_category: event_ticket_category
+    negate: 0
+    target_bundles_drag_drop:
+      campaign_rule:
+        weight: 4
+        enabled: false
+      event_ticket_category:
+        weight: 5
+        enabled: true
+      text_body:
+        weight: 6
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.paragraph.event_ticket_category.field_ticket_category_name.yml
+++ b/config/sync/field.field.paragraph.event_ticket_category.field_ticket_category_name.yml
@@ -1,0 +1,19 @@
+uuid: f2ec6a69-395c-4683-a00e-6a567830d7b9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_ticket_category_name
+    - paragraphs.paragraphs_type.event_ticket_category
+id: paragraph.event_ticket_category.field_ticket_category_name
+field_name: field_ticket_category_name
+entity_type: paragraph
+bundle: event_ticket_category
+label: Name
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.event_ticket_category.field_ticket_category_price.yml
+++ b/config/sync/field.field.paragraph.event_ticket_category.field_ticket_category_price.yml
@@ -1,0 +1,23 @@
+uuid: 5bf5715f-f899-4364-83e9-087733d804e0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_ticket_category_price
+    - paragraphs.paragraphs_type.event_ticket_category
+id: paragraph.event_ticket_category.field_ticket_category_price
+field_name: field_ticket_category_price
+entity_type: paragraph
+bundle: event_ticket_category
+label: Price
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0.0
+  max: null
+  prefix: DKK
+  suffix: ''
+field_type: decimal

--- a/config/sync/field.field.paragraph.event_ticket_category.field_ticket_category_price.yml
+++ b/config/sync/field.field.paragraph.event_ticket_category.field_ticket_category_price.yml
@@ -18,6 +18,6 @@ default_value_callback: ''
 settings:
   min: 0.0
   max: null
-  prefix: DKK
+  prefix: ''
   suffix: ''
 field_type: decimal

--- a/config/sync/field.storage.node.field_ticket_categories.yml
+++ b/config/sync/field.storage.node.field_ticket_categories.yml
@@ -1,0 +1,21 @@
+uuid: 19cd3224-6432-4577-bf70-3719a5793e7b
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_ticket_categories
+field_name: field_ticket_categories
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_ticket_category_name.yml
+++ b/config/sync/field.storage.paragraph.field_ticket_category_name.yml
@@ -1,0 +1,21 @@
+uuid: e4c73a8b-d6be-49be-93fb-301bac97914d
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_ticket_category_name
+field_name: field_ticket_category_name
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_ticket_category_price.yml
+++ b/config/sync/field.storage.paragraph.field_ticket_category_price.yml
@@ -1,0 +1,20 @@
+uuid: fb35a4cf-1eed-4915-ab98-7a85b98394af
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_ticket_category_price
+field_name: field_ticket_category_price
+entity_type: paragraph
+type: decimal
+settings:
+  precision: 10
+  scale: 2
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/da/views.view.files.yml
+++ b/config/sync/language/da/views.view.files.yml
@@ -26,6 +26,8 @@ display:
           label: Ændringsdato
         count:
           label: 'Brugt i'
+          alter:
+            path: 'admin/content/files/usage/{{ fid }}'
       pager:
         options:
           tags:

--- a/config/sync/language/da/views.view.media_library.yml
+++ b/config/sync/language/da/views.view.media_library.yml
@@ -52,6 +52,9 @@ display:
         name:
           separator: ', '
         edit_media:
+          alter:
+            text: 'Redigér {{ name }}'
+            alt: 'Redigér {{ name }}'
           text: Redigér
         delete_media:
           alter:

--- a/config/sync/language/da/views.view.user_admin_people.yml
+++ b/config/sync/language/da/views.view.user_admin_people.yml
@@ -19,6 +19,9 @@ display:
           label: Roller
         created:
           label: 'Medlem i'
+          settings:
+            future_format: '@interval'
+            past_format: '@interval'
         access:
           label: 'Seneste tilgang'
           settings:

--- a/config/sync/paragraphs.paragraphs_type.event_ticket_category.yml
+++ b/config/sync/paragraphs.paragraphs_type.event_ticket_category.yml
@@ -1,0 +1,10 @@
+uuid: a982e6eb-1e47-4e47-9454-13ce7cd63d40
+langcode: en
+status: true
+dependencies: {  }
+id: event_ticket_category
+label: 'Ticket category'
+icon_uuid: null
+icon_default: null
+description: 'A combination of ticket category name and price for an event. '
+behavior_plugins: {  }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,7 @@ parameters:
     # Drupal Form API makes extensive use for arrays which we cannot provide
     # more detailed typing of.
     - '#.*\:\:(buildForm|getEditableConfigNames|submitForm|validateForm)\(\) .* no value type specified in iterable type array\.#'
+    - '#_form_alter\(\) has parameter \$form with no value type specified in iterable type array\.#'
     # Drupal preprocess functions uses variables array which we cannot provide more detailed typing of.
     - '#Function .*_preprocess_.*\(\) has parameter \$variables with no value type specified in iterable type array\.#'
     # Drupal hook_page_attachments functions uses page array which we cannot provide more detailed typing of.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 parameters:
   level: 8
+  checkGenericClassInNonGenericObjectType: false
   paths:
     - web/modules/custom
     - web/profiles/dpl_cms
@@ -19,6 +20,8 @@ parameters:
     - '#Drupal\\.*\\Plugin\\Block\\.*Block::__construct\(\) .* no value type specified in iterable type array\.#'
     - '#Drupal\\.*\\Plugin\\Block\\.*Block::create\(\) .* no value type specified in iterable type array\.#'
     - '#Function [a-z_]+_dpl_react_apps_data\(\) has parameter \$data with no value type specified in iterable type array\.#'
+    # Ignore iterable types for FieldItemListInterface.
+    - '#no value type specified in iterable type Drupal\\Core\\Field\\FieldItemListInterface#'
   scanFiles:
     # Needed to make locale_translation_batch_fetch_finished() discoverable.
     - web/core/modules/locale/locale.batch.inc

--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -27,3 +27,10 @@
   height: calc(100% - 140px) !important;
   max-height: 100% !important;
 }
+
+/* Display name and price fields inline for ticket categories. */
+.ticket-category-inline-fields {
+  display: grid;
+  grid-template-columns: minmax(0, max-content) minmax(5rem, 10rem);
+  gap: var(--gin-spacing-m);
+}

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -5,6 +5,7 @@
  * Module file for DPL Event.
  */
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\dpl_event\EventState;
 use Drupal\job_scheduler\Entity\JobSchedule;
 use Drupal\node\NodeInterface;
@@ -116,6 +117,15 @@ function dpl_event_set_occurred_callback(JobSchedule $job): void {
     $event->set("field_event_state", EventState::Occurred);
     $event->save();
   }
+}
+
+/**
+ * Implements hook_form_node_event_form_alter().
+ */
+function dpl_event_form_node_event_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  // Use the generic "Access" value as the default for the first ticket
+  // category when creating events.
+  $form["field_ticket_categories"]["widget"][0]["subform"]["field_ticket_category_name"]["widget"][0]["value"]["#default_value"] = t('Access', [], ['context' => 'dpl_event']);
 }
 
 /**

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -172,3 +172,19 @@ function dpl_event_preprocess_field(array &$variables): void {
     $variables['items'][0]['content']['#title'] = $event_state->label();
   }
 }
+
+/**
+ * Implements hook_preprocess_field__field_ticket_category_price().
+ *
+ * Adds an array of formatted prices.
+ */
+function dpl_event_preprocess_field__field_ticket_category_price(array &$variables) : void {
+  /** @var \Drupal\dpl_event\PriceFormatter $price_formatter */
+  $price_formatter = \Drupal::service('dpl_event.price_formatter');
+  /** @var \Drupal\Core\Field\FieldItemListInterface $items */
+  $items = $variables['element']['#items'];
+  $prices = array_map(function (array $price) use ($price_formatter): string {
+    return $price_formatter->formatPrice($price["value"]);
+  }, $items->getValue());
+  $variables['prices'] = $prices;
+}

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -125,7 +125,11 @@ function dpl_event_set_occurred_callback(JobSchedule $job): void {
 function dpl_event_form_node_event_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   // Use the generic "Access" value as the default for the first ticket
   // category when creating events.
-  $form["field_ticket_categories"]["widget"][0]["subform"]["field_ticket_category_name"]["widget"][0]["value"]["#default_value"] = t('Access', [], ['context' => 'dpl_event']);
+  $ticket_category_name_value = $form["field_ticket_categories"]["widget"][0]["subform"]["field_ticket_category_name"]["widget"][0]["value"] ?? [];
+  if (!array_key_exists("#default_value", $ticket_category_name_value)) {
+    throw new DomainException("Unable to locate name field for first ticket category. Cannot set default value.");
+  }
+  $ticket_category_name_value["#default_value"] = t('Access', [], ['context' => 'dpl_event']);
 }
 
 /**

--- a/web/modules/custom/dpl_event/dpl_event.services.yml
+++ b/web/modules/custom/dpl_event/dpl_event.services.yml
@@ -1,0 +1,4 @@
+services:
+  dpl_event.price_formatter:
+    class: Drupal\dpl_event\PriceFormatter
+    arguments: ["@string_translation"]

--- a/web/modules/custom/dpl_event/src/PriceFormatter.php
+++ b/web/modules/custom/dpl_event/src/PriceFormatter.php
@@ -24,12 +24,12 @@ class PriceFormatter {
    * Format a single price.
    */
   public function formatPrice(string $price_string): string {
-    $context = ['context' => 'dpl_event'];
+    $translation_options = ['context' => 'dpl_event'];
 
     $price = BigDecimal::of($price_string);
     return match(TRUE) {
       // Events with 0 cost should show "Free" instead of a numeric price.
-      $price->isEqualTo(0) => $this->translation->translate("Free", [], $context),
+      $price->isEqualTo(0) => $this->translation->translate("Free", [], $translation_options),
       // Add the kr. suffix for now.
       // For multi-currency support this should be replaced by a configurable
       // suffix and appropriate separators.

--- a/web/modules/custom/dpl_event/src/PriceFormatter.php
+++ b/web/modules/custom/dpl_event/src/PriceFormatter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\dpl_event;
+
+use Brick\Math\BigDecimal;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Formats prices according to local rules.
+ *
+ * This is important as we do not rely on fields built for prices. Instead we
+ * have double fields with values as strings.
+ */
+class PriceFormatter {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    protected TranslationInterface $translation,
+  ) {}
+
+  /**
+   * Format a single price.
+   */
+  public function formatPrice(string $price_string): string {
+    $context = ['context' => 'dpl_event'];
+
+    $price = BigDecimal::of($price_string);
+    return match(TRUE) {
+      // Events with 0 cost should show "Free" instead of a numeric price.
+      $price->isEqualTo(0) => $this->translation->translate("Free", [], $context),
+      // Add the kr. suffix for now.
+      // For multi-currency support this should be replaced by a configurable
+      // suffix and appropriate separators.
+      // Strip fractions from prices which do not use them.
+      !$price->hasNonZeroFractionalPart() => $this->translation->translate("@price kr.", ['@price' => $price->getIntegralPart()]),
+      // Prices with fractions must be output with exactly two digits in the
+      // fraction to match standard formatting of prices.
+      default => $this->translation->translate("@price kr.", ['@price' => number_format($price->toFloat(), 2, ',', '.')])
+    };
+  }
+
+}

--- a/web/modules/custom/dpl_event/src/PriceFormatter.php
+++ b/web/modules/custom/dpl_event/src/PriceFormatter.php
@@ -27,18 +27,25 @@ class PriceFormatter {
     $translation_options = ['context' => 'dpl_event'];
 
     $price = BigDecimal::of($price_string);
-    return match(TRUE) {
+    if ($price->isEqualTo(0)) {
       // Events with 0 cost should show "Free" instead of a numeric price.
-      $price->isEqualTo(0) => $this->translation->translate("Free", [], $translation_options),
+      $price_string = $this->translation->translate("Free", [], $translation_options);
+    }
+    else {
       // Add the kr. suffix for now.
       // For multi-currency support this should be replaced by a configurable
       // suffix and appropriate separators.
-      // Strip fractions from prices which do not use them.
-      !$price->hasNonZeroFractionalPart() => $this->translation->translate("@price kr.", ['@price' => $price->getIntegralPart()]),
-      // Prices with fractions must be output with exactly two digits in the
-      // fraction to match standard formatting of prices.
-      default => $this->translation->translate("@price kr.", ['@price' => number_format($price->toFloat(), 2, ',', '.')])
-    };
+      if (!$price->hasNonZeroFractionalPart()) {
+        // Strip fractions from prices which do not use them.
+        $price_string = $this->translation->translate("@price kr.", ['@price' => $price->getIntegralPart()]);
+      }
+      else {
+        // Prices with fractions must be output with exactly two digits in the
+        // fraction to match standard formatting of prices.
+        $price_string = $this->translation->translate("@price kr.", ['@price' => number_format($price->toFloat(), 2, ',', '.')]);
+      }
+    }
+    return $price_string;
   }
 
 }

--- a/web/modules/custom/dpl_event/tests/src/Unit/PriceFormatterTest.php
+++ b/web/modules/custom/dpl_event/tests/src/Unit/PriceFormatterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace dpl_event\tests\src\Unit;
+
+use Drupal\dpl_event\PriceFormatter;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Test case for price formatting.
+ */
+class PriceFormatterTest extends UnitTestCase {
+
+  /**
+   * Provides examples of price strings and how they should be formatted.
+   *
+   * @return array<array{string, string}>
+   *   Array of examples. Each example contains a price string and how it
+   *   should be formatted. This matches signature of testPriceFormatting().
+   */
+  public function priceProvider(): array {
+    return [
+      ["0", "Free"],
+      ["0.0", "Free"],
+      ["0.00", "Free"],
+      ["10.0", "10 kr."],
+      ["10.00", "10 kr."],
+      ["10.01", "10,01 kr."],
+      ["10.1", "10,10 kr."],
+      ["10.100", "10,10 kr."],
+      // We are currently rounding any fractional digits beyond 2.
+      ["10.101", "10,10 kr."],
+      ["10.109", "10,11 kr."],
+    ];
+  }
+
+  /**
+   * Test all examples of price strings.
+   *
+   * @dataProvider priceProvider
+   */
+  public function testPriceFormatting(string $price_string, string $formatted_price): void {
+    $priceFormatter = new PriceFormatter($this->getStringTranslationStub());
+    $this->assertSame($formatted_price, $priceFormatter->formatPrice($price_string));
+  }
+
+}

--- a/web/modules/custom/dpl_login/tests/src/Unit/ConfigTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/ConfigTest.php
@@ -34,6 +34,8 @@ class ConfigTest extends UnitTestCase {
    * {@inheritdoc}
    */
   public function setUp(): void {
+    parent::setUp();
+
     $this->config = $config = $this->prophesize(ImmutableConfig::class);
     $this->config->get('settings')->willReturn([
       'agency_id' => '775100',

--- a/web/modules/custom/dpl_login/tests/src/Unit/DplLoginControllerTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/DplLoginControllerTest.php
@@ -34,6 +34,8 @@ class DplLoginControllerTest extends UnitTestCase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
+    parent::setUp();
+
     $builder = new MockBuilder();
     $builder->setNamespace('Drupal\dpl_login\Controller')
       ->setName("user_logout")

--- a/web/modules/custom/dpl_login/tests/src/Unit/UserTokenAuthProviderTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/UserTokenAuthProviderTest.php
@@ -43,6 +43,8 @@ class UserTokenAuthProviderTest extends UnitTestCase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
+    parent::setUp();
+
     $this->openIdClient = $this->prophesize(OpenIDConnectClientInterface::class);
     $this->moduleInvoker = $this->prophesize(ModuleHandlerInterface::class);
     $this->authMap = $this->prophesize(OpenIDConnectAuthmap::class);

--- a/web/modules/custom/dpl_url_proxy/tests/src/Unit/UrlProxyResourceTest.php
+++ b/web/modules/custom/dpl_url_proxy/tests/src/Unit/UrlProxyResourceTest.php
@@ -26,6 +26,8 @@ class UrlProxyResourceTest extends UnitTestCase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
+    parent::setUp();
+
     $config = $this->prophesize(ImmutableConfig::class);
     $config->get('values')->willReturn([
       'prefix' => '',

--- a/web/themes/custom/novel/templates/fields/field--field-ticket-category-name.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-ticket-category-name.html.twig
@@ -1,0 +1,7 @@
+{# Spaceless is important to get the right distance between elements in
+   paragraph--event-ticket-category.html.twig. #}
+{% apply spaceless %}
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}
+{% endapply %}

--- a/web/themes/custom/novel/templates/fields/field--field-ticket-category-price.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-ticket-category-price.html.twig
@@ -1,14 +1,3 @@
-{% for item in items %}
-  {% set price = item.content['#markup'] %}
-
-  {# Events with 0 cost should be marked as free #}
-  {% if price matches '/^0.0+$/' %}
-    {{ "Free" | trans }}
-  {# Strip fractions from prices which do not use them #}
-  {# Add the kr. suffix for now. For multicurrency support this should be replaced by a configurable value. #}
-  {% elseif price matches '/^\\d+.0+$/' %}
-    {{ "@price kr." | t({'@price': price[:-3] }) }}
-  {% else %}
-    {{ "@price kr." | t({'@price': price}) }}
-  {% endif %}
+{% for price in prices %}
+  {{ price }}
 {% endfor %}

--- a/web/themes/custom/novel/templates/fields/field--field-ticket-category-price.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-ticket-category-price.html.twig
@@ -1,0 +1,14 @@
+{% for item in items %}
+  {% set price = item.content['#markup'] %}
+
+  {# Events with 0 cost should be marked as free #}
+  {% if price matches '/^0.0+$/' %}
+    {{ "Free" | trans }}
+  {# Strip fractions from prices which do not use them #}
+  {# Add the kr. suffix for now. For multicurrency support this should be replaced by a configurable value. #}
+  {% elseif price matches '/^\\d+.0+$/' %}
+    {{ "@price kr." | t({'@price': price[:-3] }) }}
+  {% else %}
+    {{ "@price kr." | t({'@price': price}) }}
+  {% endif %}
+{% endfor %}

--- a/web/themes/custom/novel/templates/fields/field--node--field-ticket-categories--event.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-ticket-categories--event.html.twig
@@ -1,0 +1,10 @@
+{% if items|length == 1 %}
+  {# Events with a single ticket category should only show the price. #}
+  {{ items.0.content['#paragraph'].field_ticket_category_price|view }}
+{% else %}
+  <dl>
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+  </dl>
+{% endif %}

--- a/web/themes/custom/novel/templates/fields/field--node--field-ticket-categories--event.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-ticket-categories--event.html.twig
@@ -1,10 +1,8 @@
 {% if items|length == 1 %}
   {# Events with a single ticket category should only show the price. #}
-  {{ items.0.content['#paragraph'].field_ticket_category_price|view }}
+  <span>{{ items.0.content['#paragraph'].field_ticket_category_price|view }}</span>
 {% else %}
-  <dl>
   {% for item in items %}
     {{ item.content }}
   {% endfor %}
-  </dl>
 {% endif %}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -20,7 +20,7 @@
       </div>
     </div>
     <dl class="list-description event-description__info list-description--event">
-      {% if content.field_event_place.0 %}
+      {% if content.field_ticket_categories.0 %}
         <div class="list-description__item">
           <dt class="list-description__key">{{ "Price" | trans }}</dt>
           <dd class="list-description__value">

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -21,6 +21,14 @@
     </div>
     <dl class="list-description event-description__info list-description--event">
       {% if content.field_event_place.0 %}
+        <div class="list-description__item">
+          <dt class="list-description__key">{{ "Price" | trans }}</dt>
+          <dd class="list-description__value">
+            {{content.field_ticket_categories}}
+          </dd>
+        </div>
+      {% endif %}
+      {% if content.field_event_place.0 %}
       <div class="list-description__item">
         <dt class="list-description__key">
           {{ "Place" | trans }}:
@@ -41,6 +49,6 @@
     </dl>
   </section>
   {{ content|without('field_event_date', 'field_event_description', 'field_event_link', 'field_event_address',
-  'field_event_place') }}
+  'field_event_place', 'field_ticket_categories') }}
 </article>
 

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--event-ticket-category.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--event-ticket-category.html.twig
@@ -1,0 +1,3 @@
+{# Structure is based rendering being embedded in field--node--field-ticket-categories--event.html.twig #}
+<dt>{{ content.field_ticket_category_name }}</dt>
+<dd>{{ content.field_ticket_category_price }}</dd>

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--event-ticket-category.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--event-ticket-category.html.twig
@@ -1,3 +1,4 @@
 {# Structure is based rendering being embedded in field--node--field-ticket-categories--event.html.twig #}
-<dt>{{ content.field_ticket_category_name }}</dt>
-<dd>{{ content.field_ticket_category_price }}</dd>
+<div>
+  {{ content.field_ticket_category_name }}: {{ content.field_ticket_category_price }}
+</div>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-57

#### Description

This PR adds handling of ticket categories and prices. The primary changes are:

- Adding a new paragraph "Ticket category" with fields for name (string) and price (decimal)
- Implementing logic for formatting prices in a new service
- Rendering prices as a part of the event metadata

Please check out the individual commits for additional commentary.

#### Screenshot of the result

<img width="1392" alt="Monosnap Quam non enim obcaecati iste | DPL CMS 2023-12-11 09-18-04" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/e96d8854-ff75-4c46-bf23-c8dc1d176647">

#### Additional comments or questions

In the process I found that we need to tweak our PHPStan setup to avoid false positives when rendering fields and altering forms.