### PR TITLE
Add Taxonomy + Expandable Categories in Event Content Type

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
@@ -44,11 +45,37 @@ third_party_settings:
         description: ''
         required_fields: true
         weight: 0
+    group_tagging:
+      children:
+        - field_categories
+      label: Tagging
+      region: content
+      parent_name: ''
+      weight: 12
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
 id: node.event.default
 targetEntityType: node
 bundle: event
 mode: default
 content:
+  field_categories:
+    type: entity_reference_autocomplete_tags
+    weight: 13
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: 'Search categories..'
+    third_party_settings: {  }
   field_event_address:
     type: address_default
     weight: 7

--- a/config/sync/core.entity_form_display.taxonomy_term.categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.categories.default.yml
@@ -1,0 +1,23 @@
+uuid: 62d0279d-25d8-4c68-ac39-f59eaa0c12ac
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.categories
+id: taxonomy_term.categories.default
+targetEntityType: taxonomy_term
+bundle: categories
+mode: default
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  description: true
+  langcode: true
+  status: true

--- a/config/sync/core.entity_view_display.node.event.card.yml
+++ b/config/sync/core.entity_view_display.node.event.card.yml
@@ -51,6 +51,7 @@ content:
     weight: 1
     region: content
 hidden:
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
@@ -28,6 +29,14 @@ targetEntityType: node
 bundle: event
 mode: default
 content:
+  field_categories:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 9
+    region: content
   field_event_address:
     type: address_default
     label: above

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.full
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
@@ -29,6 +30,14 @@ targetEntityType: node
 bundle: event
 mode: full
 content:
+  field_categories:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 9
+    region: content
   field_event_address:
     type: address_default
     label: hidden

--- a/config/sync/core.entity_view_display.node.event.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.list_teaser.yml
@@ -97,6 +97,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_categories: true
   field_event_paragraphs: true
   field_event_partners: true
   field_event_state: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
@@ -30,6 +31,7 @@ content:
     weight: 100
     region: content
 hidden:
+  field_categories: true
   field_event_address: true
   field_event_date: true
   field_event_description: true

--- a/config/sync/core.entity_view_display.taxonomy_term.categories.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.categories.default.yml
@@ -12,3 +12,4 @@ content: {  }
 hidden:
   description: true
   langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.taxonomy_term.categories.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.categories.default.yml
@@ -1,0 +1,14 @@
+uuid: 11f544ab-86ed-4797-8692-6a361219a043
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.categories
+id: taxonomy_term.categories.default
+targetEntityType: taxonomy_term
+bundle: categories
+mode: default
+content: {  }
+hidden:
+  description: true
+  langcode: true

--- a/config/sync/core.entity_view_mode.taxonomy_term.full.yml
+++ b/config/sync/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,0 +1,12 @@
+uuid: 53d0cd7d-1c34-4b6e-bc9d-55c920697717
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: '-PPKjsNQPvoIDjOuUAvlLocYD976MNjb9Zpgyz5_BWE'
+id: taxonomy_term.full
+label: 'Taxonomy term page'
+targetEntityType: taxonomy_term
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -89,6 +89,7 @@ module:
   search_api_db: 0
   serialization: 0
   system: 0
+  taxonomy: 0
   text: 0
   token: 0
   toolbar: 0

--- a/config/sync/field.field.node.event.field_categories.yml
+++ b/config/sync/field.field.node.event.field_categories.yml
@@ -1,0 +1,29 @@
+uuid: 2e6ab780-a852-45ab-afbb-874d30c25091
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_categories
+    - node.type.event
+    - taxonomy.vocabulary.categories
+id: node.event.field_categories
+field_name: field_categories
+entity_type: node
+bundle: event
+label: Categories
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      categories: categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_categories.yml
+++ b/config/sync/field.storage.node.field_categories.yml
@@ -1,0 +1,20 @@
+uuid: 6b9c6a7a-fad2-4715-9cbb-5e6c5eda107a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_categories
+field_name: field_categories
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.taxonomy_term.categories.yml
+++ b/config/sync/language.content_settings.taxonomy_term.categories.yml
@@ -1,0 +1,11 @@
+uuid: 94170271-c291-4096-9a9c-80c95b235ef2
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.categories
+id: taxonomy_term.categories
+target_entity_type_id: taxonomy_term
+target_bundle: categories
+default_langcode: da
+language_alterable: false

