### PR TITLE
Add Taxonomy + Expandable Categories in Event Content Type (NEW)

### DIFF
--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -18,6 +19,7 @@ dependencies:
   module:
     - address
     - datetime_range
+    - dynamic_entity_reference
     - field_group
     - link
     - media_library
@@ -51,6 +53,16 @@ content:
     weight: 0
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_categories:
+    type: dynamic_entity_reference_default
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 40
+      placeholder: ''
     third_party_settings: {  }
   field_event_address:
     type: address_default

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -18,6 +19,7 @@ dependencies:
   module:
     - address
     - datetime_range
+    - dynamic_entity_reference
     - field_group
     - link
     - media_library
@@ -67,6 +69,16 @@ content:
     weight: 4
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_categories:
+    type: dynamic_entity_reference_default
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 40
+      placeholder: ''
     third_party_settings: {  }
   field_event_address:
     type: address_default

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventinstance.card
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -83,6 +84,7 @@ hidden:
   event_place: true
   event_state: true
   event_ticket_categories: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -18,6 +19,7 @@ dependencies:
   module:
     - address
     - date_range_formatter
+    - dynamic_entity_reference
     - entity_reference_revisions
     - link
     - text
@@ -134,6 +136,14 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_categories:
+    type: dynamic_entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 12
     region: content
   title:
     type: string

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventinstance.list
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -149,6 +150,7 @@ content:
     region: content
 hidden:
   body: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventinstance.list_teaser
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -12,6 +13,8 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_teaser_image
+    - field.field.eventinstance.default.field_teaser_text
     - field.field.eventinstance.default.field_ticket_categories
     - recurring_events.eventinstance_type.default
   module:
@@ -145,6 +148,7 @@ hidden:
   body: true
   description: true
   event_state: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventseries.default.card.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.card.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventseries.card
+    - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -64,6 +65,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -17,6 +18,7 @@ dependencies:
     - recurring_events.eventseries_type.default
   module:
     - address
+    - dynamic_entity_reference
     - entity_reference_revisions
     - link
     - options
@@ -36,6 +38,14 @@ content:
       link: false
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_categories:
+    type: dynamic_entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 13
     region: content
   field_event_address:
     type: address_default

--- a/config/sync/core.entity_view_display.eventseries.default.list.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.list.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventseries.list
+    - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -47,6 +48,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_mode.taxonomy_term.full.yml
+++ b/config/sync/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,0 +1,12 @@
+uuid: bd628b4a-f340-4545-b99f-0f253f12fbca
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: '-PPKjsNQPvoIDjOuUAvlLocYD976MNjb9Zpgyz5_BWE'
+id: taxonomy_term.full
+label: 'Taxonomy term page'
+targetEntityType: taxonomy_term
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -90,6 +90,7 @@ module:
   search_api_db: 0
   serialization: 0
   system: 0
+  taxonomy: 0
   text: 0
   token: 0
   toolbar: 0

--- a/config/sync/field.field.eventinstance.default.field_categories.yml
+++ b/config/sync/field.field.eventinstance.default.field_categories.yml
@@ -1,49 +1,48 @@
-uuid: 79c12a96-b561-43a9-b736-02a95362236b
+uuid: 8658f862-9ca9-4526-ad3c-0d7492964aac
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.paragraph.field_content_references
-    - paragraphs.paragraphs_type.content_slider
+    - field.storage.eventinstance.field_categories
+    - recurring_events.eventinstance_type.default
+    - taxonomy.vocabulary.categories
   module:
     - dynamic_entity_reference
-id: paragraph.content_slider.field_content_references
-field_name: field_content_references
-entity_type: paragraph
-bundle: content_slider
-label: Contents
+id: eventinstance.default.field_categories
+field_name: field_categories
+entity_type: eventinstance
+bundle: default
+label: Categories
 description: ''
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings:
+      target_bundles:
+        categories: categories
+      sort:
+        field: name
+        direction: asc
+      auto_create: true
+      auto_create_bundle: ''
   node:
