### PR TITLE
Use same date time format for event instances as for series

### DIFF
--- a/config/sync/recurring_events.eventinstance.config.yml
+++ b/config/sync/recurring_events.eventinstance.config.yml
@@ -1,4 +1,4 @@
 _core:
   default_config_hash: 4hMKdEF-IZHfBewW8ok-H2e30isynIPysiFD7hucbk4
-date_format: 'F jS, Y h:iA'
+date_format: 'd/m/y - H:i'
 limit: 10


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-117

#### Description

The new format is the same as we use for event series and for short date with time. 

It matches Danish defaults.

#### Screenshot of the result

<img width="1392" alt="Monosnap Event Instances | DPL CMS | Logged in 2024-01-10 09-07-31" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/8ce53f0c-988c-4af0-84bf-655ba2ac2ff6">