--- a/config/sync/language/da/core.entity_view_mode.taxonomy_term.full.yml
+++ b/config/sync/language/da/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,0 +1,1 @@
+label: Termside

--- a/config/sync/language/da/system.action.taxonomy_term_publish_action.yml
+++ b/config/sync/language/da/system.action.taxonomy_term_publish_action.yml
@@ -1,0 +1,1 @@
+label: 'Publicér taksonomiterm'

--- a/config/sync/language/da/system.action.taxonomy_term_unpublish_action.yml
+++ b/config/sync/language/da/system.action.taxonomy_term_unpublish_action.yml
@@ -1,0 +1,1 @@
+label: 'Afpublicér taksonomiterm'

--- a/config/sync/language/da/views.view.taxonomy_term.yml
+++ b/config/sync/language/da/views.view.taxonomy_term.yml
@@ -1,0 +1,31 @@
+label: 'Ord i ordforråd'
+description: 'Indhold som er knyttet til en bestemt term.'
+display:
+  default:
+    display_title: Standard
+    display_options:
+      pager:
+        options:
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      arguments:
+        tid:
+          exception:
+            title: Alle
+          title: '{{ arguments.tid }}'
+  feed_1:
+    display_title: Feed
+  page_1:
+    display_title: Side

--- a/config/sync/system.action.taxonomy_term_publish_action.yml
+++ b/config/sync/system.action.taxonomy_term_publish_action.yml
@@ -1,0 +1,13 @@
+uuid: 045d2716-5be1-4778-b946-3f1ba8faa07b
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: DoVt_VGgVLcDD4XmVbSFzr0K17SJy9imFiYusKkJBgY
+id: taxonomy_term_publish_action
+label: 'Publish taxonomy term'
+type: taxonomy_term
+plugin: 'entity:publish_action:taxonomy_term'
+configuration: {  }

--- a/config/sync/system.action.taxonomy_term_unpublish_action.yml
+++ b/config/sync/system.action.taxonomy_term_unpublish_action.yml
@@ -1,0 +1,13 @@
+uuid: ee8434c7-5eb7-4b2d-b041-f4478838421f
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: z2sNRM3ECa7FPCGnSNje_9SmZJQgwhD_6fG_L4Mr8zI
+id: taxonomy_term_unpublish_action
+label: 'Unpublish taxonomy term'
+type: taxonomy_term
+plugin: 'entity:unpublish_action:taxonomy_term'
+configuration: {  }

--- a/config/sync/taxonomy.settings.yml
+++ b/config/sync/taxonomy.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: zKpaWT6cJc1tVQQaTqatGELaCqU_oyRym6zTl27Yias
+maintain_index_table: true
+override_selector: false
+terms_per_page_admin: 100

--- a/config/sync/taxonomy.vocabulary.categories.yml
+++ b/config/sync/taxonomy.vocabulary.categories.yml
@@ -1,0 +1,8 @@
+uuid: d5f5f434-6b41-4493-ad8d-2da48a6e90e3
+langcode: da
+status: true
+dependencies: {  }
+name: Categories
+vid: categories
+description: ''
+weight: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -8,6 +8,7 @@ dependencies:
     - node.type.article
     - node.type.campaign
     - node.type.event
+    - taxonomy.vocabulary.categories
   module:
     - block
     - dpl_instant_loan
@@ -24,6 +25,7 @@ dependencies:
     - openid_connect
     - recurring_events
     - system
+    - taxonomy
     - toolbar
     - update
 id: administrator
@@ -57,6 +59,7 @@ permissions:
   - 'create campaign content'
   - 'create event content'
   - 'create image media'
+  - 'create terms in categories'
   - 'delete any article content'
   - 'delete any campaign content'
   - 'delete any event content'
@@ -72,6 +75,7 @@ permissions:
   - 'delete own eventseries entity'
   - 'delete own files'
   - 'delete own image media'
+  - 'delete terms in categories'
   - 'edit any article content'
   - 'edit any campaign content'
   - 'edit any event content'
@@ -84,6 +88,7 @@ permissions:
   - 'edit own eventinstance entity'
   - 'edit own eventseries entity'
   - 'edit own image media'
+  - 'edit terms in categories'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'revert event revisions'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -8,6 +8,7 @@ dependencies:
     - node.type.article
     - node.type.campaign
     - node.type.event
+    - taxonomy.vocabulary.categories
   module:
     - file
     - filter
@@ -15,6 +16,7 @@ dependencies:
     - node
     - recurring_events
     - system
