### PR TITLE
Add multiple text fields for event partners and modify rendering of event place

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_paragraphs
+    - field.field.node.event.field_event_partners
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - field.field.node.event.field_ticket_categories
@@ -27,19 +28,19 @@ mode: default
 content:
   field_event_address:
     type: address_default
-    weight: 31
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   field_event_date:
     type: daterange_default
-    weight: 27
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_event_description:
     type: text_textarea
-    weight: 28
+    weight: 4
     region: content
     settings:
       rows: 5
@@ -47,14 +48,14 @@ content:
     third_party_settings: {  }
   field_event_image:
     type: media_library_widget
-    weight: 33
+    weight: 10
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_event_link:
     type: link_default
-    weight: 30
+    weight: 6
     region: content
     settings:
       placeholder_url: ''
@@ -62,7 +63,7 @@ content:
     third_party_settings: {  }
   field_event_paragraphs:
     type: paragraphs
-    weight: 34
+    weight: 11
     region: content
     settings:
       title: Paragraph
@@ -88,9 +89,17 @@ content:
         paragraphs_ee:
           dialog_off_canvas: false
           dialog_style: tiles
+  field_event_partners:
+    type: string_textfield
+    weight: 9
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_event_place:
     type: string_textfield
-    weight: 32
+    weight: 8
     region: content
     settings:
       size: 60
@@ -98,13 +107,13 @@ content:
     third_party_settings: {  }
   field_event_state:
     type: options_select
-    weight: 26
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   field_ticket_categories:
     type: paragraphs
-    weight: 29
+    weight: 5
     region: content
     settings:
       title: Paragraph

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_paragraphs
+    - field.field.node.event.field_event_partners
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - field.field.node.event.field_ticket_categories
@@ -67,6 +68,14 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 7
+    region: content
+  field_event_partners:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_event_place:
     type: string

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_paragraphs
+    - field.field.node.event.field_event_partners
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - field.field.node.event.field_ticket_categories
@@ -78,6 +79,14 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 7
+    region: content
+  field_event_partners:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_event_place:
     type: string

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
     - field.field.node.event.field_event_paragraphs
+    - field.field.node.event.field_event_partners
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - field.field.node.event.field_ticket_categories
@@ -33,6 +34,7 @@ hidden:
   field_event_image: true
   field_event_link: true
   field_event_paragraphs: true
+  field_event_partners: true
   field_event_place: true
   field_event_state: true
   field_ticket_categories: true

--- a/config/sync/field.field.node.event.field_event_partners.yml
+++ b/config/sync/field.field.node.event.field_event_partners.yml
@@ -1,0 +1,19 @@
+uuid: fe259a42-4879-41a0-81b9-e7356cb8f8e6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_partners
+    - node.type.event
+id: node.event.field_event_partners
+field_name: field_event_partners
+entity_type: node
+bundle: event
+label: 'Event partners'
+description: 'A list of partners for the event'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_event_partners.yml
+++ b/config/sync/field.storage.node.field_event_partners.yml
@@ -1,0 +1,21 @@
+uuid: 5e247352-8d54-4cdf-b394-2fa6bf64dcd8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_event_partners
+field_name: field_event_partners
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/dpl_example_content/content/node/56bfda4c-2a5f-4fda-bb98-ffb5106f0a34.yml
+++ b/web/modules/custom/dpl_example_content/content/node/56bfda4c-2a5f-4fda-bb98-ffb5106f0a34.yml
@@ -191,9 +191,16 @@ default:
             -
               value: '<h2>Barokken er en kulturperiode der i Danmark gør sig gældende fra omkring 1650 – 1720</h2><p>Barokken er udtryk for en storslået og prangende stilretning inden for billedkunst, musik, arkitektur og litteratur, hvor man dyrkede det teatralske, storladne og sanselige udtryk. I dansk litteraturhistorie er det Anders Arrebo (1587-1637), som indleder barokken med sin oversættelse af Davis salmer i 1623 og Kingo bliver den kanoniserede repræsentant for perioden.<br><br>Barokkens vigtigste prosaværk i Danmark er Leonora Christina Ulfeldts (1621-1698) biografi ”Jammers minde”. ”Jammers minde” beskriver de 22 år, Leonora Christine sad fængslet i Blåtårn, anklaget for højforræderi af kong Frederik den 3.<br><br>Under perioden blev kunsten nærmest propaganda, som bl.a. i form af hyldestdigte understregede, at kongens plads var lige efter Guds. Salmer hyldede Gud som den, der giver verden mening. Samlerne er fyldt med billedsprog og modsætninger, som skal vise splittelsen mellem vores overfladiske liv og Gud, som lover, at der er en mening med tilværelsen.</p>'
               format: basic
+  field_event_partners:
+    -
+      value: 'Aarhus Musikskole'
+    -
+      value: 'Den Vestdanske Filmpulje sammen med Åby Biblioteks venner'
   field_event_place:
     -
       value: Hovedbibliotek
+    -
+      value: 'Greve bibliotek'
   field_event_state:
     -
       value: Active

