### PR TITLE
DDFLSBP-324 - Added patch to potion module that includes .links.menu.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -250,7 +250,8 @@
                 "3348283: Fix wrongly placed parameters in implode functions": "https://www.drupal.org/files/issues/2023-03-15/fix_wrongly_placed_parameters_in_implode_functions-3348283-3.patch",
                 "Update with Rector": "patches/potion-rector.patch",
                 "Mark as Drupal 10 compatible": "patches/potion-d10-info.patch",
-                "Use Drupal StaticReflectionParser with Drupal 10.1": "patches/potion-d10-1-staticreflection.patch"
+                "Use Drupal StaticReflectionParser with Drupal 10.1": "patches/potion-d10-1-staticreflection.patch",
+                "3413314: Include .links.menu.yml files in YamlExtractor.php": "https://www.drupal.org/files/issues/2024-01-08/potion-add_links_menu_yml_title_and_description_to_yaml_extractor-3413314-3.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2dcf2521dc44a980d624253d6045e7a0",
+    "content-hash": "706f82b861de80575511dd2f1115af2c",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "706f82b861de80575511dd2f1115af2c",
+    "content-hash": "38f1d4f59ad99792f2e720b591c36790",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
Link to issue
https://reload.atlassian.net/browse/DDFLSBP-324

Description
Added a patch that includes .links.menu.yml in the YamlExtractor.yml
This means that the title and descriptions in .links.menu.yml files will now be added to da.po translation file and be available to be translated when synced with poeditor.

Additional comments or questions
I have created a feature request with the suggested patch here: https://www.drupal.org/project/potion/issues/3413314
