### PR TITLE
Skip language import in pa11y ci test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -153,8 +153,13 @@ tasks:
       # errors even after a site install.
       - task dev:cache:clear:drupal
       # Import translations.
-      - task dev:cli -- drush locale-check
-      - task dev:cli -- drush locale-update
+      - |
+        if [ -n "${SKIP_LANGUAGE_IMPORT}" ]; then
+          echo "Skipping language import due to SKIP_LANGUAGE_IMPORT environment variable"
+        else
+          task dev:cli -- drush locale-check
+          task dev:cli -- drush locale-update
+        fi
       # Clear all caches to ensure we have a pristine setup.
       - task dev:cache:clear:all
       # Ensure site is reachable and warm any caches
@@ -254,6 +259,7 @@ tasks:
       - task dev:reset
     env:
       DOCKER_COMPOSE_FILES: "{{ .DOCKER_COMPOSE_FILES_CI }}"
+      SKIP_LANGUAGE_IMPORT: "true"
 
   ci:cypress:
     desc: Run Cypress functional tests


### PR DESCRIPTION


#### Description

In order to have stable tests we need to be able trust the ui language and not get suprised by translated strings.