--- a/web/themes/custom/novel/templates/fields/field--node--field-event-partners--event.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-event-partners--event.html.twig
@@ -1,0 +1,1 @@
+{% include "@novel/fields/list-description-item.html.twig" %}

--- a/web/themes/custom/novel/templates/fields/field--node--field-event-place--event.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-event-place--event.html.twig
@@ -1,0 +1,1 @@
+{% include "@novel/fields/list-description-item.html.twig" %}

--- a/web/themes/custom/novel/templates/fields/list-description-item.html.twig
+++ b/web/themes/custom/novel/templates/fields/list-description-item.html.twig
@@ -1,0 +1,13 @@
+{% if items|length > 1 %}
+  <ul>
+    {% for item in items %}
+      <li>{{ item.content }}</li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <span>
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  </span>
+{% endif %}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -48,25 +48,17 @@
             {{ "Place"|trans }}:
           </dt>
           <dd class="list-description__value">
-            <ul>
-              {% for place in content.field_event_place['#items'] %}
-                <li>{{ place.value }}</li>
-              {% endfor %}
-            </ul>
+            {{ content.field_event_place }}
           </dd>
         </div>
       {% endif %}
-      {% if elements.field_event_partners.0 %}
+      {% if content.field_event_partners.0 %}
         <div class="list-description__item">
           <dt class="list-description__key">
             {{ "Partners"|trans }}:
           </dt>
           <dd class="list-description__value">
-            <ul>
-              {% for partner in elements.field_event_partners['#items'] %}
-                <li>{{ partner.value }}</li>
-              {% endfor %}
-            </ul>
+            {{ content.field_event_partners }}
           </dd>
         </div>
       {% endif %}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -1,19 +1,19 @@
 <article {{ attributes.addClass('event-page') }}>
   <header class="event-header">
-        <section class="event-header__content">
-            <!-- Tag -->
-            {{ content.field_event_date }}
-            <h1 class="event-header__title">{{ label }}</h1>
-            {{ content.field_event_link }}
-        </section>
-        <section class="event-header__visual ">
+    <section class="event-header__content">
+      <!-- Tag -->
+      {{ content.field_event_date }}
+      <h1 class="event-header__title">{{ label }}</h1>
+      {{ content.field_event_link }}
+    </section>
+    <section class="event-header__visual ">
       {% if content.field_event_image.0 %}
         {{ content.field_event_image }}
-        {% else %}
+      {% else %}
         <div class="image-credited__no-image"></div>
       {% endif %}
-        </section>
-    </header>
+    </section>
+  </header>
 
   <section class="event-description">
     <h2 class="event-description__title">{{ "Description"|trans }}</h2>
@@ -25,15 +25,15 @@
     </div>
     <dl class="list-description event-description__info list-description--event">
       {% if content.field_event_date.0 %}
-                <div class="list-description__item">
-                    <dt class="list-description__key">{{ "Time"|trans }}</dt>
-                    <dd class="list-description__value">
-                        {{ content.field_event_date.0.start_date["#markup"]|date("H:i") }}
-                        -
-                        {{ content.field_event_date.0.end_date["#markup"]|date("H:i") }}
-                    </dd>
-                </div>
-            {% endif %}
+        <div class="list-description__item">
+          <dt class="list-description__key">{{ "Time"|trans }}</dt>
+          <dd class="list-description__value">
+            {{ content.field_event_date.0.start_date["#markup"]|date("H:i") }}
+            -
+            {{ content.field_event_date.0.end_date["#markup"]|date("H:i") }}
+          </dd>
+        </div>
+      {% endif %}
       {% if content.field_ticket_categories.0 %}
         <div class="list-description__item">
           <dt class="list-description__key">{{ "Price"|trans }}</dt>
@@ -43,14 +43,32 @@
         </div>
       {% endif %}
       {% if content.field_event_place.0 %}
-      <div class="list-description__item">
-        <dt class="list-description__key">
-          {{ "Place"|trans }}:
-        </dt>
-        <dd class="list-description__value">
-          {{ content.field_event_place }}
-        </dd>
-      </div>
+        <div class="list-description__item">
+          <dt class="list-description__key">
+            {{ "Place"|trans }}:
+          </dt>
+          <dd class="list-description__value">
+            <ul>
+              {% for place in content.field_event_place['#items'] %}
+                <li>{{ place.value }}</li>
+              {% endfor %}
+            </ul>
+          </dd>
+        </div>
+      {% endif %}
+      {% if elements.field_event_partners.0 %}
+        <div class="list-description__item">
+          <dt class="list-description__key">
+            {{ "Partners"|trans }}:
+          </dt>
+          <dd class="list-description__value">
+            <ul>
+              {% for partner in elements.field_event_partners['#items'] %}
+                <li>{{ partner.value }}</li>
+              {% endfor %}
+            </ul>
+          </dd>
+        </div>
       {% endif %}
       <div class="list-description__item">
         <dt class="list-description__key">


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-27


#### Description
This pull request adds multiple text fields for event partners and modifies the rendering of the event place field to be an unordered list.


#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/f1db1123-d5e0-4762-ba0a-f7fc5eae6a43

