### PR TITLE
Add `place` field to `event` content type

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - node.type.event
   module:
@@ -46,6 +47,14 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
+    third_party_settings: {  }
+  field_event_place:
+    type: string_textfield
+    weight: 32
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_event_state:
     type: options_select

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - node.type.event
   module:
@@ -44,6 +45,14 @@ content:
       target: ''
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_event_place:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 5
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - node.type.event
   module:
@@ -55,6 +56,14 @@ content:
       target: ''
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_event_place:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
     region: content
 hidden:
   field_event_state: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - node.type.event
   module:
@@ -27,5 +28,6 @@ hidden:
   field_event_date: true
   field_event_description: true
   field_event_link: true
+  field_event_place: true
   field_event_state: true
   langcode: true

--- a/config/sync/field.field.node.event.field_event_place.yml
+++ b/config/sync/field.field.node.event.field_event_place.yml
@@ -1,0 +1,19 @@
+uuid: c5dacd60-e34d-45be-b0dd-d2cc65d0ff7b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_place
+    - node.type.event
+id: node.event.field_event_place
+field_name: field_event_place
+entity_type: node
+bundle: event
+label: 'Event place'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_event_place.yml
+++ b/config/sync/field.storage.node.field_event_place.yml
@@ -1,0 +1,21 @@
+uuid: c538ad45-cd52-4875-846a-391031e405c0
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_event_place
+field_name: field_event_place
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/dpl_cms/translations/da.po
+++ b/web/profiles/dpl_cms/translations/da.po
@@ -3826,3 +3826,6 @@ msgstr "Roman"
 msgid "Custom theme for the Danish Public Libraries"
 msgstr "Standardtema for Folkebibliotekernes CMS"
 
+msgid "Place"
+msgstr "Sted"
+

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -20,6 +20,16 @@
       </div>
     </div>
     <dl class="list-description event-description__info list-description--event">
+      {% if content.field_event_place.0 %}
+      <div class="list-description__item">
+        <dt class="list-description__key">
+          {{ "Place" | trans }}
+        </dt>
+        <dd class="list-description__value">
+          {{ content.field_event_place }}
+        </dd>
+      </div>
+      {% endif %}
       <div class="list-description__item">
         <dt class="list-description__key">
           {{ "Adresse" | trans }}
@@ -30,5 +40,7 @@
       </div>
     </dl>
   </section>
-  {{ content|without('field_event_date', 'field_event_description', 'field_event_link', 'field_event_address') }}
+  {{ content|without('field_event_date', 'field_event_description', 'field_event_link', 'field_event_address',
+  'field_event_place') }}
 </article>
+

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -23,7 +23,7 @@
       {% if content.field_event_place.0 %}
       <div class="list-description__item">
         <dt class="list-description__key">
-          {{ "Place" | trans }}
+          {{ "Place" | trans }}:
         </dt>
         <dd class="list-description__value">
           {{ content.field_event_place }}
@@ -32,7 +32,7 @@
       {% endif %}
       <div class="list-description__item">
         <dt class="list-description__key">
-          {{ "Adresse" | trans }}
+          {{ "Adresse" | trans }}:
         </dt>
         <dd class="list-description__value">
           {{ content.field_event_address }}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-18


#### Description
This pull request adds a `place` field to the event content type. The field is currently implemented as a multi-string, but it will be replaced with a checkbox list that includes all libraries in the future. 

#### Screenshot of the result
<img width="991" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/e8bf9c1c-ed5d-4ec9-833f-4a8b608180f2">
