### PR TITLE
Introduce `dpl_identity` module for identity color customization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,7 @@
         "drush/drush": "^12",
         "myclabs/php-enum": "^1.8",
         "phpdocumentor/reflection-docblock": "^5.3",
+        "spatie/color": "^1.5",
         "symfony/property-access": "^6.2",
         "symfony/property-info": "^6.2",
         "thecodingmachine/safe": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c10e7b6bd90d5c05829a062bd704795e",
+    "content-hash": "2c19be0fe43a82c8eb43722815afc2d8",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -7612,6 +7612,65 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "spatie/color",
+            "version": "1.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/color.git",
+                "reference": "49739265900cabce4640cd26c3266fd8d2cca390"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/color/zipball/49739265900cabce4640cd26c3266fd8d2cca390",
+                "reference": "49739265900cabce4640cd26c3266fd8d2cca390",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3|^8.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^1.22",
+                "phpunit/phpunit": "^6.5||^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Color\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A little library to handle color conversions",
+            "homepage": "https://github.com/spatie/color",
+            "keywords": [
+                "color",
+                "conversion",
+                "rgb",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/color/issues",
+                "source": "https://github.com/spatie/color/tree/1.5.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-18T12:58:32+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -20,6 +20,7 @@ module:
   dpl_favorites_list_material_component: 0
   dpl_fbs: 0
   dpl_fees: 0
+  dpl_identity: 0
   dpl_instant_loan: 0
   dpl_library_agency: 0
   dpl_library_token: 0

--- a/web/modules/custom/dpl_identity/dpl_identity.info.yml
+++ b/web/modules/custom/dpl_identity/dpl_identity.info.yml
@@ -1,0 +1,5 @@
+name: "dpl identity"
+type: module
+description: "Add identity settings"
+package: DPL
+core_version_requirement: ^10

--- a/web/modules/custom/dpl_identity/dpl_identity.links.menu.yml
+++ b/web/modules/custom/dpl_identity/dpl_identity.links.menu.yml
@@ -1,0 +1,6 @@
+dpl_identity.color:
+  title: "Identity color"
+  description: "Add identity color"
+  parent: "system.admin_config_services"
+  route_name: dpl_identity.color
+  weight: 0

--- a/web/modules/custom/dpl_identity/dpl_identity.links.menu.yml
+++ b/web/modules/custom/dpl_identity/dpl_identity.links.menu.yml
@@ -1,6 +1,6 @@
-dpl_identity.color:
-  title: "Identity color"
-  description: "Add identity color"
+dpl_identity.settings:
+  title: "Identity Settings"
+  description: "Configure identity settings"
   parent: "system.admin_config_services"
-  route_name: dpl_identity.color
+  route_name: dpl_identity.settings
   weight: 0

--- a/web/modules/custom/dpl_identity/dpl_identity.module
+++ b/web/modules/custom/dpl_identity/dpl_identity.module
@@ -17,7 +17,11 @@ use function Safe\substr;
  */
 function dpl_identity_preprocess_html(array &$variables): void {
   $config = Drupal::config('dpl_identity.settings');
-  $identityColor = $config->get('identity_color') ?? '#365342';
+  $identityColor = $config->get('identity_color');
+
+  if (empty($identityColor)) {
+    return;
+  }
 
   [$h, $s, $l] = dpl_identity_hex_to_hsl($identityColor);
 

--- a/web/modules/custom/dpl_identity/dpl_identity.module
+++ b/web/modules/custom/dpl_identity/dpl_identity.module
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for dpl identity module.
+ */
+
+use function Safe\substr;
+
+/**
+ * Implements hook_preprocess_html().
+ *
+ * Adds custom inline CSS based on the identity color setting.
+ *
+ * @param array $variables
+ *   An associative array of variables passed to the theme layer.
+ */
+function dpl_identity_preprocess_html(array &$variables): void {
+  $config = Drupal::config('dpl_identity.settings');
+  $identityColor = $config->get('identity_color') ?? '#365342';
+
+  [$h, $s, $l] = dpl_identity_hex_to_hsl($identityColor);
+
+  $custom_css = "
+    :root {
+      --identity-color-h: {$h} !important;
+      --identity-color-s: {$s}% !important;
+      --identity-color-l: {$l}% !important;
+    }
+  ";
+
+  $variables['#attached']['html_head'][] = [
+    [
+      '#type' => 'inline_template',
+      '#template' => '<style type="text/css">{{ style|safe_join("") }}</style>',
+      '#context' => ['style' => [$custom_css]],
+    ],
+    'dpl_identity_custom_identity_color',
+  ];
+}
+
+/**
+ * Converts a HEX color to its HSL components.
+ *
+ * @param string $hexColor
+ *   The color in hex format.
+ *
+ * @return array<float>
+ *   Returns an array containing the HSL components.
+ */
+function dpl_identity_hex_to_hsl(string $hexColor): array {
+  $hexColor = str_replace('#', '', $hexColor);
+
+  $r = hexdec(substr($hexColor, 0, 2));
+  $g = hexdec(substr($hexColor, 2, 2));
+  $b = hexdec(substr($hexColor, 4, 2));
+
+  $r = $r / 255;
+  $g = $g / 255;
+  $b = $b / 255;
+
+  $max = max($r, $g, $b);
+  $min = min($r, $g, $b);
+
+  $l = ($max + $min) / 2;
+  $d = $max - $min;
+
+  // Initialize $h and $s to avoid undefined variable warnings.
+  $h = $s = 0;
+
+  if ($d != 0) {
+    $s = $d / (1 - abs(2 * $l - 1));
+
+    switch ($max) {
+      case $r:
+        $h = 60 * fmod((($g - $b) / $d), 6);
+        if ($b > $g) {
+          $h += 360;
+        }
+        break;
+
+      case $g:
+        $h = 60 * (($b - $r) / $d + 2);
+        break;
+
+      case $b:
+        $h = 60 * (($r - $g) / $d + 4);
+        break;
+    }
+  }
+
+  $h = round($h, 2);
+  $s = round($s * 100, 2);
+  $l = round($l * 100, 2);
+
+  return [$h, $s, $l];
+}

--- a/web/modules/custom/dpl_identity/dpl_identity.module
+++ b/web/modules/custom/dpl_identity/dpl_identity.module
@@ -5,7 +5,7 @@
  * Primary module hooks for dpl identity module.
  */
 
-use function Safe\substr;
+use Spatie\Color\Hex;
 
 /**
  * Implements hook_preprocess_html().
@@ -23,13 +23,14 @@ function dpl_identity_preprocess_html(array &$variables): void {
     return;
   }
 
-  [$h, $s, $l] = dpl_identity_hex_to_hsl($identityColor);
+  // Use Spatie's Hex class to convert the color.
+  $hslColor = Hex::fromString($identityColor)->toHsl();
 
   $custom_css = "
     :root {
-      --identity-color-h: {$h} !important;
-      --identity-color-s: {$s}% !important;
-      --identity-color-l: {$l}% !important;
+      --identity-color-h: {$hslColor->hue()} !important;
+      --identity-color-s: {$hslColor->saturation()}% !important;
+      --identity-color-l: {$hslColor->lightness()}% !important;
     }
   ";
 
@@ -41,61 +42,4 @@ function dpl_identity_preprocess_html(array &$variables): void {
     ],
     'dpl_identity_custom_identity_color',
   ];
-}
-
-/**
- * Converts a HEX color to its HSL components.
- *
- * @param string $hexColor
- *   The color in hex format.
- *
- * @return array<float>
- *   Returns an array containing the HSL components.
- */
-function dpl_identity_hex_to_hsl(string $hexColor): array {
-  $hexColor = str_replace('#', '', $hexColor);
-
-  $r = hexdec(substr($hexColor, 0, 2));
-  $g = hexdec(substr($hexColor, 2, 2));
-  $b = hexdec(substr($hexColor, 4, 2));
-
-  $r = $r / 255;
-  $g = $g / 255;
-  $b = $b / 255;
-
-  $max = max($r, $g, $b);
-  $min = min($r, $g, $b);
-
-  $l = ($max + $min) / 2;
-  $d = $max - $min;
-
-  // Initialize $h and $s to avoid undefined variable warnings.
-  $h = $s = 0;
-
-  if ($d != 0) {
-    $s = $d / (1 - abs(2 * $l - 1));
-
-    switch ($max) {
-      case $r:
-        $h = 60 * fmod((($g - $b) / $d), 6);
-        if ($b > $g) {
-          $h += 360;
-        }
-        break;
-
-      case $g:
-        $h = 60 * (($b - $r) / $d + 2);
-        break;
-
-      case $b:
-        $h = 60 * (($r - $g) / $d + 4);
-        break;
-    }
-  }
-
-  $h = round($h, 2);
-  $s = round($s * 100, 2);
-  $l = round($l * 100, 2);
-
-  return [$h, $s, $l];
 }

--- a/web/modules/custom/dpl_identity/dpl_identity.routing.yml
+++ b/web/modules/custom/dpl_identity/dpl_identity.routing.yml
@@ -1,7 +1,7 @@
-dpl_identity.color:
-  path: "/admin/config/dpl_identity"
+dpl_identity.settings:
+  path: "/admin/config/dpl_identity/settings"
   defaults:
     _form: '\Drupal\dpl_identity\Form\IdentityConfigForm'
-    _title: "Identity Color"
+    _title: "Identity Settings"
   requirements:
     _permission: "administer site configuration"

--- a/web/modules/custom/dpl_identity/dpl_identity.routing.yml
+++ b/web/modules/custom/dpl_identity/dpl_identity.routing.yml
@@ -1,0 +1,7 @@
+dpl_identity.color:
+  path: "/admin/config/dpl_identity"
+  defaults:
+    _form: '\Drupal\dpl_identity\Form\IdentityConfigForm'
+    _title: "Identity Color"
+  requirements:
+    _permission: "administer site configuration"

--- a/web/modules/custom/dpl_identity/src/Form/IdentityConfigForm.php
+++ b/web/modules/custom/dpl_identity/src/Form/IdentityConfigForm.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\dpl_identity\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines a form for setting identity configuration.
+ */
+class IdentityConfigForm extends FormBase {
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new IdentityConfigForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): IdentityConfigForm {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'dpl_identity_config_form';
+  }
+
+  /**
+   * Form submission handler.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $values = $form_state->getValues();
+    $this->configFactory->getEditable('dpl_identity.settings')
+      ->set('identity_color', $values['identity_color'])
+      ->save();
+  }
+
+  /**
+   * Builds the form.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return array
+   *   The form structure.
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // Load existing configuration for the form.
+    $config = $this->configFactory->get('dpl_identity.settings');
+
+    $form['identity_color'] = [
+      '#type' => 'color',
+      '#title' => $this->t('Identity Color'),
+      '#default_value' => $config->get('identity_color') ?? '#365342',
+      '#description' => $this->t('Choose library identity color.'),
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save Configuration'),
+      '#button_type' => 'primary',
+    ];
+
+    return $form;
+  }
+
+}

--- a/web/modules/custom/dpl_identity/src/Form/IdentityConfigForm.php
+++ b/web/modules/custom/dpl_identity/src/Form/IdentityConfigForm.php
@@ -2,40 +2,21 @@
 
 namespace Drupal\dpl_identity\Form;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Defines a form for setting identity configuration.
  */
-class IdentityConfigForm extends FormBase {
-
-  /**
-   * The config factory service.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
-
-  /**
-   * Constructs a new IdentityConfigForm object.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory service.
-   */
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->configFactory = $config_factory;
-  }
+class IdentityConfigForm extends ConfigFormBase {
 
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container): IdentityConfigForm {
-    return new static(
-      $container->get('config.factory')
-    );
+  protected function getEditableConfigNames() {
+    return [
+      'dpl_identity.settings',
+    ];
   }
 
   /**
@@ -46,49 +27,36 @@ class IdentityConfigForm extends FormBase {
   }
 
   /**
-   * Form submission handler.
-   *
-   * @param array $form
-   *   An associative array containing the structure of the form.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The current state of the form.
-   */
-  public function submitForm(array &$form, FormStateInterface $form_state): void {
-    $values = $form_state->getValues();
-    $this->configFactory->getEditable('dpl_identity.settings')
-      ->set('identity_color', $values['identity_color'])
-      ->save();
-  }
-
-  /**
    * Builds the form.
    *
-   * @param array $form
-   *   An associative array containing the structure of the form.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The current state of the form.
-   *
-   * @return array
-   *   The form structure.
+   * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     // Load existing configuration for the form.
-    $config = $this->configFactory->get('dpl_identity.settings');
+    $config = $this->config('dpl_identity.settings');
 
     $form['identity_color'] = [
       '#type' => 'color',
-      '#title' => $this->t('Identity Color'),
-      '#default_value' => $config->get('identity_color') ?? '#365342',
-      '#description' => $this->t('Choose library identity color.'),
+      '#title' => $this->t('Identity Color', [], ['context' => 'Identity settings']),
+      '#default_value' => $config->get('identity_color'),
+      '#description' => $this->t('Choose library identity color.', [], ['context' => 'Identity settings']),
     ];
 
-    $form['actions']['submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Save Configuration'),
-      '#button_type' => 'primary',
-    ];
+    return parent::buildForm($form, $form_state);
+  }
 
-    return $form;
+  /**
+   * Form submission handler.
+   *
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    // Save the configuration.
+    $this->config('dpl_identity.settings')
+      ->set('identity_color', $form_state->getValue('identity_color'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
   }
 
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-100

#### Description
This pull request introduces the `dpl_identity module, designed to enable users to choose a preferred identity color.

Upon selecting a color, the module dynamically inserts a style tag into the HTML head. This action effectively overrides the predefined style variables, allowing for customized color schemes.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/09cbf5d4-c76c-4090-8e9c-bdf54c23f9ed