-    handler: views
-    handler_settings:
-      view:
-        view_name: entity_reference_content
-        display_name: entity_reference_1
-        arguments: {  }
-  eventinstance:
-    handler: views
-    handler_settings:
-      view:
-        view_name: entity_reference_event_instance
-        display_name: entity_reference_1
-        arguments: {  }
-  eventseries:
-    handler: views
-    handler_settings:
-      view:
-        view_name: entity_reference_event_series
-        display_name: entity_reference_1
-        arguments: {  }
+    handler: 'default:node'
+    handler_settings: {  }
   crop:
     handler: 'default:crop'
     handler_settings: {  }
   menu_link_content:
     handler: 'default:menu_link_content'
+    handler_settings: {  }
+  eventinstance:
+    handler: 'default:eventinstance'
+    handler_settings: {  }
+  eventseries:
+    handler: 'default:eventseries'
     handler_settings: {  }
   file:
     handler: 'default:file'
@@ -65,8 +64,5 @@ settings:
     handler_settings: {  }
   user:
     handler: 'default:user'
-    handler_settings: {  }
-  taxonomy_term:
-    handler: 'default:taxonomy_term'
     handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/config/sync/field.field.eventseries.default.field_categories.yml
+++ b/config/sync/field.field.eventseries.default.field_categories.yml
@@ -1,49 +1,48 @@
-uuid: 79c12a96-b561-43a9-b736-02a95362236b
+uuid: f3bc51e7-f1fa-4f9e-850e-4d68ffb40cf2
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.paragraph.field_content_references
-    - paragraphs.paragraphs_type.content_slider
+    - field.storage.eventseries.field_categories
+    - recurring_events.eventseries_type.default
+    - taxonomy.vocabulary.categories
   module:
     - dynamic_entity_reference
-id: paragraph.content_slider.field_content_references
-field_name: field_content_references
-entity_type: paragraph
-bundle: content_slider
-label: Contents
+id: eventseries.default.field_categories
+field_name: field_categories
+entity_type: eventseries
+bundle: default
+label: Categories
 description: ''
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings:
+      target_bundles:
+        categories: categories
+      sort:
+        field: name
+        direction: asc
+      auto_create: true
+      auto_create_bundle: ''
   node:
-    handler: views
-    handler_settings:
-      view:
-        view_name: entity_reference_content
-        display_name: entity_reference_1
-        arguments: {  }
-  eventinstance:
-    handler: views
-    handler_settings:
-      view:
-        view_name: entity_reference_event_instance
-        display_name: entity_reference_1
-        arguments: {  }
-  eventseries:
-    handler: views
-    handler_settings:
-      view:
-        view_name: entity_reference_event_series
-        display_name: entity_reference_1
-        arguments: {  }
+    handler: 'default:node'
+    handler_settings: {  }
   crop:
     handler: 'default:crop'
     handler_settings: {  }
   menu_link_content:
     handler: 'default:menu_link_content'
+    handler_settings: {  }
+  eventinstance:
+    handler: 'default:eventinstance'
+    handler_settings: {  }
+  eventseries:
+    handler: 'default:eventseries'
     handler_settings: {  }
   file:
     handler: 'default:file'
@@ -65,8 +64,5 @@ settings:
     handler_settings: {  }
   user:
     handler: 'default:user'
-    handler_settings: {  }
-  taxonomy_term:
-    handler: 'default:taxonomy_term'
     handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/config/sync/field.storage.eventinstance.field_categories.yml
+++ b/config/sync/field.storage.eventinstance.field_categories.yml
@@ -1,0 +1,23 @@
+uuid: d7c2accb-a5cd-497d-8495-3f87a1bd8615
+langcode: en
+status: true
+dependencies:
+  module:
+    - dynamic_entity_reference
+    - recurring_events
+    - taxonomy
+id: eventinstance.field_categories
+field_name: field_categories
+entity_type: eventinstance
+type: dynamic_entity_reference
+settings:
+  exclude_entity_types: false
+  entity_type_ids:
+    taxonomy_term: taxonomy_term
+module: dynamic_entity_reference
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.eventseries.field_categories.yml
+++ b/config/sync/field.storage.eventseries.field_categories.yml
@@ -1,0 +1,23 @@
+uuid: d5bbdcb6-995a-45c3-ad9d-3dd0de41251c
+langcode: en
+status: true
+dependencies:
+  module:
+    - dynamic_entity_reference
+    - recurring_events
+    - taxonomy
+id: eventseries.field_categories
+field_name: field_categories
+entity_type: eventseries
+type: dynamic_entity_reference
+settings:
+  exclude_entity_types: false
+  entity_type_ids:
+    taxonomy_term: taxonomy_term
+module: dynamic_entity_reference
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.taxonomy_term.categories.yml
+++ b/config/sync/language.content_settings.taxonomy_term.categories.yml
@@ -1,0 +1,11 @@
+uuid: e1238ce1-b3e7-4ea0-aae4-ca19204b8385
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.categories
+id: taxonomy_term.categories
+target_entity_type_id: taxonomy_term
+target_bundle: categories
+default_langcode: da
+language_alterable: false

