### PR TITLE
DDFLSBP-267 - Changed to linkit fields instead for url fields for for…

### DIFF
--- a/web/modules/custom/dpl_fees/src/DplFeesSettings.php
+++ b/web/modules/custom/dpl_fees/src/DplFeesSettings.php
@@ -48,4 +48,23 @@ class DplFeesSettings extends DplReactConfigBase {
     return $this->loadConfig()->get('fees_list_size_mobile') ?? self::FEES_LIST_SIZE_MOBILE;
   }
 
+  /**
+   * Get the fees and replacement cost url.
+   *
+   * @return string
+   *   The fees and replacement cost url or the fallback value.
+   */
+  public function getFeesAndReplacementCostsUrl(): string {
+    return $this->loadConfig()->get('fees_and_replacement_costs_url') ?? self::FEES_AND_REPLACEMENT_COSTS_URL;
+  }
+
+  /**
+   * Get the payment overview url.
+   *
+   * @return string
+   *   The payment overview url or the fallback value.
+   */
+  public function getPaymentOverviewUrl(): string {
+    return $this->loadConfig()->get('payment_overview_url') ?? self::PAYMENT_OVERVIEW_URL;
+  }
 }

--- a/web/modules/custom/dpl_fees/src/DplFeesSettings.php
+++ b/web/modules/custom/dpl_fees/src/DplFeesSettings.php
@@ -67,4 +67,5 @@ class DplFeesSettings extends DplReactConfigBase {
   public function getPaymentOverviewUrl(): string {
     return $this->loadConfig()->get('payment_overview_url') ?? self::PAYMENT_OVERVIEW_URL;
   }
+
 }

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -63,28 +63,37 @@ class FeesListSettingsForm extends ConfigFormBase {
 
     $form['settings'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Basic settings'),
+      '#title' => $this->t('Basic settings', [], ['context' => 'Fees list settings form']),
       '#tree' => FALSE,
     ];
 
     $form['settings']['fees_and_replacement_costs_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Fees and Replacement costs URL'),
-      '#description' => $this->t('File or URL containing the fees and replacement costs'),
+      '#type' => 'linkit',
+      '#title' => $this->t('Fees and Replacement costs URL', [], ['context' => 'Fees list settings form']),
+      '#description' => $this->t('File or URL containing the fees and replacement costs. You can search for an internal url. Or you can add an external url (starting with "http://" or "https://").', [], ['context' => 'Fees list settings form']),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
       '#default_value' => $config->get('fees_and_replacement_costs_url') ?? DplFeesSettings::FEES_AND_REPLACEMENT_COSTS_URL,
     ];
 
     $form['settings']['payment_overview_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Payment overview url'),
+      '#type' => 'linkit',
+      '#title' => $this->t('Payment overview url', [], ['context' => 'Fees list settings form']),
+      '#description' => $this->t('You can search for an internal url. Or you can add an external url (starting with http:// or https://).', [], ['context' => 'Fees list settings form']),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
       '#default_value' => $config->get('payment_overview_url') ?? DplFeesSettings::PAYMENT_OVERVIEW_URL,
     ];
 
     $form['settings']['fee_list_body_text'] = [
       '#type' => 'textarea',
-      '#title' => $this->t('Intro text'),
-      '#description' => $this->t('Display an intro-text below the headline'),
-      '#default_value' => $config->get('fee_list_body_text') ?? $this->t('Fees and replacement costs are handled through the new system "Mit betalingsoverblik.'),
+      '#title' => $this->t('Intro text', [], ['context' => 'Fees list settings form']),
+      '#description' => $this->t('Display an intro-text below the headline', [], ['context' => 'Fees list settings form']),
+      '#default_value' => $config->get('fee_list_body_text') ?? $this->t('Fees and replacement costs are handled through the new system "Mit betalingsoverblik.', [], ['context' => 'Fees list settings form']),
     ];
 
     return parent::buildForm($form, $form_state);

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -24,7 +24,8 @@ class FeesListSettingsForm extends ConfigFormBase {
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
-    protected DplReactConfigInterface $configService
+    protected DplReactConfigInterface $configService,
+    protected DplFeesSettings $feesSettings
   ) {
     $this->setConfigFactory($config_factory);
   }