+    - taxonomy
     - toolbar
 id: editor
 label: Editor
@@ -32,6 +34,7 @@ permissions:
   - 'create campaign content'
   - 'create event content'
   - 'create image media'
+  - 'create terms in categories'
   - 'delete any article content'
   - 'delete any campaign content'
   - 'delete any event content'
@@ -45,6 +48,7 @@ permissions:
   - 'delete own eventseries entity'
   - 'delete own files'
   - 'delete own image media'
+  - 'delete terms in categories'
   - 'edit any article content'
   - 'edit any campaign content'
   - 'edit any event content'
@@ -57,6 +61,7 @@ permissions:
   - 'edit own eventinstance entity'
   - 'edit own eventseries entity'
   - 'edit own image media'
+  - 'edit terms in categories'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'revert event revisions'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -8,6 +8,7 @@ dependencies:
     - node.type.article
     - node.type.campaign
     - node.type.event
+    - taxonomy.vocabulary.categories
   module:
     - dpl_instant_loan
     - dpl_library_agency
@@ -18,6 +19,7 @@ dependencies:
     - node
     - recurring_events
     - system
+    - taxonomy
     - toolbar
 id: local_administrator
 label: 'Local Administrator'
@@ -38,6 +40,7 @@ permissions:
   - 'create campaign content'
   - 'create event content'
   - 'create image media'
+  - 'create terms in categories'
   - 'delete any article content'
   - 'delete any campaign content'
   - 'delete any event content'
@@ -52,6 +55,7 @@ permissions:
   - 'delete own eventseries entity'
   - 'delete own files'
   - 'delete own image media'
+  - 'delete terms in categories'
   - 'edit any article content'
   - 'edit any campaign content'
   - 'edit any event content'
@@ -64,6 +68,7 @@ permissions:
   - 'edit own eventinstance entity'
   - 'edit own eventseries entity'
   - 'edit own image media'
+  - 'edit terms in categories'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'revert event revisions'

--- a/config/sync/user.role.mediator.yml
+++ b/config/sync/user.role.mediator.yml
@@ -8,6 +8,7 @@ dependencies:
     - node.type.article
     - node.type.campaign
     - node.type.event
+    - taxonomy.vocabulary.categories
   module:
     - file
     - filter
@@ -15,6 +16,7 @@ dependencies:
     - node
     - recurring_events
     - system
+    - taxonomy
     - toolbar
 id: mediator
 label: Mediator
@@ -32,6 +34,7 @@ permissions:
   - 'create campaign content'
   - 'create event content'
   - 'create image media'
+  - 'create terms in categories'
   - 'delete any article content'
   - 'delete any campaign content'
   - 'delete any event content'
@@ -45,6 +48,7 @@ permissions:
   - 'delete own eventseries entity'
   - 'delete own files'
   - 'delete own image media'
+  - 'delete terms in categories'
   - 'edit any article content'
   - 'edit any campaign content'
   - 'edit any event content'
@@ -57,6 +61,7 @@ permissions:
   - 'edit own eventinstance entity'
   - 'edit own eventseries entity'
   - 'edit own image media'
+  - 'edit terms in categories'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'revert event revisions'

--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -1,0 +1,319 @@
+uuid: 2c025f1e-0760-438e-968b-3392c85cb22c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+  module:
+    - node
+    - taxonomy
+    - user
+_core:
+  default_config_hash: YKgw0f77GEmCu6_6Om9Mbig0mON9JdfVuMxTtd0WQaI
+id: taxonomy_term
+label: 'Taxonomy term'
+module: taxonomy
+description: 'Content belonging to a certain taxonomy term.'
+tag: default
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields: {  }
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: 0
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        sticky:
+          id: sticky
+          table: taxonomy_index
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: sticky
+          exposed: false
+        created:
+          id: created
+          table: taxonomy_index
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          default_action: 'not found'
+          exception:
+            value: ''
+            title_enable: false
+            title: All
+          title_enable: true
+          title: '{{ arguments.tid }}'
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:taxonomy_term'
+            fail: 'not found'
+          validate_options:
+            bundles: {  }
+            access: true
+            operation: view
+            multiple: 0
+          break_phrase: false
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+      filters:
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: taxonomy_index
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      link_display: page_1
+      link_url: ''
+      header:
+        entity_taxonomy_term:
+          id: entity_taxonomy_term
+          table: views
+          field: entity_taxonomy_term
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: entity
+          empty: true
+          target: '{{ raw_arguments.tid }}'
+          view_mode: full
+          tokenize: true
+          bypass_access: false
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  feed_1:
+    id: feed_1
+    display_title: Feed
+    display_plugin: feed
+    position: 2
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      style:
+        type: rss
+        options:
+          grouping: {  }
+          uses_fields: false
+          description: ''
+      row:
+        type: node_rss
+        options:
+          relationship: none
+          view_mode: default
+      query:
+        type: views_query
+        options: {  }
+      display_extenders: {  }
+      path: taxonomy/term/%/feed
+      displays:
+        page_1: page_1
+        default: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      query:
+        type: views_query
+        options: {  }
+      display_extenders: {  }
+      path: taxonomy/term/%
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    a3a4aa80-7380-4a87-aa02-a0ba240410ba: eventinstance
+    c33b509c-f16e-4416-806f-d75bcf235316: eventinstance
     618e176a-a45a-4c36-a197-664230aa0a34: media
     dc33677f-8894-4717-b34b-d985f6ad875f: media
     65432ee1-43f1-4130-9565-5683467d4b5a: media