--- a/config/sync/language/da/core.entity_view_mode.taxonomy_term.full.yml
+++ b/config/sync/language/da/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,0 +1,1 @@
+label: Termside

--- a/config/sync/language/da/system.action.taxonomy_term_publish_action.yml
+++ b/config/sync/language/da/system.action.taxonomy_term_publish_action.yml
@@ -1,0 +1,1 @@
+label: 'Publicér taksonomiterm'

--- a/config/sync/language/da/system.action.taxonomy_term_unpublish_action.yml
+++ b/config/sync/language/da/system.action.taxonomy_term_unpublish_action.yml
@@ -1,0 +1,1 @@
+label: 'Afpublicér taksonomiterm'

--- a/config/sync/language/da/views.view.taxonomy_term.yml
+++ b/config/sync/language/da/views.view.taxonomy_term.yml
@@ -1,0 +1,31 @@
+label: 'Ord i ordforråd'
+description: 'Indhold som er knyttet til en bestemt term.'
+display:
+  default:
+    display_title: Standard
+    display_options:
+      pager:
+        options:
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      arguments:
+        tid:
+          exception:
+            title: Alle
+          title: '{{ arguments.tid }}'
+  feed_1:
+    display_title: Feed
+  page_1:
+    display_title: Side

--- a/config/sync/system.action.taxonomy_term_publish_action.yml
+++ b/config/sync/system.action.taxonomy_term_publish_action.yml
@@ -1,0 +1,13 @@
+uuid: 5f07927b-258b-4501-a9d6-fc64ef1ea6cd
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: DoVt_VGgVLcDD4XmVbSFzr0K17SJy9imFiYusKkJBgY
+id: taxonomy_term_publish_action
+label: 'Publish taxonomy term'
+type: taxonomy_term
+plugin: 'entity:publish_action:taxonomy_term'
+configuration: {  }

--- a/config/sync/system.action.taxonomy_term_unpublish_action.yml
+++ b/config/sync/system.action.taxonomy_term_unpublish_action.yml
@@ -1,0 +1,13 @@
+uuid: 03076c80-7e3a-4ea3-b08d-eb045ac7cef0
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: z2sNRM3ECa7FPCGnSNje_9SmZJQgwhD_6fG_L4Mr8zI
+id: taxonomy_term_unpublish_action
+label: 'Unpublish taxonomy term'
+type: taxonomy_term
+plugin: 'entity:unpublish_action:taxonomy_term'
+configuration: {  }

--- a/config/sync/taxonomy.settings.yml
+++ b/config/sync/taxonomy.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: zKpaWT6cJc1tVQQaTqatGELaCqU_oyRym6zTl27Yias
+maintain_index_table: true
+override_selector: false
+terms_per_page_admin: 100

--- a/config/sync/taxonomy.vocabulary.categories.yml
+++ b/config/sync/taxonomy.vocabulary.categories.yml
@@ -1,0 +1,8 @@
+uuid: 2ff40f47-58d5-4979-ae08-5a6c21ce9a1f
+langcode: da
+status: true
+dependencies: {  }
+name: Categories
+vid: categories
+description: ''
+weight: 0

