### PR TITLE
DDFLSBP-324 - Added patch to potion module that includes .links.menu.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -236,7 +236,8 @@
             "drupal/potion": {
                 "3201365: Allow setting a default write mode when running potion:generate": "https://www.drupal.org/files/issues/2021-03-03/potion-allow_setting_a_default_write_mode-3201365-2.patch",
                 "3348283: Fix wrongly placed parameters in implode functions": "https://www.drupal.org/files/issues/2023-03-15/fix_wrongly_placed_parameters_in_implode_functions-3348283-3.patch",
-                "Update for Drupal 10 compatibility": "patches/potion-rector-d10-7140243.patch"
+                "Update for Drupal 10 compatibility": "patches/potion-rector-d10-7140243.patch",
+                "3413314: Include .links.menu.yml files in YamlExtractor.php": "https://www.drupal.org/files/issues/2024-01-08/potion-add_links_menu_yml_title_and_description_to_yaml_extractor-3413314-3.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc47330f6b5fad8f8cb265280e59ef71",
+    "content-hash": "706f82b861de80575511dd2f1115af2c",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2263,16 +2263,8 @@
                     "homepage": "https://www.drupal.org/user/46549"
                 },
                 {
-                    "name": "googletorp",
-                    "homepage": "https://www.drupal.org/user/386230"
-                },
-                {
                     "name": "jsacksick",
                     "homepage": "https://www.drupal.org/user/972218"
-                },
-                {
-                    "name": "mglaman",
-                    "homepage": "https://www.drupal.org/user/2416470"
                 },
                 {
                     "name": "rszrama",
@@ -3168,8 +3160,8 @@
                     "version": "1.0.1",
                     "datestamp": "1691138049",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-324

#### Description

Added a patch that includes .links.menu.yml in the YamlExtractor.yml
This means that the title and descriptions in .links.menu.yml files will now be added to da.po translation file and be available to be translated when synced with poeditor.

#### Additional comments or questions

I have created a feature request with the suggested patch here: https://www.drupal.org/project/potion/issues/3413314
