### PR TITLE
Add Taxonomy + Expandable Categories in Event Content Type (NEW)

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
@@ -49,6 +50,16 @@ targetEntityType: node
 bundle: event
 mode: default
 content:
+  field_categories:
+    type: entity_reference_autocomplete
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_event_address:
     type: address_default
     weight: 7

--- a/config/sync/core.entity_view_display.node.event.card.yml
+++ b/config/sync/core.entity_view_display.node.event.card.yml
@@ -4,11 +4,14 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.card
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_paragraphs
+    - field.field.node.event.field_event_partners
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
     - field.field.node.event.field_teaser_image
@@ -51,6 +54,7 @@ content:
     weight: 1
     region: content
 hidden:
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
@@ -28,6 +29,14 @@ targetEntityType: node
 bundle: event
 mode: default
 content:
+  field_categories:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 9
+    region: content
   field_event_address:
     type: address_default
     label: above

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.full
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
@@ -29,6 +30,14 @@ targetEntityType: node
 bundle: event
 mode: full
 content:
+  field_categories:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 9
+    region: content
   field_event_address:
     type: address_default
     label: hidden

--- a/config/sync/core.entity_view_display.node.event.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.list_teaser.yml
@@ -4,13 +4,18 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.list_teaser
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_image
     - field.field.node.event.field_event_link
+    - field.field.node.event.field_event_paragraphs
+    - field.field.node.event.field_event_partners
     - field.field.node.event.field_event_place
     - field.field.node.event.field_event_state
+    - field.field.node.event.field_teaser_image
+    - field.field.node.event.field_teaser_text
     - field.field.node.event.field_ticket_categories
     - node.type.event
   module:
@@ -97,6 +102,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_categories: true
   field_event_paragraphs: true
   field_event_partners: true
   field_event_state: true

--- a/config/sync/core.entity_view_display.node.event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.event.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.event.field_categories
     - field.field.node.event.field_event_address
     - field.field.node.event.field_event_date
     - field.field.node.event.field_event_description
@@ -30,6 +31,7 @@ content:
     weight: 100
     region: content
 hidden:
+  field_categories: true
   field_event_address: true
   field_event_date: true
   field_event_description: true

--- a/config/sync/core.entity_view_mode.taxonomy_term.full.yml
+++ b/config/sync/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,0 +1,12 @@
+uuid: 295b3e38-c4b2-482b-91f3-1328f1040409
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: '-PPKjsNQPvoIDjOuUAvlLocYD976MNjb9Zpgyz5_BWE'
+id: taxonomy_term.full
+label: 'Taxonomy term page'
+targetEntityType: taxonomy_term
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -89,6 +89,7 @@ module:
   search_api_db: 0
   serialization: 0
   system: 0
+  taxonomy: 0
   text: 0
   token: 0
   toolbar: 0

--- a/config/sync/field.field.node.event.field_categories.yml
+++ b/config/sync/field.field.node.event.field_categories.yml
@@ -1,0 +1,29 @@
+uuid: ad75826f-1862-4084-9286-70a386f28d79
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_categories
+    - node.type.event
+    - taxonomy.vocabulary.categories
+id: node.event.field_categories
+field_name: field_categories
+entity_type: node
+bundle: event
+label: Categories
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      categories: categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_categories.yml
+++ b/config/sync/field.storage.node.field_categories.yml
@@ -1,0 +1,20 @@
+uuid: b969c146-ad61-4e64-8aba-94314a7565e0
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_categories
+field_name: field_categories
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.taxonomy_term.categories.yml
+++ b/config/sync/language.content_settings.taxonomy_term.categories.yml
@@ -1,0 +1,11 @@
+uuid: f9233205-d200-4667-b337-4f456bed485f
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.categories
+id: taxonomy_term.categories
+target_entity_type_id: taxonomy_term
+target_bundle: categories
+default_langcode: da
+language_alterable: false

--- a/config/sync/language/da/core.entity_view_mode.taxonomy_term.full.yml
+++ b/config/sync/language/da/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,0 +1,1 @@
+label: Termside

--- a/config/sync/language/da/system.action.taxonomy_term_publish_action.yml
+++ b/config/sync/language/da/system.action.taxonomy_term_publish_action.yml
@@ -1,0 +1,1 @@
+label: 'Publicér taksonomiterm'

--- a/config/sync/language/da/system.action.taxonomy_term_unpublish_action.yml
+++ b/config/sync/language/da/system.action.taxonomy_term_unpublish_action.yml
@@ -1,0 +1,1 @@
+label: 'Afpublicér taksonomiterm'

