### PR TITLE
Add paragraph field to event and enable the link paragraph

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_paragraphs
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - field.field.node.event.field_ticket_categories
@@ -16,8 +17,8 @@ dependencies:
     - address
     - datetime_range
     - link
-    - paragraphs
     - media_library
+    - paragraphs
     - text
 id: node.event.default
 targetEntityType: node
@@ -58,6 +59,24 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
+    third_party_settings: {  }
+  field_event_paragraphs:
+    type: paragraphs
+    weight: 34
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
     third_party_settings: {  }
   field_event_place:
     type: string_textfield

--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -67,17 +67,27 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
-      closed_mode: summary
+      edit_mode: closed
+      closed_mode: preview
       autocollapse: none
       closed_mode_threshold: 0
-      add_mode: dropdown
+      add_mode: modal
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
       features:
+        add_above: '0'
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
-    third_party_settings: {  }
+    third_party_settings:
+      paragraphs_features:
+        add_in_between: true
+        add_in_between_link_count: 0
+        delete_confirmation: true
+        show_drag_and_drop: true
+      paragraphs_ee:
+        paragraphs_ee:
+          dialog_off_canvas: false
+          dialog_style: tiles
   field_event_place:
     type: string_textfield
     weight: 32

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_paragraphs
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - field.field.node.event.field_ticket_categories
@@ -57,6 +58,15 @@ content:
       target: ''
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_event_paragraphs:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 7
     region: content
   field_event_place:
     type: string

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_paragraphs
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - field.field.node.event.field_ticket_categories
@@ -30,7 +31,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   field_event_date:
     type: daterange_plain
@@ -55,7 +56,7 @@ content:
       view_mode: hero_wide
       link: false
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   field_event_link:
     type: link
@@ -69,13 +70,22 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_event_paragraphs:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 7
+    region: content
   field_event_place:
     type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   field_ticket_categories:
     type: entity_reference_revisions_entity_view
@@ -84,7 +94,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
 hidden:
   field_event_state: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_paragraphs
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - field.field.node.event.field_ticket_categories
@@ -31,6 +32,7 @@ hidden:
   field_event_description: true
   field_event_image: true
   field_event_link: true
+  field_event_paragraphs: true
   field_event_place: true
   field_event_state: true
   field_ticket_categories: true

--- a/config/sync/field.field.node.event.field_event_paragraphs.yml
+++ b/config/sync/field.field.node.event.field_event_paragraphs.yml
@@ -1,0 +1,45 @@
+uuid: 102d30ad-b093-4f05-bb7a-501e27d6321a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_paragraphs
+    - node.type.event
+    - paragraphs.paragraphs_type.campaign_rule
+    - paragraphs.paragraphs_type.event_ticket_category
+  module:
+    - entity_reference_revisions
+id: node.event.field_event_paragraphs
+field_name: field_event_paragraphs
+entity_type: node
+bundle: event
+label: Paragraphs
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      campaign_rule: campaign_rule
+      event_ticket_category: event_ticket_category
+    negate: 1
+    target_bundles_drag_drop:
+      campaign_rule:
+        weight: 6
+        enabled: true
+      event_ticket_category:
+        weight: 7
+        enabled: true
+      links:
+        weight: 8
+        enabled: false
+      medias:
+        weight: 9
+        enabled: false
+      text_body:
+        weight: 10
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.storage.node.field_event_paragraphs.yml
+++ b/config/sync/field.storage.node.field_event_paragraphs.yml
@@ -1,0 +1,21 @@
+uuid: d0ca1814-702e-4a46-a023-8346059c381c
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_event_paragraphs
+field_name: field_event_paragraphs
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -62,6 +62,9 @@
       </div>
     </dl>
   </section>
+  <section class="event-paragraphs">
+    {{ content.field_event_paragraphs }}
+  </section>
   {{ content|without('field_event_date', 'field_event_description', 'field_event_link', 'field_event_address',
-  'field_event_place', 'field_ticket_categories', 'field_event_image') }}
+  'field_event_place', 'field_ticket_categories', 'field_event_image', 'field_event_paragraphs') }}
 </article>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-94

#### Description
This pull request adds a new 'paragraph' field to our event content type. This feature enables the use of reusable paragraphs, enhancing content flexibility across different types. Currently, this update focuses on integrating 'link and the text body paragraphs', which are essential for our events.


#### Screenshot of the result
<img width="1054" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/8d7d5b3e-348b-43a4-a2c5-d2d435e334ce">