### PR TITLE
Ensure that translations added to release gets registered

### DIFF
--- a/.github/workflows/translate-source.yml
+++ b/.github/workflows/translate-source.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - develop
+      - release/**
+
 jobs:
 
   SendToPoeditor:


### PR DESCRIPTION
Since we work with release branches we want translations to be registered regulary.

Before this change we only registered translations when changes where merged into develop.
That caused confusion and forced us to merge the release into develop and create an new demo environment.
If we did not do that, the translation changes would not be registered.