--- a/config/sync/language/da/views.view.taxonomy_term.yml
+++ b/config/sync/language/da/views.view.taxonomy_term.yml
@@ -1,0 +1,31 @@
+label: 'Ord i ordforråd'
+description: 'Indhold som er knyttet til en bestemt term.'
+display:
+  default:
+    display_title: Standard
+    display_options:
+      pager:
+        options:
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      arguments:
+        tid:
+          exception:
+            title: Alle
+          title: '{{ arguments.tid }}'
+  feed_1:
+    display_title: Feed
+  page_1:
+    display_title: Side

--- a/config/sync/system.action.taxonomy_term_publish_action.yml
+++ b/config/sync/system.action.taxonomy_term_publish_action.yml
@@ -1,0 +1,13 @@
+uuid: 8b7c7893-2f4e-42c5-8276-d4def897bb33
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: DoVt_VGgVLcDD4XmVbSFzr0K17SJy9imFiYusKkJBgY
+id: taxonomy_term_publish_action
+label: 'Publish taxonomy term'
+type: taxonomy_term
+plugin: 'entity:publish_action:taxonomy_term'
+configuration: {  }

--- a/config/sync/system.action.taxonomy_term_unpublish_action.yml
+++ b/config/sync/system.action.taxonomy_term_unpublish_action.yml
@@ -1,0 +1,13 @@
+uuid: 957a2977-57df-4ef3-9ce3-47e482ef1665
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: z2sNRM3ECa7FPCGnSNje_9SmZJQgwhD_6fG_L4Mr8zI
+id: taxonomy_term_unpublish_action
+label: 'Unpublish taxonomy term'
+type: taxonomy_term
+plugin: 'entity:unpublish_action:taxonomy_term'
+configuration: {  }

--- a/config/sync/taxonomy.settings.yml
+++ b/config/sync/taxonomy.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: zKpaWT6cJc1tVQQaTqatGELaCqU_oyRym6zTl27Yias
+maintain_index_table: true
+override_selector: false
+terms_per_page_admin: 100

--- a/config/sync/taxonomy.vocabulary.categories.yml
+++ b/config/sync/taxonomy.vocabulary.categories.yml
@@ -1,0 +1,8 @@
+uuid: a2720c43-f549-41e8-80dd-3e4542566c27
+langcode: da
+status: true
+dependencies: {  }
+name: Categories
+vid: categories
+description: ''
+weight: 0

--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -1,0 +1,319 @@
+uuid: 4ae432f5-caa1-4be6-8249-b1933bca0f27
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+  module:
+    - node
+    - taxonomy
+    - user
+_core:
+  default_config_hash: YKgw0f77GEmCu6_6Om9Mbig0mON9JdfVuMxTtd0WQaI
+id: taxonomy_term
+label: 'Taxonomy term'
+module: taxonomy
+description: 'Content belonging to a certain taxonomy term.'
+tag: default
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields: {  }
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: 0
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        sticky:
+          id: sticky
+          table: taxonomy_index
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: sticky
+          exposed: false
+        created:
+          id: created
+          table: taxonomy_index
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          default_action: 'not found'
+          exception:
+            value: ''
+            title_enable: false
+            title: All
+          title_enable: true
+          title: '{{ arguments.tid }}'
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:taxonomy_term'
+            fail: 'not found'
+          validate_options:
+            bundles: {  }
+            access: true
+            operation: view
+            multiple: 0
+          break_phrase: false
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+      filters:
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: taxonomy_index
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      link_display: page_1
+      link_url: ''
+      header:
+        entity_taxonomy_term:
+          id: entity_taxonomy_term
+          table: views
+          field: entity_taxonomy_term
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: entity
+          empty: true
+          target: '{{ raw_arguments.tid }}'
+          view_mode: full
+          tokenize: true
+          bypass_access: false
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  feed_1:
+    id: feed_1
+    display_title: Feed
+    display_plugin: feed
+    position: 2
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      style:
+        type: rss
+        options:
+          grouping: {  }
+          uses_fields: false
+          description: ''
+      row:
+        type: node_rss
+        options:
+          relationship: none
+          view_mode: default
+      query:
+        type: views_query
+        options: {  }
+      display_extenders: {  }
+      path: taxonomy/term/%/feed
+      displays:
+        page_1: page_1
+        default: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      query:
+        type: views_query
+        options: {  }
+      display_extenders: {  }
+      path: taxonomy/term/%
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    a3a4aa80-7380-4a87-aa02-a0ba240410ba: eventinstance
+    16be6a5d-4f3e-4255-aae1-070e85bb8186: eventinstance
     618e176a-a45a-4c36-a197-664230aa0a34: media
     dc33677f-8894-4717-b34b-d985f6ad875f: media
     65432ee1-43f1-4130-9565-5683467d4b5a: media
