### PR TITLE
Don't trigger translation workflow on release branches

### DIFF
--- a/.github/workflows/translate-source.yml
+++ b/.github/workflows/translate-source.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - release/**
 
 jobs:
 


### PR DESCRIPTION

#### Description
Don't trigger translation workflow on release branches
Since it is not possible to make the full translation workflow work with dynamic branches (which release/*) are we remove that possibility again.
