### PR TITLE
Bug/ddflsbp 362/undefined value for default interest periods

### DIFF
--- a/config/sync/dpl_library_agency.general_settings.yml
+++ b/config/sync/dpl_library_agency.general_settings.yml
@@ -1,10 +1,6 @@
 reservation_sms_notifications_disabled: 0
 expiration_warning_days_before_config: 6
 interest_periods_config: '180-6 måneder'
-default_interest_period_config: '[
-    {
-        "value": "180",
-        "label": "6 måneder"
-    }
-]'
+default_interest_period_config:  "180"
+
 ereolen_my_page_url: 'https://ereolen.dk/user/me'

--- a/config/sync/dpl_library_agency.general_settings.yml
+++ b/config/sync/dpl_library_agency.general_settings.yml
@@ -1,6 +1,6 @@
 reservation_sms_notifications_disabled: 0
 expiration_warning_days_before_config: 6
 interest_periods_config: '180-6 måneder'
-default_interest_period_config:  "180"
+default_interest_period_config: '180'
 
 ereolen_my_page_url: 'https://ereolen.dk/user/me'


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-362

#### Description

The configuration for default_interest_period_config was unusable as it was formatted as an "stringformatted" array. But as the default_interest_period field is a select field, it would only need a value. Now the default_interest_period_config has been formatted correctly to only contain that value.