### PR TITLE
Update aspect ratio in event hero image

### DIFF
--- a/config/sync/core.entity_view_mode.media.hero_wide.yml
+++ b/config/sync/core.entity_view_mode.media.hero_wide.yml
@@ -5,6 +5,6 @@ dependencies:
   module:
     - media
 id: media.hero_wide
-label: 'Hero wide (16/9)'
+label: 'Hero wide (4/3)'
 targetEntityType: media
 cache: true

--- a/config/sync/image.style.hero_wide.yml
+++ b/config/sync/image.style.hero_wide.yml
@@ -1,15 +1,17 @@
 uuid: fbc150b6-cc72-4520-a434-9d0dde58e4bc
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_wide
-label: 'Hero wide (16/9)'
+label: 'Hero wide (4/3)'
 effects:
-  7f3e51a9-6f0e-4672-8f59-bd82b434a2e4:
-    uuid: 7f3e51a9-6f0e-4672-8f59-bd82b434a2e4
-    id: image_scale_and_crop
-    weight: 1
+  8d2afbd6-1b08-4b50-b48e-534e108d3549:
+    uuid: 8d2afbd6-1b08-4b50-b48e-534e108d3549
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 800
-      height: 450
-      anchor: center-center
+      height: 600
+      crop_type: focal_point

--- a/config/sync/language/da/views.view.files.yml
+++ b/config/sync/language/da/views.view.files.yml
@@ -26,6 +26,8 @@ display:
           label: Ændringsdato
         count:
           label: 'Brugt i'
+          alter:
+            path: 'admin/content/files/usage/{{ fid }}'
       pager:
         options:
           tags:

--- a/config/sync/language/da/views.view.user_admin_people.yml
+++ b/config/sync/language/da/views.view.user_admin_people.yml
@@ -19,6 +19,9 @@ display:
           label: Roller
         created:
           label: 'Medlem i'
+          settings:
+            future_format: '@interval'
+            past_format: '@interval'
         access:
           label: 'Seneste tilgang'
           settings:


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-96


#### Description
This pull request updates the event hero image from a 16:9 to a 4:3 aspect ratio and adds a focal point


#### Screenshot of the result
<img width="1054" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/de40ff88-a1c0-4808-8606-aa39313d967a">