@@ -35,6 +36,7 @@ class FeesListSettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container): self {
     return new static(
       $container->get('config.factory'),
+      \Drupal::service('dpl_fees.settings'),
       \Drupal::service('dpl_fees.settings')
     );
   }
@@ -78,7 +80,7 @@ class FeesListSettingsForm extends ConfigFormBase {
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',
       ],
-      '#default_value' => $config->get('fees_and_replacement_costs_url') ?? DplFeesSettings::FEES_AND_REPLACEMENT_COSTS_URL,
+      '#default_value' => $this->feesSettings->getFeesAndReplacementCostsUrl(),
     ];
 
     $form['settings']['payment_overview_url'] = [
@@ -92,7 +94,7 @@ class FeesListSettingsForm extends ConfigFormBase {
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',
       ],
-      '#default_value' => $config->get('payment_overview_url') ?? DplFeesSettings::PAYMENT_OVERVIEW_URL,
+      '#default_value' => $this->feesSettings->getPaymentOverviewUrl(),
     ];
 
     $form['settings']['fee_list_body_text'] = [

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -70,7 +70,10 @@ class FeesListSettingsForm extends ConfigFormBase {
     $form['settings']['fees_and_replacement_costs_url'] = [
       '#type' => 'linkit',
       '#title' => $this->t('Fees and Replacement costs URL', [], ['context' => 'Fees list settings form']),
-      '#description' => $this->t('File or URL containing the fees and replacement costs. You can search for an internal url. Or you can add an external url (starting with "http://" or "https://").', [], ['context' => 'Fees list settings form']),
+      '#description' => $this->t('File or URL containing the fees and replacement costs. <br>
+                                         You can add a relative url (e.g. /takster). <br>
+                                         You can search for an internal url. <br>
+                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Fees list settings form']),
       '#autocomplete_route_name' => 'linkit.autocomplete',
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',
@@ -81,7 +84,10 @@ class FeesListSettingsForm extends ConfigFormBase {
     $form['settings']['payment_overview_url'] = [
       '#type' => 'linkit',
       '#title' => $this->t('Payment overview url', [], ['context' => 'Fees list settings form']),
-      '#description' => $this->t('You can search for an internal url. Or you can add an external url (starting with http:// or https://).', [], ['context' => 'Fees list settings form']),
+      '#description' => $this->t('URL containing the payment overview. <br>
+                                         You can add a relative url (e.g. /takster). <br>
+                                         You can search for an internal url. <br>
+                                         You can add an external url (starting with "http://" or "https://")', [], ['context' => 'Fees list settings form']),
       '#autocomplete_route_name' => 'linkit.autocomplete',
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -173,7 +173,10 @@ class GeneralSettingsForm extends ConfigFormBase {
     $form['reservations']['pause_reservation_info_url'] = [
       '#type' => 'linkit',
       '#title' => $this->t('Pause reservation link', [], ['context' => 'Library Agency Configuration']),
-      '#description' => $this->t('The link with infomation about reservations', [], ['context' => 'Library Agency Configuration']),
+      '#description' => $this->t('The link with information about reservations. <br>
+                                         You can add a relative url (e.g. /takster). <br>
+                                         You can search for an internal url. <br>
+                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Library Agency Configuration']),
       '#autocomplete_route_name' => 'linkit.autocomplete',
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',
@@ -191,7 +194,10 @@ class GeneralSettingsForm extends ConfigFormBase {
     $form['settings']['blocked_user']['blocked_patron_e_link_url'] = [
       '#type' => 'linkit',
       '#title' => $this->t('Blocked user link for modal', [], ['context' => 'Library Agency Configuration']),
-      '#description' => $this->t('If a user is blocked because of fees a modal appears. This field makes it possible to place a link in the modal to e.g. payment options or help page.', [], ['context' => 'Library Agency Configuration']),
+      '#description' => $this->t('If a user is blocked because of fees a modal appears. This field makes it possible to place a link in the modal to e.g. payment options or help page. <br>
+                                         You can add a relative url (e.g. /takster). <br>
+                                         You can search for an internal url. <br>
+                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Library Agency Configuration']),
       '#autocomplete_route_name' => 'linkit.autocomplete',
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -158,7 +158,7 @@ class GeneralSettingsForm extends ConfigFormBase {
 
     $form['reservations']['ereolen_my_page_url'] = [
       '#type' => 'url',
-      '#title' => $this->t('Ereolen link', [], ['context' => 'Library Agency Configuration']),
+      '#title' => $this->t('Ereolen my page link', [], ['context' => 'Library Agency Configuration']),
       '#description' => $this->t('My page in ereolen', [], ['context' => 'Library Agency Configuration']),
       '#default_value' => $config->get('ereolen_my_page_url') ?? GeneralSettings::EREOLEN_MY_PAGE_URL,
     ];
@@ -171,9 +171,13 @@ class GeneralSettingsForm extends ConfigFormBase {
     ];
 
     $form['reservations']['pause_reservation_info_url'] = [
-      '#type' => 'url',
+      '#type' => 'linkit',
       '#title' => $this->t('Pause reservation link', [], ['context' => 'Library Agency Configuration']),
       '#description' => $this->t('The link with infomation about reservations', [], ['context' => 'Library Agency Configuration']),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
       '#default_value' => $config->get('pause_reservation_info_url') ?? GeneralSettings::PAUSE_RESERVATION_INFO_URL,
     ];
 
@@ -185,9 +189,13 @@ class GeneralSettingsForm extends ConfigFormBase {
     ];
 
     $form['settings']['blocked_user']['blocked_patron_e_link_url'] = [
-      '#type' => 'url',
+      '#type' => 'linkit',
       '#title' => $this->t('Blocked user link for modal', [], ['context' => 'Library Agency Configuration']),
       '#description' => $this->t('If a user is blocked because of fees a modal appears. This field makes it possible to place a link in the modal to e.g. payment options or help page.', [], ['context' => 'Library Agency Configuration']),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
       '#default_value' => $config->get('blocked_patron_e_link_url') ?? GeneralSettings::BLOCKED_PATRON_E_LINK_URL,
     ];
 

--- a/web/modules/custom/dpl_patron_page/src/Form/PatronPageSettingsForm.php
+++ b/web/modules/custom/dpl_patron_page/src/Form/PatronPageSettingsForm.php
@@ -63,26 +63,30 @@ class PatronPageSettingsForm extends ConfigFormBase {
 
     $form['settings'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Basic settings'),
+      '#title' => $this->t('Basic settings', [], ['context' => 'Patron page settings form']),
       '#tree' => FALSE,
     ];
 
     $form['settings']['delete_patron_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Delete patron link'),
-      '#description' => $this->t('Link to a page where it is possible to delete patron'),
+      '#type' => 'linkit',
+      '#title' => $this->t('Delete patron link', [], ['context' => 'Patron page settings form']),
+      '#description' => $this->t('Link to a page where it is possible to delete patron', [], ['context' => 'Patron page settings form']),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
       '#default_value' => $config->get('delete_patron_url') ?? '',
     ];
 
     $form['settings']['always_available_ereolen'] = [
       '#type' => 'url',
-      '#title' => $this->t('Ereolen always available'),
+      '#title' => $this->t('Ereolen always available', [], ['context' => 'Patron page settings form']),
       '#default_value' => $config->get('always_available_ereolen') ?? DplPatronPageSettings::ALWAYS_AVAILABLE_EREOLEN,
     ];
 
     $form['settings']['pincode_length_min'] = [
       '#type' => 'number',
-      '#title' => $this->t('Pincode length (min)'),
+      '#title' => $this->t('Pincode length (min)', [], ['context' => 'Patron page settings form']),
       '#default_value' => $config->get('pincode_length_min') ?? DplPatronPageSettings::PINCODE_LENGTH_MIN,
       '#min' => 4,
       '#step' => 1,
@@ -90,7 +94,7 @@ class PatronPageSettingsForm extends ConfigFormBase {
 
     $form['settings']['pincode_length_max'] = [
       '#type' => 'number',
-      '#title' => $this->t('Pincode length max'),
+      '#title' => $this->t('Pincode length max', [], ['context' => 'Patron page settings form']),
       '#default_value' => $config->get('pincode_length_max') ?? DplPatronPageSettings::PINCODE_LENGTH_MAX,
       '#min' => 4,
       '#step' => 1,

--- a/web/modules/custom/dpl_patron_page/src/Form/PatronPageSettingsForm.php
+++ b/web/modules/custom/dpl_patron_page/src/Form/PatronPageSettingsForm.php
@@ -70,7 +70,10 @@ class PatronPageSettingsForm extends ConfigFormBase {
     $form['settings']['delete_patron_url'] = [
       '#type' => 'linkit',
       '#title' => $this->t('Delete patron link', [], ['context' => 'Patron page settings form']),
-      '#description' => $this->t('Link to a page where it is possible to delete patron', [], ['context' => 'Patron page settings form']),
+      '#description' => $this->t('Link to a page where it is possible to delete patron. <br>
+                                         You can add a relative url (e.g. /takster). <br>
+                                         You can search for an internal url. <br>
+                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Patron page settings form']),
       '#autocomplete_route_name' => 'linkit.autocomplete',
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',

--- a/web/modules/custom/dpl_patron_reg/src/Form/PatronRegSettingsForm.php
+++ b/web/modules/custom/dpl_patron_reg/src/Form/PatronRegSettingsForm.php
@@ -63,22 +63,26 @@ class PatronRegSettingsForm extends ConfigFormBase {
 
     $form['age_limit'] = [
       '#type' => 'number',
-      '#title' => $this->t('Minimum age to allow self registration'),
+      '#title' => $this->t('Minimum age to allow self registration', [], ['context' => 'Patron registration settings form']),
       '#default_value' => $config->get('age_limit') ?? DplPatronRegSettings::AGE_LIMIT,
       '#min' => 1,
       '#step' => 1,
     ];
 
     $form['redirect_on_user_created_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Redirect on create'),
-      '#description' => $this->t('Redirect to this on user successful created'),
+      '#type' => 'linkit',
+      '#title' => $this->t('Redirect on create', [], ['context' => 'Patron registration settings form']),
+      '#description' => $this->t('Redirect to this on user successful created', [], ['context' => 'Patron registration settings form']),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
       '#default_value' => $config->get('redirect_on_user_created_url') ?? DplPatronRegSettings::REDIRECT_ON_USER_CREATED_URL,
     ];
 
     $form['information'] = [
       '#type' => 'text_format',
-      '#title' => $this->t('Information page'),
+      '#title' => $this->t('Information page', [], ['context' => 'Patron registration settings form']),
       '#default_value' => $config->get('information')['value'] ?? DplPatronRegSettings::INFORMATION_VALUE,
       '#format' => $config->get('information')['format'] ?? DplPatronRegSettings::INFORMATION_FORMAT,
     ];

--- a/web/modules/custom/dpl_patron_reg/src/Form/PatronRegSettingsForm.php
+++ b/web/modules/custom/dpl_patron_reg/src/Form/PatronRegSettingsForm.php
@@ -72,7 +72,10 @@ class PatronRegSettingsForm extends ConfigFormBase {
     $form['redirect_on_user_created_url'] = [
       '#type' => 'linkit',
       '#title' => $this->t('Redirect on create', [], ['context' => 'Patron registration settings form']),
-      '#description' => $this->t('Redirect to this on user successful created', [], ['context' => 'Patron registration settings form']),
+      '#description' => $this->t('Redirect to page when user is successful created. <br>
+                                         You can add a relative url (e.g. /takster). <br>
+                                         You can search for an internal url. <br>
+                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Patron registration settings form']),
       '#autocomplete_route_name' => 'linkit.autocomplete',
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-267

#### Description

This PR changes the way some URL form fields work. URL form fields that will be linking to internal urls, can now handle relative urls. The linkit form API type also makes it possible to search for internal urls. 

For URL form fields that will only be used for linking to external urls (Ereolen, Publizon and FBS) are left unchanged.

#### Other comments

I have also added context for translatable strings in the forms that I did the URL field changes.