@@ -101,7 +101,7 @@ default:
         href: 'http://dapple-cms.docker/user/login'
   event_instances:
     -
-      entity: a3a4aa80-7380-4a87-aa02-a0ba240410ba
+      entity: 16be6a5d-4f3e-4255-aae1-070e85bb8186
   field_event_address:
     -
       langcode: en

--- a/web/modules/custom/dpl_example_content/content/node/56bfda4c-2a5f-4fda-bb98-ffb5106f0a34.yml
+++ b/web/modules/custom/dpl_example_content/content/node/56bfda4c-2a5f-4fda-bb98-ffb5106f0a34.yml
@@ -5,6 +5,7 @@ _meta:
   bundle: event
   default_langcode: da
   depends:
+    8f627181-1cd6-42a2-9c71-75d85c966bcb: taxonomy_term
     618e176a-a45a-4c36-a197-664230aa0a34: media
     dc33677f-8894-4717-b34b-d985f6ad875f: media
     65432ee1-43f1-4130-9565-5683467d4b5a: media
@@ -39,6 +40,9 @@ default:
       attributes:
         name: title
         content: 'Fernisering Moderne Dans | DPL CMS'
+  field_categories:
+    -
+      entity: 8f627181-1cd6-42a2-9c71-75d85c966bcb
   field_event_address:
     -
       langcode: en

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/8f627181-1cd6-42a2-9c71-75d85c966bcb.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/8f627181-1cd6-42a2-9c71-75d85c966bcb.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 8f627181-1cd6-42a2-9c71-75d85c966bcb
+  bundle: categories
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: Event
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Event | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/1'

--- a/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
@@ -42,3 +42,6 @@ default_content:
     - 6d5e9b4c-389d-4735-a8a3-82883f64aeb0
     # PDF used in article 1, event 1 and eventseries 1
     - 3403d0ba-cbdc-425d-93f4-6cdabb5378b1
+  taxonomy_term:
+    # Event 1: From Figma
+    - 8f627181-1cd6-42a2-9c71-75d85c966bcb

--- a/web/themes/custom/novel/novel.libraries.yml
+++ b/web/themes/custom/novel/novel.libraries.yml
@@ -29,3 +29,7 @@ swiper:
     theme:
       "https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css":
         { type: external }
+
+show-more:
+  js:
+    assets/dpl-design-system/js/show-more.js: {}

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -1,0 +1,22 @@
+{{ attach_library('novel/show-more') }}
+{% set show_more_text = '...'|t %}
+{% set show_less_text = 'Show less'|t %}
+
+{% if items|length > 1 %}
+    <ul data-show-more-list>
+        {% for item in items %}
+            <li data-show-more-item class="tag tag--fill tag--small">
+                {{ item.content|raw }}
+            </li>
+        {% endfor %}
+      <button class="tag tag--fill tag--small cursor-pointer" aria-expanded="false" data-show-more-button data-show-more-text="{{ show_more_text }}" data-show-less-text="{{ show_less_text }}">
+          {{ show_more_text }}
+      </button>
+    </ul>
+{% else %}
+    {% for item in items %}
+        <span class="tag tag--fill tag--small">
+            {{ item.content|raw }}
+        </span>
+    {% endfor %}
+{% endif %}

--- a/web/themes/custom/novel/templates/layout/full-event.html.twig
+++ b/web/themes/custom/novel/templates/layout/full-event.html.twig
@@ -1,7 +1,9 @@
 <article {{ attributes.addClass('event-page') }}>
   <header class="event-header">
     <section class="event-header__content">
-      <!-- Tag -->
+      <div class="event-header__tags">
+        {{ categories }}
+      </div>
       <div class="event-header__date">
       {{ date }}
       </div>

--- a/web/themes/custom/novel/templates/layout/node--event--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--event--full.html.twig
@@ -30,5 +30,6 @@
   'paragraphs': content.field_event_paragraphs,
   'date': content.field_event_date,
   'description': content.field_event_description,
-  'description_items': description_items
+  'description_items': description_items,
+  'categories': content.field_categories,
 } only %}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-130

#### Description

This pull request introduces two key updates to the event content type in the 'dpl-cms' system. Firstly, it integrates taxonomy and categories, enabling users to tag events effectively. Secondly, it adds a 'Show More/Less' feature to the field categories template, improving user interaction by allowing the category list to be expanded or collapsed. 

#### Screenshot of the result
<img width="963" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/2dba71bb-320b-4285-b8a5-a66db9bdc071">