### PR TITLE
Enhance Recurring Event forms with Gin

### DIFF
--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -243,3 +243,20 @@ function dpl_event_preprocess_node(array &$variables): void {
     $variables['ticket_price_display'] = $price_formatter->formatPriceRange($prices);
   }
 }
+
+/**
+ * Implements hook_gin_content_form_routes().
+ *
+ * @return string[] An array of event-related routes which should be managed as
+ *   content forms by the Gin theme.
+ */
+function dpl_event_gin_content_form_routes() : array {
+  return [
+    'entity.eventseries.add_form',
+    'entity.eventseries.edit_form',
+    // There is no direct add form for instances. They are always created in
+    // relation to series.
+    'entity.eventseries.add_instance_form',
+    'entity.eventinstance.edit_form',
+  ];
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-125

#### Description

Gin will only enhance node type forms by default. Implement a hook provided by Gin to register routes to add and edit event series and instances provided by the Recurring Events module as content forms.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

Should this be a patch to the Recurring Events module instead?