### PR TITLE
Add Hero Image to `Event` Content-Type

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
+    - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
@@ -16,6 +17,7 @@ dependencies:
     - datetime_range
     - link
     - paragraphs
+    - media_library
     - text
 id: node.event.default
 targetEntityType: node
@@ -41,6 +43,13 @@ content:
     settings:
       rows: 5
       placeholder: ''
+    third_party_settings: {  }
+  field_event_image:
+    type: media_library_widget
+    weight: 33
+    region: content
+    settings:
+      media_types: {  }
     third_party_settings: {  }
   field_event_link:
     type: link_default

--- a/config/sync/core.entity_view_display.media.image.hero_wide.yml
+++ b/config/sync/core.entity_view_display.media.image.hero_wide.yml
@@ -1,0 +1,33 @@
+uuid: 197c46b2-8d49-44dc-9cb0-bc5c472d5780
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.hero_wide
+    - field.field.media.image.field_media_image
+    - image.style.hero_wide
+    - media.type.image
+  module:
+    - image
+id: media.image.hero_wide
+targetEntityType: media
+bundle: image
+mode: hero_wide
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: hero_wide
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
+    - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
@@ -35,6 +36,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 6
     region: content
   field_event_link:
     type: link

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
+    - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
@@ -46,6 +47,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: hero_wide
+      link: false
+    third_party_settings: {  }
+    weight: 5
     region: content
   field_event_link:
     type: link

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
+    - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
@@ -28,6 +29,7 @@ hidden:
   field_event_address: true
   field_event_date: true
   field_event_description: true
+  field_event_image: true
   field_event_link: true
   field_event_place: true
   field_event_state: true

--- a/config/sync/core.entity_view_mode.media.hero_wide.yml
+++ b/config/sync/core.entity_view_mode.media.hero_wide.yml
@@ -1,0 +1,10 @@
+uuid: 29fb4d73-2ba1-4a03-a74f-9406047ae2a9
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.hero_wide
+label: 'Hero wide (16/9)'
+targetEntityType: media
+cache: true

--- a/config/sync/field.field.node.event.field_event_image.yml
+++ b/config/sync/field.field.node.event.field_event_image.yml
@@ -1,0 +1,29 @@
+uuid: bf4c5dda-865a-4d68-b3a7-e173020ab2df
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_image
+    - media.type.image
+    - node.type.event
+id: node.event.field_event_image
+field_name: field_event_image
+entity_type: node
+bundle: event
+label: 'Event image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_event_image.yml
+++ b/config/sync/field.storage.node.field_event_image.yml
@@ -1,0 +1,20 @@
+uuid: 04d1e2bc-2d25-47ce-8913-26aa4899cf02
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_event_image
+field_name: field_event_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/image.style.hero_wide.yml
+++ b/config/sync/image.style.hero_wide.yml
@@ -1,0 +1,15 @@
+uuid: fbc150b6-cc72-4520-a434-9d0dde58e4bc
+langcode: en
+status: true
+dependencies: {  }
+name: hero_wide
+label: 'Hero wide (16/9)'
+effects:
+  7f3e51a9-6f0e-4672-8f59-bd82b434a2e4:
+    uuid: 7f3e51a9-6f0e-4672-8f59-bd82b434a2e4
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 800
+      height: 450
+      anchor: center-center

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -1,15 +1,15 @@
 <article {{ attributes.addClass('event-page') }}>
   <header class="event-header">
-    <section class="event-header__content">
-      <!-- Tag -->
-      {{ content.field_event_date }}
-      <h1 class="event-header__title">{{ label }}</h1>
-      {{ content.field_event_link }}
-    </section>
-    <section class="event-header__visual">
-      <!-- image -->
-    </section>
-  </header>
+        <section class="event-header__content">
+            <!-- Tag -->
+            {{ content.field_event_date }}
+            <h1 class="event-header__title">{{ label }}</h1>
+            {{ content.field_event_link }}
+        </section>
+        <section class="event-header__visual ">
+      {{ content.field_event_image }}
+        </section>
+    </header>
 
   <section class="event-description">
     <h2 class="event-description__title">{{ "Description"|trans }}</h2>
@@ -49,5 +49,5 @@
     </dl>
   </section>
   {{ content|without('field_event_date', 'field_event_description', 'field_event_link', 'field_event_address',
-  'field_event_place', 'field_ticket_categories') }}
+  'field_event_place', 'field_ticket_categories', 'field_event_image') }}
 </article>

--- a/web/themes/custom/novel/templates/media/media--image.html.twig
+++ b/web/themes/custom/novel/templates/media/media--image.html.twig
@@ -1,0 +1,8 @@
+{#
+  An image can have a byline, which uses a <figcaption>.
+  Therefore, it is important that we wrap it in a <figure>.
+#}
+<figure {{ attributes.addClass('image-credited') }}>
+  {{ title_suffix.contextual_links }}
+  {{ content }}
+</figure>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-75


#### Description

This pull request introduces a new hero image feature to the Event content-type. It encompasses two primary changes: adding a field_event_image field to Event, and implementing a 16:9 (Hero Wide) format in our image styles. 

#### Screenshot of the result
<img width="1228" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/ec53cc27-2779-4bf0-b051-c27dfe7445b7">
