### PR TITLE
Change patron menu translation function string params

### DIFF
--- a/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
+++ b/web/modules/custom/dpl_patron_menu/src/Plugin/Block/PatronMenuBlock.php
@@ -108,46 +108,46 @@ class PatronMenuBlock extends BlockBase implements ContainerFactoryPluginInterfa
     // generated menu. A place for further improvements.
     $menu = [
       [
-        "name" => $this->t("Dashboard", [], ["context" => 'Patron menu']),
-        "link" => dpl_react_apps_ensure_url_is_string(
+        "name" => $this->t('Dashboard', [], ['context' => 'Patron menu']),
+        'link' => dpl_react_apps_ensure_url_is_string(
           Url::fromRoute('dpl_dashboard.list', [], ['absolute' => TRUE])->toString()
         ),
-        "dataId" => "40",
+        'dataId' => '40',
       ],
       [
-        "name" => $this->t("Loans", [], ["context" => 'Patron menu']),
-        "link" => dpl_react_apps_ensure_url_is_string(
+        'name' => $this->t('Loans', [], ['context' => 'Patron menu']),
+        'link' => dpl_react_apps_ensure_url_is_string(
           Url::fromRoute('dpl_loans.list', [], ['absolute' => TRUE])->toString()
         ),
-        "dataId" => "1",
+        'dataId' => '1',
       ],
       [
-        "name" => $this->t("Reservations", [], ["context" => 'Patron menu']),
-        "link" => dpl_react_apps_ensure_url_is_string(
+        'name' => $this->t('Reservations', [], ['context' => 'Patron menu']),
+        'link' => dpl_react_apps_ensure_url_is_string(
           Url::fromRoute('dpl_reservations.list', [], ['absolute' => TRUE])->toString()
         ),
-        "dataId" => "2",
+        'dataId' => '2',
       ],
       [
-        "name" => $this->t("My list", [], ["context" => 'Patron menu']),
-        "link" => dpl_react_apps_ensure_url_is_string(
+        'name' => $this->t('My list', [], ['context' => 'Patron menu']),
+        'link' => dpl_react_apps_ensure_url_is_string(
           Url::fromRoute('dpl_favorites_list.list', [], ['absolute' => TRUE])->toString()
         ),
-        "dataId" => "20",
+        'dataId' => '20',
       ],
       [
-        "name" => $this->t("Fees & Replacement costs", [], ["context" => 'Patron menu']),
-        "link" => dpl_react_apps_ensure_url_is_string(
+        'name' => $this->t('Fees & Replacement costs', [], ['context' => 'Patron menu']),
+        'link' => dpl_react_apps_ensure_url_is_string(
           Url::fromRoute('dpl_fees.list', [], ['absolute' => TRUE])->toString()
         ),
-        "dataId" => "4",
+        'dataId' => '4',
       ],
       [
-        "name" => $this->t("My account", [], ["context" => 'Patron menu']),
-        "link" => dpl_react_apps_ensure_url_is_string(
+        'name' => $this->t('My account', [], ['context' => 'Patron menu']),
+        'link' => dpl_react_apps_ensure_url_is_string(
           Url::fromRoute('dpl_dashboard.list', [], ['absolute' => TRUE])->toString()
         ),
-        "dataId" => "40",
+        'dataId' => '40',
       ],
     ];
 


### PR DESCRIPTION


#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-379

#### Description
Change patron menu translation function string params to use single quotes instead of double.
This is crazy, but apparently Potion won't use context if it is not defined with single quotes!!! Really!