@@ -101,7 +101,7 @@ default:
         href: 'http://dapple-cms.docker/user/login'
   event_instances:
     -
-      entity: a3a4aa80-7380-4a87-aa02-a0ba240410ba
+      entity: c33b509c-f16e-4416-806f-d75bcf235316
   field_event_address:
     -
       langcode: en

--- a/web/modules/custom/dpl_example_content/content/node/56bfda4c-2a5f-4fda-bb98-ffb5106f0a34.yml
+++ b/web/modules/custom/dpl_example_content/content/node/56bfda4c-2a5f-4fda-bb98-ffb5106f0a34.yml
@@ -5,6 +5,7 @@ _meta:
   bundle: event
   default_langcode: da
   depends:
+    4981b021-895f-40cb-a67f-e91c1c0182e4: taxonomy_term
     618e176a-a45a-4c36-a197-664230aa0a34: media
     dc33677f-8894-4717-b34b-d985f6ad875f: media
     65432ee1-43f1-4130-9565-5683467d4b5a: media
@@ -39,6 +40,9 @@ default:
       attributes:
         name: title
         content: 'Fernisering Moderne Dans | DPL CMS'
+  field_categories:
+    -
+      entity: 4981b021-895f-40cb-a67f-e91c1c0182e4
   field_event_address:
     -
       langcode: en

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/4981b021-895f-40cb-a67f-e91c1c0182e4.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/4981b021-895f-40cb-a67f-e91c1c0182e4.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 4981b021-895f-40cb-a67f-e91c1c0182e4
+  bundle: categories
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: Event
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Event | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/1'

--- a/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
@@ -42,3 +42,6 @@ default_content:
     - 6d5e9b4c-389d-4735-a8a3-82883f64aeb0
     # PDF used in article 1, event 1 and eventseries 1
     - 3403d0ba-cbdc-425d-93f4-6cdabb5378b1
+  taxonomy_term:
+    # Categori in event 1
+    - 4981b021-895f-40cb-a67f-e91c1c0182e4

--- a/web/themes/custom/novel/novel.libraries.yml
+++ b/web/themes/custom/novel/novel.libraries.yml
@@ -29,3 +29,8 @@ swiper:
     theme:
       "https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css":
         { type: external }
+
+show-more:
+  js:
+    assets/dpl-design-system/js/show-more.js: {}
+

--- a/web/themes/custom/novel/novel.libraries.yml
+++ b/web/themes/custom/novel/novel.libraries.yml
@@ -33,4 +33,3 @@ swiper:
 show-more:
   js:
     assets/dpl-design-system/js/show-more.js: {}
-

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -1,5 +1,14 @@
+{{ attach_library('novel/show-more') }}
+{% set show_more_text = '...'|t %}
+{% set show_less_text = 'Show less'|t %}
+
+
 {% for item in items %}
-	<span class="tag tag--fill cursor-pointer tag--small">
+	<span data-show-more-item class="tag tag--fill tag--small">
 		{{ item.content|raw }}
 	</span>
 {% endfor %}
