### PR TITLE
Update FeesListBlock text string definitions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
             "type": "package",
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-react",
-                "version": "2024.3.0",
+                "version": "2024.3.1",
                 "type": "drupal-library",
                 "dist": {
                     "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/branch-release%2F2024-3-0/dist-release-2024-3-0.zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "706f82b861de80575511dd2f1115af2c",
+    "content-hash": "779d3172688d37002d45580ec3cb02c7",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1108,7 +1108,7 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-react",
-            "version": "2024.3.0",
+            "version": "2024.3.1",
             "dist": {
                 "type": "zip",
                 "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/branch-release%2F2024-3-0/dist-release-2024-3-0.zip"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "779d3172688d37002d45580ec3cb02c7",
+    "content-hash": "ecd53509fdb3c719b16e286f33dca0cd",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
+++ b/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
@@ -103,8 +103,8 @@ class FeesListBlock extends BlockBase implements ContainerFactoryPluginInterface
       'total-fee-amount-text' => $this->t("Fee", [], ['context' => 'Fees list']),
       'total-text' => $this->t("Total: @total", [], ['context' => 'Fees list']),
       'turned-in-text' => $this->t("Turned in @date", [], ['context' => 'Fees list']),
-      'unpaid-fees-first-headline-text' => $this->t("Unsettled debt 1", [], ['context' => 'Fees list']),
-      'unpaid-fees-second-headline-text' => $this->t("Unsettled debt 2", [], ['context' => 'Fees list']),
+      'unpaid-fees-payable-by-client-headline-text' => $this->t("Unsettled debt - paid on site", [], ['context' => 'Fees list']),
+      'unpaid-fees-not-payable-by-client-headline-text' => $this->t("Unsettled debt - paid externally", [], ['context' => 'Fees list']),
       'view-fees-and-compensation-rates-text' => $this->t("see our fees and replacement costs", [], ['context' => 'Fees list']),
     ] + DplReactAppsController::externalApiBaseUrls();
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-332

#### Description

A sibling to [this PR](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/857) where some text string definitions were changed.

#### Screenshot of the result
-
#### Additional comments or questions
Accessibility and cypress are failing because the dpl-react package doesn't contain these translation strings. 
I will update it after the sibling PR is merged in.