### PR TITLE
Fix event date timezone

### DIFF
--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -291,6 +291,8 @@ function dpl_event_gin_content_form_routes() : array {
  */
 function dpl_event_preprocess_eventinstance__list_teaser(array &$variables): void {
   $eventInstance = $variables['eventinstance'];
+  /** @var \Drupal\Core\Datetime\DateFormatterInterface $date_formatter */
+  $date_formatter = \Drupal::service('date.formatter');
 
   // Extract the event url.
   $variables['eventinstance_url'] = Url::fromRoute('entity.eventinstance.canonical', ['eventinstance' => $eventInstance->id()])->toString();
@@ -309,24 +311,17 @@ function dpl_event_preprocess_eventinstance__list_teaser(array &$variables): voi
 
   // Extract start_date, end_date and datetime attributes.
   if (!$eventInstance->get('date')->isEmpty()) {
-    // Get the site's default timezone.
-    $site_timezone = date_default_timezone_get();
     $date_field = $eventInstance->get('date')->first();
 
-    if ($date_field) {
-      $start_date = $date_field->start_date;
-      $end_date = $date_field->end_date;
+    $start_date = $date_field->start_date;
+    $end_date = $date_field->end_date;
 
-      // Format the dates in the site's timezone.
-      if ($start_date instanceof DrupalDateTime) {
-        $start_date->setTimezone(new \DateTimeZone($site_timezone));
-        $variables['start_date'] = $start_date->format('H:i');
-        $variables['datetime_attribute'] = $start_date->format(DATE_ATOM);
-      }
-      if ($end_date instanceof DrupalDateTime) {
-        $end_date->setTimezone(new \DateTimeZone($site_timezone));
-        $variables['end_date'] = $end_date->format('H:i');
-      }
+    if ($start_date instanceof DrupalDateTime) {
+      $variables['start_date'] = $date_formatter->format($start_date->getTimestamp(), 'custom', 'H:i');
+      $variables['datetime_attribute'] = $date_formatter->format($start_date->getTimestamp(), DATE_ATOM);
+    }
+    if ($end_date instanceof DrupalDateTime) {
+      $variables['end_date'] = $date_formatter->format($end_date->getTimestamp(), 'custom', 'H:i');
     }
   }
 }

--- a/web/modules/custom/dpl_event/dpl_event.services.yml
+++ b/web/modules/custom/dpl_event/dpl_event.services.yml
@@ -4,4 +4,5 @@ services:
     arguments: ["@string_translation"]
   dpl_event.reoccurring_date_formatter:
     class: Drupal\dpl_event\ReoccurringDateFormatter
-    arguments: ["@string_translation", "@entity_type.manager"]
+    arguments:
+      ["@string_translation", "@entity_type.manager", "@date.formatter"]

--- a/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
+++ b/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
@@ -125,18 +125,17 @@ class ReoccurringDateFormatter {
       return NULL;
     }
 
-    $event_instance_dates = $event_instance->get('date')->getValue();
-
-    $start_date = $event_instance_dates[0]['value'] ?? NULL;
-    $end_date = $event_instance_dates[0]['end_value'] ?? NULL;
-    if (!$start_date || !$end_date) {
+    if ($event_instance->get('date')->isEmpty()) {
       return NULL;
     }
 
+    /** @var \Drupal\datetime_range\Plugin\Field\FieldType\DateRangeItem $event_instance_date */
+    $event_instance_date = $event_instance->get('date')->first();
+
     // Return the dates, and the related IDs.
     return [
-      'start' => new DrupalDateTime($start_date),
-      'end' => new DrupalDateTime($end_date),
+      'start' => $event_instance_date->get('start_date')->getValue(),
+      'end' => $event_instance_date->get('end_date')->getValue(),
       'upcoming_ids' => $upcoming_ids,
     ];
   }

--- a/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
+++ b/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dpl_event;
 
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
@@ -20,6 +21,7 @@ class ReoccurringDateFormatter {
   public function __construct(
     protected TranslationInterface $translation,
     protected EntityTypeManagerInterface $entityTypeManager,
+    protected DateFormatterInterface $dateFormatter,
   ) {}
 
   /**
@@ -71,7 +73,7 @@ class ReoccurringDateFormatter {
       default:
         $upcoming_ids = $upcoming_event_dates['upcoming_ids'];
 
-        $date_string = $start_date->format('j F');
+        $date_string = $this->formatDate($start_date, 'j F');
 
         if (count($upcoming_ids) > 1) {
           $prefix = $this->translation->translate('Next');
@@ -81,7 +83,7 @@ class ReoccurringDateFormatter {
         break;
     }
 
-    $time_string = "{$start_date->format('H:i')} - {$end_date->format('H:i')}";
+    $time_string = "{$this->formatDate($start_date, 'H:i')} - {$this->formatDate($end_date, 'H:i')}";
 
     return "$date_string $time_string";
 
@@ -137,6 +139,13 @@ class ReoccurringDateFormatter {
       'end' => new DrupalDateTime($end_date),
       'upcoming_ids' => $upcoming_ids,
     ];
+  }
+
+  /**
+   * Format a datetime to a string respecting the local timezone.
+   */
+  private function formatDate(DrupalDateTime $datetime, string $format) : string {
+    return $this->dateFormatter->format($datetime->getTimestamp(), 'custom', $format);
   }
 
 }

--- a/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
+++ b/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
@@ -69,7 +69,7 @@ class ReoccurringDateFormatter {
 
       // DD/MM/YY | H:i - H:i.
       default:
-        $upcoming_ids = $upcoming_event_dates['upcoming_ids'] ?? [];
+        $upcoming_ids = $upcoming_event_dates['upcoming_ids'];
 
         $date_string = $start_date->format('j F');
 
@@ -93,7 +93,7 @@ class ReoccurringDateFormatter {
    * @param \Drupal\recurring_events\Entity\EventSeries $event_series
    *   The event series object.
    *
-   * @return null|array<mixed>
+   * @return null|array{'start': \Drupal\Core\Datetime\DrupalDateTime, 'end': \Drupal\Core\Datetime\DrupalDateTime, 'upcoming_ids': array<int, string>}
    *   An array containing the following keys:
    *   - start: The start date of the upcoming event as a DrupalDateTime object.
    *   - end: The end date of the upcoming event as a DrupalDateTime object.

--- a/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
@@ -1,9 +1,8 @@
-{% set dates = eventinstance.get('date').getValue() %}
-
+{% set date = eventinstance.get('date').get(0) %}
 {% set description_items = [
   {
     label: "Time"|trans,
-    value: dates.0 ? dates.0.value|date('H:i') ~ ' - ' ~ dates.0.end_value|date('H:i') : null
+    value: date ? date.get('start_date').getValue().getTimestamp()|format_date('custom', 'H:i') ~ ' - ' ~ date.get('end_date').getValue().getTimestamp()|format_date('custom', 'H:i') : null
   },
   {
     label: "Price"|trans,


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-167

#### Description

Event dates were displayed as 1 hour off the input provided by editors.

Dates are stored and returned in UTC by default. Our timezone is
the site timezone which is Europe/Copenhagen. To convert them to
the proper timezone you need to use a DateFormatter instead of calling
format() directly. This is also what Core field formatters for dates
and the Twig function format_date() do.

Inject a DateFormatter into our RecurringDateFormatter and
eventinstance preprocessing and use this.

#### Screenshot of the result

##### Before

Events:

<img width="1392" alt="Monosnap Fernisering Moderne Dans | DPL CMS 2024-01-19 12-37-53" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/029c0313-4248-44f9-9307-3d01a1685d35">


Instance:

<img width="1392" alt="Monosnap | DPL CMS 2024-01-19 12-37-39" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/39d0badc-a05c-4148-a8bf-eaf8b7a6576e">


Series:

<img width="1392" alt="Monosnap Events | DPL CMS 2024-01-19 12-37-19" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/42bae4b9-bd0d-4bd5-9ea1-5c33db76bad8">


##### After

Events:

![Monosnap Events | DPL CMS 2024-01-19 11-05-19](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/067b4bc0-3c95-440f-8d3c-5e6d007a7c05)

Instance:

![Monosnap Fernisering Moderne Dans | DPL CMS 2024-01-19 11-04-47](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/d1a8a8a3-36bb-4141-93df-9c06c834136a)

Series:

![Monosnap | DPL CMS 2024-01-19 11-03-12](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/b9e6d459-bd18-4f15-9709-4633bca440b6)