+
+<button class="tag tag--fill tag--small cursor-pointer" aria-expanded="false" data-show-more-button data-show-more-text="{{ show_more_text }}" data-show-less-text="{{ show_less_text }}">
+	{{ show_more_text }}
+</button>

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -1,0 +1,5 @@
+{% for item in items %}
+	<span class="tag tag--fill cursor-pointer tag--small">
+		{{ item.content|raw }}
+	</span>
+{% endfor %}

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -2,13 +2,12 @@
 {% set show_more_text = '...'|t %}
 {% set show_less_text = 'Show less'|t %}
 
-
 {% for item in items %}
-	<span data-show-more-item class="tag tag--fill tag--small">
-		{{ item.content|raw }}
-	</span>
+    <span data-show-more-item class="tag tag--fill tag--small">
+        {{ item.content|raw }}
+    </span>
 {% endfor %}
 
 <button class="tag tag--fill tag--small cursor-pointer" aria-expanded="false" data-show-more-button data-show-more-text="{{ show_more_text }}" data-show-less-text="{{ show_less_text }}">
-	{{ show_more_text }}
+    {{ show_more_text }}
 </button>

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -13,7 +13,8 @@
   <button class="tag tag--fill tag--small cursor-pointer"
           aria-expanded="false"
           aria-controls="show-more-item-list"
-          data-show-more-button data-show-more-text="{{ show_more_text }}"
+          data-show-more-button
+          data-show-more-text="{{ show_more_text }}"
           data-show-less-text="{{ show_less_text }}">
     {{ show_more_text }}
   </button>

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -2,12 +2,25 @@
 {% set show_more_text = '...'|t %}
 {% set show_less_text = 'Show less'|t %}
 
-{% for item in items %}
-    <span data-show-more-item class="tag tag--fill tag--small">
+{% if items|length > 1 %}
+  <ul id="show-more-item-list">
+    {% for item in items %}
+      <li data-show-more-item class="tag tag--fill tag--small">
         {{ item.content|raw }}
-    </span>
-{% endfor %}
-
-<button class="tag tag--fill tag--small cursor-pointer" aria-expanded="false" data-show-more-button data-show-more-text="{{ show_more_text }}" data-show-less-text="{{ show_less_text }}">
+      </li>
+    {% endfor %}
+  </ul>
+  <button class="tag tag--fill tag--small cursor-pointer"
+          aria-expanded="false"
+          aria-controls="show-more-item-list"
+          data-show-more-button data-show-more-text="{{ show_more_text }}"
+          data-show-less-text="{{ show_less_text }}">
     {{ show_more_text }}
-</button>
+  </button>
+{% else %}
+  {% for item in items %}
+    <span data-show-more-item class="tag tag--fill tag--small">
+      {{ item.content|raw }}
+    </span>
+  {% endfor %}
+{% endif %}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -1,7 +1,7 @@
 <article {{ attributes.addClass('event-page') }}>
   <header class="event-header">
     <section class="event-header__content">
-      <div class="event-header__tag">
+      <div class="event-header__tags">
         {{ content.field_categories }}
       </div>
       {{ content.field_event_date }}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -78,4 +78,3 @@
   {{ content.field_event_paragraphs }}
   </section>
 </article>
-{{dd(content)}}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -1,7 +1,9 @@
 <article {{ attributes.addClass('event-page') }}>
   <header class="event-header">
     <section class="event-header__content">
-      <!-- Tag -->
+      <div class="event-header__tag">
+        {{ content.field_categories }}
+      </div>
       {{ content.field_event_date }}
       <h1 class="event-header__title">{{ label }}</h1>
       {{ content.field_event_link }}
@@ -76,3 +78,4 @@
   {{ content.field_event_paragraphs }}
   </section>
 </article>
+{{dd(content)}}

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -4,7 +4,9 @@
       <div class="event-header__tags">
         {{ content.field_categories }}
       </div>
+      <div class="event-header__date">
       {{ content.field_event_date }}
+      </div>
       <h1 class="event-header__title">{{ label }}</h1>
       {{ content.field_event_link }}
     </section>


### PR DESCRIPTION
#### Depend on https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/427

#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-130

#### Description

This pull request introduces two key updates to the event content type in the 'dpl-cms' system. Firstly, it integrates taxonomy and categories, enabling users to tag events effectively. Secondly, it adds a 'Show More/Less' feature to the field categories template, improving user interaction by allowing the category list to be expanded or collapsed. 

#### Screenshot of the result
<img width="963" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/2dba71bb-320b-4285-b8a5-a66db9bdc071">
<img width="381" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/1c4c7ca5-493c-47bf-bc30-a248e1153530">