--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -1,0 +1,319 @@
+uuid: 21515a64-532d-44ee-89b2-2aab29871194
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+  module:
+    - node
+    - taxonomy
+    - user
+_core:
+  default_config_hash: YKgw0f77GEmCu6_6Om9Mbig0mON9JdfVuMxTtd0WQaI
+id: taxonomy_term
+label: 'Taxonomy term'
+module: taxonomy
+description: 'Content belonging to a certain taxonomy term.'
+tag: default
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields: {  }
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: 0
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        sticky:
+          id: sticky
+          table: taxonomy_index
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: sticky
+          exposed: false
+        created:
+          id: created
+          table: taxonomy_index
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          default_action: 'not found'
+          exception:
+            value: ''
+            title_enable: false
+            title: All
+          title_enable: true
+          title: '{{ arguments.tid }}'
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:taxonomy_term'
+            fail: 'not found'
+          validate_options:
+            bundles: {  }
+            access: true
+            operation: view
+            multiple: 0
+          break_phrase: false
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+      filters:
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: taxonomy_index
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      link_display: page_1
+      link_url: ''
+      header:
+        entity_taxonomy_term:
+          id: entity_taxonomy_term
+          table: views
+          field: entity_taxonomy_term
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: entity
+          empty: true
+          target: '{{ raw_arguments.tid }}'
+          view_mode: full
+          tokenize: true
+          bypass_access: false
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  feed_1:
+    id: feed_1
+    display_title: Feed
+    display_plugin: feed
+    position: 2
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      style:
+        type: rss
+        options:
+          grouping: {  }
+          uses_fields: false
+          description: ''
+      row:
+        type: node_rss
+        options:
+          relationship: none
+          view_mode: default
+      query:
+        type: views_query
+        options: {  }
+      display_extenders: {  }
+      path: taxonomy/term/%/feed
+      displays:
+        page_1: page_1
+        default: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      query:
+        type: views_query
+        options: {  }
+      display_extenders: {  }
+      path: taxonomy/term/%
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/web/themes/custom/novel/novel.libraries.yml
+++ b/web/themes/custom/novel/novel.libraries.yml
@@ -29,3 +29,7 @@ swiper:
     theme:
       "https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css":
         { type: external }
+
+show-more:
+  js:
+    assets/dpl-design-system/js/show-more.js: {}

--- a/web/themes/custom/novel/templates/components/full-event.html.twig
+++ b/web/themes/custom/novel/templates/components/full-event.html.twig
@@ -1,14 +1,14 @@
 <article {{ attributes.addClass('event-page') }}>
   <header class="event-header">
     <section class="event-header__content">
-      <!-- Tag -->
-
+      <div class="event-header__tags">
+        {{ categories }}
+      </div>
       {% if date %}
         <time class="event-header__date">
           {{ date }}
         </time>
       {% endif %}
-
       <h1 class="event-header__title">{{ label }}</h1>
       {{ event_link }}
     </section>

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -1,0 +1,22 @@
+{{ attach_library('novel/show-more') }}
+{% set show_more_text = '...'|t %}
+{% set show_less_text = 'Show less'|t %}
+
+{% if items|length > 1 %}
+    <ul data-show-more-list>
+        {% for item in items %}
+            <li data-show-more-item class="tag tag--fill tag--small">
+                {{ item.content|raw }}
+            </li>
+        {% endfor %}
+      <button class="tag tag--fill tag--small cursor-pointer" aria-expanded="false" data-show-more-button data-show-more-text="{{ show_more_text }}" data-show-less-text="{{ show_less_text }}">
+          {{ show_more_text }}
+      </button>
+    </ul>
+{% else %}
+    {% for item in items %}
+        <span class="tag tag--fill tag--small">
+            {{ item.content|raw }}
+        </span>
+    {% endfor %}
+{% endif %}

--- a/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
@@ -30,5 +30,6 @@
   'paragraphs': content.event_paragraphs,
   'date': content.date,
   'description': content.event_description,
-  'description_items': description_items
+  'description_items': description_items,
+  'categories': content.field_categories,
 } only %}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-130

#### Description

This pull request introduces two key updates to the event content type in the 'dpl-cms' system. Firstly, it integrates taxonomy and categories, enabling users to tag events effectively. Secondly, it adds a 'Show More/Less' feature to the field categories template, improving user interaction by allowing the category list to be expanded or collapsed. 

#### Screenshot of the result
<img width="963" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/2dba71bb-320b-4285-b8a5-a66db9bdc071">