### PR TITLE
Implement GitHub Actions job which checks exported config

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -276,4 +276,4 @@ jobs:
       - name: Export configuration
         run: task dev:cli -- drush config-export -y
       - name: Check for uncommited configuration after install
-        run: git diff --ignore-space-at-eol --exit-code config/sync/
+        run: git diff --ignore-space-at-eol --exit-code config/sync/*.yml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -257,3 +257,23 @@ jobs:
         run: task ci:openapi:download
       - name: Ensure specification has not drifted
         run: git diff --ignore-space-at-eol --exit-code openapi.json
+
+  CheckDrupalConfig:
+    name: Check Drupal Config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Our Taskfile requires a proper checkout to function because of
+          # certain vars.
+          fetch-depth: 0
+      - name: Install go-task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup site
+        run: task ci:reset
+      - name: Export configuration
+        run: task dev:cli -- drush config-export -y
+      - name: Check for uncommited configuration after install
+        run: git diff --ignore-space-at-eol --exit-code config/sync/

--- a/config/sync/language/da/views.view.files.yml
+++ b/config/sync/language/da/views.view.files.yml
@@ -26,6 +26,8 @@ display:
           label: Ændringsdato
         count:
           label: 'Brugt i'
+          alter:
+            path: 'admin/content/files/usage/{{ fid }}'
       pager:
         options:
           tags:

--- a/config/sync/language/da/views.view.user_admin_people.yml
+++ b/config/sync/language/da/views.view.user_admin_people.yml
@@ -19,6 +19,9 @@ display:
           label: Roller
         created:
           label: 'Medlem i'
+          settings:
+            future_format: '@interval'
+            past_format: '@interval'
         access:
           label: 'Seneste tilgang'
           settings:


### PR DESCRIPTION
#### Description

By default there should not be any changes to configuration directly after installing the site.

Add a GitHub Actions job which installs the site, immediately exports the configuration and checks for changes. If there are any changes the job will fail.

We are using a similar approach for checking for changes to the OpenAPI specification.

Commit status for [03e0ad0](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/629/commits/03e0ad086b0e34eff5f660a01d3058f906e55814) shows that it works.

The remaining commits are changes to make it go green again.