### PR TITLE
Allow editors to choose focal points for image-cropping. DDFFORM-72

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,7 @@
         "drupal/devel": "~5.0.2",
         "drupal/enum_field": "^1.0",
         "drupal/field_group": "^3.4",
+        "drupal/focal_point": "^2.0",
         "drupal/gin": "^3.0@RC",
         "drupal/gin_toolbar": "^1.0@RC",
         "drupal/handy_cache_tags": "^1.4",
@@ -97,6 +98,7 @@
         "drupal/jsonlog": "^4.0",
         "drupal/libraries": "^4.0",
         "drupal/linkit": "^6.0",
+        "drupal/media_library_edit": "^3.0",
         "drupal/metatag": "^2.0",
         "drupal/multiple_fields_remove_button": "^2.2",
         "drupal/openapi": "^2.1",
@@ -214,6 +216,9 @@
             "drupal/core": {
                 "Configure core to not check permissions before accepting an updated module": "patches/disable-core-upload-permission-check.diff",
                 "3073554: Add a token for publication status": "https://www.drupal.org/files/issues/2019-08-09/3073554_10.patch"
+            },
+            "drupal/focal_point": {
+                "3162210: Preview link accidentally closes the media library": "https://www.drupal.org/files/issues/2020-10-11/preview_link_accidentally_closes_the_media_library-3162210-19.patch"
             },
             "drupal/jsonlog": {
                 "3251587: Change logging from stdout to stderr": "https://www.drupal.org/files/issues/2021-11-29/jsonlog-change-stdout-to-stderr-3251587-3.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b96075ccca8710a5421a674c8a01f6c0",
+    "content-hash": "07cd9574cb45a434fdcd00a88de5adf0",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2822,6 +2822,63 @@
             "time": "2023-09-19T17:58:10+00:00"
         },
         {
+            "name": "drupal/crop",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/crop.git",
+                "reference": "8.x-2.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/crop-8.x-2.3.zip",
+                "reference": "8.x-2.3",
+                "shasum": "8e109cf60077f4c605c4d1f895cb3dc28613a23a"
+            },
+            "require": {
+                "drupal/core": "^9.3 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.3",
+                    "datestamp": "1665437894",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Drupal Media Team",
+                    "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                },
+                {
+                    "name": "woprrr",
+                    "homepage": "https://www.drupal.org/user/858604"
+                }
+            ],
+            "description": "Provides storage and API for image crops.",
+            "homepage": "https://www.drupal.org/project/crop",
+            "support": {
+                "source": "https://git.drupalcode.org/project/crop",
+                "issues": "https://www.drupal.org/project/issues/crop"
+            }
+        },
+        {
             "name": "drupal/customerror",
             "version": "1.0.0-beta3",
             "source": {
@@ -3198,6 +3255,63 @@
             }
         },
         {
+            "name": "drupal/focal_point",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/focal_point.git",
+                "reference": "2.0.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/focal_point-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "8e809795ec6a68a0bc3740b0b0a41bfa53d4d6d5"
+            },
+            "require": {
+                "drupal/core": "^9.3 || ^10",
+                "drupal/crop": "^2.3",
+                "drupal/jquery_ui": "^1.6",
+                "drupal/jquery_ui_draggable": "^2.0"
+            },
+            "require-dev": {
+                "drupal/crop": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.2",
+                    "datestamp": "1690451892",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander Ross (bleen)",
+                    "homepage": "https://www.drupal.org/u/bleen",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Rajeshreeputra",
+                    "homepage": "https://www.drupal.org/user/3418561"
+                }
+            ],
+            "description": "Focal Point allows content creators to mark the most important part of an image for easier cropping.",
+            "homepage": "https://drupal.org/project/focal_point",
+            "support": {
+                "source": "https://cgit.drupalcode.org/focal_point",
+                "issues": "https://drupal.org/project/issues/focal_point",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
             "name": "drupal/gin",
             "version": "3.0.0-rc7",
             "source": {
@@ -3443,6 +3557,155 @@
             }
         },
         {
+            "name": "drupal/jquery_ui",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/jquery_ui.git",
+                "reference": "8.x-1.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/jquery_ui-8.x-1.6.zip",
+                "reference": "8.x-1.6",
+                "shasum": "0ddccdcf35a066de1843e1d9670677ee1a2faac0"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.6",
+                    "datestamp": "1668521197",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bnjmnm",
+                    "homepage": "https://www.drupal.org/user/2369194"
+                },
+                {
+                    "name": "jjeff",
+                    "homepage": "https://www.drupal.org/user/17190"
+                },
+                {
+                    "name": "lauriii",
+                    "homepage": "https://www.drupal.org/user/1078742"
+                },
+                {
+                    "name": "litwol",
+                    "homepage": "https://www.drupal.org/user/78134"
+                },
+                {
+                    "name": "mfb",
+                    "homepage": "https://www.drupal.org/user/12302"
+                },
+                {
+                    "name": "mfer",
+                    "homepage": "https://www.drupal.org/user/25701"
+                },
+                {
+                    "name": "mikelutz",
+                    "homepage": "https://www.drupal.org/user/2972409"
+                },
+                {
+                    "name": "nod_",
+                    "homepage": "https://www.drupal.org/user/598310"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
+                },
+                {
+                    "name": "RobLoach",
+                    "homepage": "https://www.drupal.org/user/61114"
+                },
+                {
+                    "name": "sun",
+                    "homepage": "https://www.drupal.org/user/54136"
+                },
+                {
+                    "name": "webchick",
+                    "homepage": "https://www.drupal.org/user/24967"
+                },
+                {
+                    "name": "Wim Leers",
+                    "homepage": "https://www.drupal.org/user/99777"
+                },
+                {
+                    "name": "zrpnr",
+                    "homepage": "https://www.drupal.org/user/1448368"
+                }
+            ],
+            "description": "Provides jQuery UI library.",
+            "homepage": "https://www.drupal.org/project/jquery_ui",
+            "support": {
+                "source": "https://git.drupalcode.org/project/jquery_ui"
+            }
+        },
+        {
+            "name": "drupal/jquery_ui_draggable",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/jquery_ui_draggable.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/jquery_ui_draggable-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "13a8f4bf037449cd176ddb967fc9cba9a466a705"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10",
+                "drupal/jquery_ui": "^1.6"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1670871516",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bnjmnm",
+                    "homepage": "https://www.drupal.org/user/2369194"
+                },
+                {
+                    "name": "lauriii",
+                    "homepage": "https://www.drupal.org/user/1078742"
+                },
+                {
+                    "name": "zrpnr",
+                    "homepage": "https://www.drupal.org/user/1448368"
+                }
+            ],
+            "description": "Provides jQuery UI Draggable library.",
+            "homepage": "https://www.drupal.org/project/jquery_ui_draggable",
+            "support": {
+                "source": "https://git.drupalcode.org/project/jquery_ui_draggable"
+            }
+        },
+        {
             "name": "drupal/jsonlog",
             "version": "4.0.0",
             "source": {
@@ -3622,6 +3885,54 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/linkit",
                 "issues": "http://drupal.org/project/linkit"
+            }
+        },
+        {
+            "name": "drupal/media_library_edit",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/media_library_edit.git",
+                "reference": "3.0.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/media_library_edit-3.0.2.zip",
+                "reference": "3.0.2",
+                "shasum": "5ca17d7c8fad363a2826b2a6c0709fcde3958499"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.0.2",
+                    "datestamp": "1671913381",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "ahebrank",
+                    "homepage": "https://www.drupal.org/user/3190515"
+                }
+            ],
+            "description": "Add an edit button to the Media Library widget when an item is selected.",
+            "homepage": "https://www.drupal.org/project/media_library_edit",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/media_library_edit",
+                "issues": "https://www.drupal.org/project/issues/media_library_edit"
             }
         },
         {

--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -5,10 +5,10 @@ dependencies:
   config:
     - field.field.media.image.field_byline
     - field.field.media.image.field_media_image
-    - image.style.thumbnail
+    - image.style.focal_point_preview
     - media.type.image
   module:
-    - image
+    - focal_point
 id: media.image.default
 targetEntityType: media
 bundle: image
@@ -23,12 +23,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_media_image:
-    type: image_image
+    type: image_focal_point
     weight: 1
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: focal_point_preview
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/config/sync/core.entity_form_display.media.image.media_library.yml
+++ b/config/sync/core.entity_form_display.media.image.media_library.yml
@@ -6,22 +6,24 @@ dependencies:
     - core.entity_form_mode.media.media_library
     - field.field.media.image.field_byline
     - field.field.media.image.field_media_image
-    - image.style.thumbnail
+    - image.style.focal_point_preview
     - media.type.image
   module:
-    - image
+    - focal_point
 id: media.image.media_library
 targetEntityType: media
 bundle: image
 mode: media_library
 content:
   field_media_image:
-    type: image_image
+    type: image_focal_point
     weight: -50
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: focal_point_preview
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -7,6 +7,7 @@ module:
   breakpoint: 0
   ckeditor5: 0
   config_filter: 0
+  crop: 0
   customerror: 0
   datetime: 0
   datetime_range: 0
@@ -45,6 +46,7 @@ module:
   field_group: 0
   file: 0
   filter: 0
+  focal_point: 0
   gin_toolbar: 0
   handy_cache_tags: 0
   image: 0
@@ -56,6 +58,7 @@ module:
   locale: 0
   media: 0
   media_library: 0
+  media_library_edit: 0
   menu_link_content: 0
   metatag: 0
   multiple_fields_remove_button: 0

--- a/config/sync/crop.settings.yml
+++ b/config/sync/crop.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: 7eGOTSG7bRv_AAqu-Ls8CSnob7zPF1ez-lD2OLZgBHs
+flush_derivative_images: true

--- a/config/sync/crop.type.focal_point.yml
+++ b/config/sync/crop.type.focal_point.yml
@@ -1,0 +1,14 @@
+uuid: da90a39d-a29f-464b-8b70-2528e1648472
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: flCi9IdafdLXlJqvoHguutUOiC05-aynK4niYN4YZ3o
+label: 'Focal point'
+id: focal_point
+description: 'Crop type used by Focal point module.'
+aspect_ratio: ''
+soft_limit_width: null
+soft_limit_height: null
+hard_limit_width: null
+hard_limit_height: null

--- a/config/sync/field.field.media.image.field_media_image.yml
+++ b/config/sync/field.field.media.image.field_media_image.yml
@@ -12,7 +12,7 @@ field_name: field_media_image
 entity_type: media
 bundle: image
 label: Image
-description: ''
+description: "You can set a focal point, by clicking on the preview on the image, moving the white target.<br>\r\nBy setting a focal point, you tell the system which part of the image to keep in focus when it gets cropped.<br>\r\nUse the \"preview\" function, to see how your image will be cropped across image styles."
 required: true
 translatable: true
 default_value: {  }
@@ -22,7 +22,7 @@ settings:
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
+  max_filesize: 25mb
   max_resolution: ''
   min_resolution: ''
   alt_field: true
@@ -30,7 +30,7 @@ settings:
   title_field: false
   title_field_required: false
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null

--- a/config/sync/focal_point.settings.yml
+++ b/config/sync/focal_point.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: 8JOAPEbjHMB4rDFCsu3EXEx6L2UDQ5SSDyN0d7S0Ic0
+crop_type: focal_point
+default_value: '50,50'

--- a/config/sync/image.style.campaign_image.yml
+++ b/config/sync/image.style.campaign_image.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 name: campaign_image
-label: 'Campaign image'
+label: 'Campaign image (? x 150px)'
 effects:
   d2931fb8-e714-4189-9b45-86be75b9aa86:
     uuid: d2931fb8-e714-4189-9b45-86be75b9aa86

--- a/config/sync/image.style.focal_point_preview.yml
+++ b/config/sync/image.style.focal_point_preview.yml
@@ -1,0 +1,15 @@
+uuid: a1f1b6a1-dc88-49c7-9b10-46c27bd6d606
+langcode: en
+status: true
+dependencies: {  }
+name: focal_point_preview
+label: 'Focal Point Preview'
+effects:
+  56a54da3-ea68-4942-9897-389c5fbdc08d:
+    uuid: 56a54da3-ea68-4942-9897-389c5fbdc08d
+    id: image_scale
+    weight: 1
+    data:
+      width: 300
+      height: null
+      upscale: true

--- a/config/sync/image.style.media_library.yml
+++ b/config/sync/image.style.media_library.yml
@@ -2,19 +2,21 @@ uuid: bef7f48f-780d-4676-941f-f98a54be0179
 langcode: en
 status: true
 dependencies:
+  module:
+    - focal_point
   enforced:
     module:
       - media_library
 _core:
   default_config_hash: 7qJqToD1OQLAyeswpmg7M0LRxQlw1URQkJDWUJCnmR8
 name: media_library
-label: 'Media Library thumbnail (220×220)'
+label: 'Media Library thumbnail (220 x 220px)'
 effects:
-  75b076a8-1234-4b42-85db-bf377c4d8d5f:
-    uuid: 75b076a8-1234-4b42-85db-bf377c4d8d5f
-    id: image_scale
-    weight: 0
+  b3ee86ce-f4be-48ac-8987-354a1459ed55:
+    uuid: b3ee86ce-f4be-48ac-8987-354a1459ed55
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 220
       height: 220
-      upscale: false
+      crop_type: focal_point

--- a/config/sync/image.style.paragraph_squared.yml
+++ b/config/sync/image.style.paragraph_squared.yml
@@ -1,0 +1,17 @@
+uuid: fe28a735-7d65-4a02-9904-25a72982b0e1
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: paragraph_squared
+label: 'Paragraph, Squared (1:1 / 496x496px)'
+effects:
+  5e30c738-9948-46ce-9cb2-6890ed071d26:
+    uuid: 5e30c738-9948-46ce-9cb2-6890ed071d26
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 496
+      height: 496
+      crop_type: focal_point

--- a/config/sync/image.style.paragraph_wide.yml
+++ b/config/sync/image.style.paragraph_wide.yml
@@ -1,0 +1,17 @@
+uuid: 37b0bebe-2aa3-4da3-9faf-3a1f1a025883
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: paragraph_wide
+label: 'Paragraph, Wide (896x670px)'
+effects:
+  28b07894-b322-4b00-89c5-49c8fdb2afe7:
+    uuid: 28b07894-b322-4b00-89c5-49c8fdb2afe7
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 896
+      height: 670
+      crop_type: focal_point

--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -26,6 +26,14 @@
 .ui-dialog-content[style] {
   height: calc(100% - 140px) !important;
   max-height: 100% !important;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  box-sizing: border-box;
+}
+
+/* Tweak the focal point preview. */
+.focal-point-derivative-preview-label {
+  font-size: 1em;
 }
 
 /* Display name and price fields inline for ticket categories. */


### PR DESCRIPTION
- Using the 'focal_points' module, which also comes with a preview functionality, that allows the editor to see which image styles will be created, based on the crop.
- Also includes 'media_library_edit' module, to improve the editor experience when editing content.
- A few minor admin CSS tweaks, to make the focal point preview play nice in the GIN admin theme.
