### PR TITLE
Taxonomy: Categories and tags

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -274,6 +274,11 @@ tasks:
           -i https://raw.githubusercontent.com/danskernesdigitalebibliotek/dpl-react/main/src/core/fbs/fbs-adapter.yaml \
           -g php -o /local/packages/fbs-client -c /openapi-generator.config.fbs.yaml
 
+  dev:example-content:update:
+    desc: Update the example content module with data from the current site
+    cmds:
+      - cmd: task dev:cli -- drush default-content:export-module dpl_example_content
+
   ci:reset:
     desc: Create CI setup in a clean state
     cmds:

--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,9 @@
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-design-system",
                 "type": "drupal-library",
-                "version": "0.0.0-dev",
+                "version": "2024.6.0-rc1",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/branch-taxonomy_categories/dist-taxonomy-categories.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/branch-release%2F2024-6-0/dist-release-2024-6-0.zip",
                     "type": "zip"
                 }
             }
@@ -74,7 +74,7 @@
         "brick/math": "^0.12.1",
         "composer/installers": "1.12.0",
         "cweagans/composer-patches": "1.7.3",
-        "danskernesdigitalebibliotek/dpl-design-system": "0.0.0-dev",
+        "danskernesdigitalebibliotek/dpl-design-system": "2024.6.0-rc1",
         "danskernesdigitalebibliotek/dpl-react": "2024.6.0-rc1",
         "danskernesdigitalebibliotek/fbs-client": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",

--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,9 @@
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-design-system",
                 "type": "drupal-library",
-                "version": "2024.6.0-rc1",
+                "version": "0.0.0-dev",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/branch-release%2F2024-6-0/dist-release-2024-6-0.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/branch-taxonomy_categories/dist-taxonomy-categories.zip",
                     "type": "zip"
                 }
             }
@@ -74,7 +74,7 @@
         "brick/math": "^0.12.1",
         "composer/installers": "1.12.0",
         "cweagans/composer-patches": "1.7.3",
-        "danskernesdigitalebibliotek/dpl-design-system": "2024.6.0-rc1",
+        "danskernesdigitalebibliotek/dpl-design-system": "0.0.0-dev",
         "danskernesdigitalebibliotek/dpl-react": "2024.6.0-rc1",
         "danskernesdigitalebibliotek/fbs-client": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",

--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,6 @@
         "drupal/restui": "^1.21",
         "drupal/search_api": "^1.31",
         "drupal/twig_tweak": "^3.2.1",
-        "drupal/twigsuggest": "^1.0@RC",
         "drupal/upgrade_status": "^4.0",
         "drupal/uuid_url": "^1.3",
         "drupal/varnish_purge": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,7 @@
         "drupal/restui": "^1.21",
         "drupal/search_api": "^1.31",
         "drupal/twig_tweak": "^3.2.1",
+        "drupal/twigsuggest": "^1.0@RC",
         "drupal/upgrade_status": "^4.0",
         "drupal/uuid_url": "^1.3",
         "drupal/varnish_purge": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48359da25f1633c551d2b5cc76b37b5a",
+    "content-hash": "c73dcf69315148852dd966cab6a96793",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1099,10 +1099,10 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-design-system",
-            "version": "0.0.0-dev",
+            "version": "2024.6.0-rc1",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/branch-taxonomy_categories/dist-taxonomy-categories.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/branch-release%2F2024-6-0/dist-release-2024-6-0.zip"
             },
             "type": "drupal-library"
         },
@@ -15374,7 +15374,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "danskernesdigitalebibliotek/dpl-design-system": 20,
         "drupal/customerror": 10,
         "drupal/default_content": 15,
         "drupal/gin": 5,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c73dcf69315148852dd966cab6a96793",
+    "content-hash": "48359da25f1633c551d2b5cc76b37b5a",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1099,10 +1099,10 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-design-system",
-            "version": "2024.6.0-rc1",
+            "version": "0.0.0-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/branch-release%2F2024-6-0/dist-release-2024-6-0.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-design-system/releases/download/branch-taxonomy_categories/dist-taxonomy-categories.zip"
             },
             "type": "drupal-library"
         },
@@ -15374,6 +15374,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "danskernesdigitalebibliotek/dpl-design-system": 20,
         "drupal/customerror": 10,
         "drupal/default_content": 15,
         "drupal/gin": 5,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c73dcf69315148852dd966cab6a96793",
+    "content-hash": "28e0f8e9791d9923695cb30afbedd9f8",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -15380,7 +15380,8 @@
         "drupal/gin_toolbar": 5,
         "drupal/openapi_rest": 5,
         "drupal/potion": 20,
-        "drupal/recurring_events": 5
+        "drupal/recurring_events": 5,
+        "drupal/twigsuggest": 5
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28e0f8e9791d9923695cb30afbedd9f8",
+    "content-hash": "c73dcf69315148852dd966cab6a96793",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -15380,8 +15380,7 @@
         "drupal/gin_toolbar": 5,
         "drupal/openapi_rest": 5,
         "drupal/potion": 20,
-        "drupal/recurring_events": 5,
-        "drupal/twigsuggest": 5
+        "drupal/recurring_events": 5
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -51,6 +52,16 @@ content:
     weight: 0
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_categories:
+    type: entity_reference_autocomplete
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_event_address:
     type: address_default

--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
     - field.field.eventinstance.default.field_ticket_categories
@@ -129,6 +130,16 @@ content:
     weight: 2
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 27
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_teaser_image:
     type: media_library_widget

--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -54,14 +54,10 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_categories:
-    type: entity_reference_autocomplete
+    type: options_select
     weight: 26
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_event_address:
     type: address_default

--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -33,7 +33,7 @@ third_party_settings:
       label: 'Teaser card'
       region: content
       parent_name: ''
-      weight: 11
+      weight: 12
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -56,26 +56,26 @@ content:
     third_party_settings: {  }
   field_categories:
     type: options_select
-    weight: 26
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_event_address:
     type: address_default
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   field_event_image:
     type: media_library_widget
-    weight: 9
+    weight: 10
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_event_link:
     type: link_default
-    weight: 5
+    weight: 6
     region: content
     settings:
       placeholder_url: ''
@@ -83,7 +83,7 @@ content:
     third_party_settings: {  }
   field_event_paragraphs:
     type: paragraphs
-    weight: 10
+    weight: 11
     region: content
     settings:
       title: Paragraph
@@ -111,7 +111,7 @@ content:
           dialog_style: tiles
   field_event_partners:
     type: string_textfield
-    weight: 8
+    weight: 9
     region: content
     settings:
       size: 60
@@ -119,7 +119,7 @@ content:
     third_party_settings: {  }
   field_event_place:
     type: string_textfield
-    weight: 7
+    weight: 8
     region: content
     settings:
       size: 60
@@ -133,7 +133,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 27
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
@@ -158,7 +158,7 @@ content:
     third_party_settings: {  }
   field_ticket_categories:
     type: paragraphs
-    weight: 4
+    weight: 5
     region: content
     settings:
       title: Paragraph

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -70,14 +70,10 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_categories:
-    type: entity_reference_autocomplete
+    type: options_select
     weight: 26
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_event_address:
     type: address_default

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -67,6 +68,16 @@ content:
     weight: 4
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_categories:
+    type: entity_reference_autocomplete
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_event_address:
     type: address_default

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.eventseries.default.field_event_partners
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
+    - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
     - field.field.eventseries.default.field_ticket_categories
@@ -153,6 +154,16 @@ content:
     weight: 2
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 27
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_teaser_image:
     type: media_library_widget

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -35,7 +35,7 @@ third_party_settings:
       label: 'Teaser card'
       region: content
       parent_name: ''
-      weight: 19
+      weight: 20
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -60,31 +60,31 @@ content:
     third_party_settings: {  }
   custom_date:
     type: daterange_default
-    weight: 4
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   daily_recurring_date:
     type: daily_recurring_date
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   field_categories:
     type: options_select
-    weight: 26
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   field_event_address:
     type: address_default
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   field_event_description:
     type: text_textarea
-    weight: 11
+    weight: 12
     region: content
     settings:
       rows: 5
@@ -92,14 +92,14 @@ content:
     third_party_settings: {  }
   field_event_image:
     type: media_library_widget
-    weight: 17
+    weight: 18
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_event_link:
     type: link_default
-    weight: 13
+    weight: 14
     region: content
     settings:
       placeholder_url: ''
@@ -107,7 +107,7 @@ content:
     third_party_settings: {  }
   field_event_paragraphs:
     type: paragraphs
-    weight: 18
+    weight: 19
     region: content
     settings:
       title: Paragraph
@@ -135,7 +135,7 @@ content:
           dialog_style: tiles
   field_event_partners:
     type: string_textfield
-    weight: 16
+    weight: 17
     region: content
     settings:
       size: 60
@@ -143,7 +143,7 @@ content:
     third_party_settings: {  }
   field_event_place:
     type: string_textfield
-    weight: 15
+    weight: 16
     region: content
     settings:
       size: 60
@@ -151,13 +151,13 @@ content:
     third_party_settings: {  }
   field_event_state:
     type: options_select
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 27
+    weight: 11
     region: content
     settings:
       match_operator: CONTAINS
@@ -182,7 +182,7 @@ content:
     third_party_settings: {  }
   field_ticket_categories:
     type: paragraphs
-    weight: 12
+    weight: 13
     region: content
     settings:
       title: Paragraph
@@ -200,7 +200,7 @@ content:
     third_party_settings: {  }
   monthly_recurring_date:
     type: monthly_recurring_date
-    weight: 4
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -212,7 +212,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 1
+    weight: 0
     region: content
     settings:
       display_label: true
@@ -237,13 +237,13 @@ content:
     third_party_settings: {  }
   weekly_recurring_date:
     type: weekly_recurring_date
-    weight: 4
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   yearly_recurring_date:
     type: yearly_recurring_date
-    weight: 4
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -29,7 +29,7 @@ third_party_settings:
       label: 'Meta tags'
       region: content
       parent_name: ''
-      weight: 6
+      weight: 8
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -46,7 +46,7 @@ third_party_settings:
       label: 'Teaser card'
       region: content
       parent_name: ''
-      weight: 7
+      weight: 9
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -71,13 +71,13 @@ content:
     third_party_settings: {  }
   field_categories:
     type: options_select
-    weight: 26
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   field_override_author:
     type: string_textfield
-    weight: 5
+    weight: 7
     region: content
     settings:
       size: 60
@@ -85,7 +85,7 @@ content:
     third_party_settings: {  }
   field_paragraphs:
     type: paragraphs
-    weight: 2
+    weight: 4
     region: content
     settings:
       title: Paragraph
@@ -113,7 +113,7 @@ content:
         show_drag_and_drop: true
   field_show_override_author:
     type: boolean_checkbox
-    weight: 4
+    weight: 6
     region: content
     settings:
       display_label: true
@@ -128,7 +128,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 27
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
@@ -155,7 +155,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 3
+    weight: 5
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
     - field.field.node.article.field_subtitle
+    - field.field.node.article.field_tags
     - field.field.node.article.field_teaser_image
     - field.field.node.article.field_teaser_text
     - node.type.article
@@ -123,6 +124,16 @@ content:
     region: content
     settings:
       rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 27
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_teaser_image:

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.article.field_canonical_url
+    - field.field.node.article.field_categories
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
@@ -66,6 +67,12 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
+    third_party_settings: {  }
+  field_categories:
+    type: options_select
+    weight: 26
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_override_author:
     type: string_textfield

--- a/config/sync/core.entity_form_display.taxonomy_term.categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.categories.default.yml
@@ -1,0 +1,35 @@
+uuid: 85fc4e91-0814-4569-8f2b-b35a1870042b
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.categories
+id: taxonomy_term.categories.default
+targetEntityType: taxonomy_term
+bundle: categories
+mode: default
+content:
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  description: true

--- a/config/sync/core.entity_form_display.taxonomy_term.tags.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.tags.default.yml
@@ -1,0 +1,35 @@
+uuid: 6151cf14-ab6f-4478-a6f1-7bc945379aa6
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.default
+targetEntityType: taxonomy_term
+bundle: tags
+mode: default
+content:
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  description: true

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -47,6 +47,14 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  event_categories:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 52
+    region: content
   event_teaser_image:
     type: entity_reference_entity_view
     label: hidden

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventinstance.card
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -83,6 +84,7 @@ hidden:
   event_place: true
   event_state: true
   event_ticket_categories: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
     - field.field.eventinstance.default.field_ticket_categories
@@ -54,6 +55,14 @@ content:
       link: true
     third_party_settings: {  }
     weight: 52
+    region: content
+  event_tags:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
     region: content
   event_teaser_image:
     type: entity_reference_entity_view
@@ -101,6 +110,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   field_ticket_categories: true

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
     - field.field.eventinstance.default.field_ticket_categories
@@ -118,6 +119,14 @@ content:
     third_party_settings: {  }
     weight: 7
     region: content
+  event_tags:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 13
+    region: content
   event_teaser_image:
     type: entity_reference_entity_view
     label: hidden
@@ -165,6 +174,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   field_ticket_categories: true

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -134,6 +135,14 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_categories:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 12
     region: content
   title:
     type: string

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -57,6 +57,14 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  event_categories:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 12
+    region: content
   event_description:
     type: text_default
     label: hidden
@@ -136,14 +144,6 @@ content:
     third_party_settings: {  }
     weight: 8
     region: content
-  field_categories:
-    type: entity_reference_label
-    label: hidden
-    settings:
-      link: false
-    third_party_settings: {  }
-    weight: 12
-    region: content
   title:
     type: string
     label: hidden
@@ -156,6 +156,7 @@ hidden:
   body: true
   description: true
   event_state: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -56,6 +56,14 @@ content:
     third_party_settings: {  }
     weight: 51
     region: content
+  event_categories:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 52
+    region: content
   event_description:
     type: text_default
     label: visible

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventinstance.list
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -149,6 +150,7 @@ content:
     region: content
 hidden:
   body: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
     - field.field.eventinstance.default.field_ticket_categories
@@ -123,6 +124,14 @@ content:
     third_party_settings: {  }
     weight: 57
     region: content
+  event_tags:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
   event_teaser_image:
     type: entity_reference_label
     label: visible
@@ -167,6 +176,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   field_ticket_categories: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -119,22 +119,6 @@ content:
     third_party_settings: {  }
     weight: 7
     region: content
-  event_teaser_image:
-    type: entity_reference_label
-    label: visible
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 59
-    region: content
-  event_teaser_text:
-    type: string
-    label: visible
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 60
-    region: content
   event_ticket_categories:
     type: entity_reference_revisions_entity_view
     label: hidden
@@ -156,6 +140,8 @@ hidden:
   body: true
   description: true
   event_state: true
+  event_teaser_image: true
+  event_teaser_text: true
   field_categories: true
   field_event_address: true
   field_event_description: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
     - field.field.eventinstance.default.field_ticket_categories
@@ -119,6 +120,14 @@ content:
     third_party_settings: {  }
     weight: 7
     region: content
+  event_tags:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
   event_ticket_categories:
     type: entity_reference_revisions_entity_view
     label: hidden
@@ -151,6 +160,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   field_ticket_categories: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -58,6 +58,14 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  event_categories:
+    type: entity_reference_label
+    label: visually_hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 10
+    region: content
   event_description:
     type: text_default
     label: hidden

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventinstance.list_teaser
+    - field.field.eventinstance.default.field_categories
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -12,6 +13,8 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_teaser_image
+    - field.field.eventinstance.default.field_teaser_text
     - field.field.eventinstance.default.field_ticket_categories
     - recurring_events.eventinstance_type.default
   module:
@@ -145,6 +148,7 @@ hidden:
   body: true
   description: true
   event_state: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventseries.default.card.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.card.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventseries.card
+    - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -64,6 +65,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventseries.default.card.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.card.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventseries.default.field_event_partners
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
+    - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
     - field.field.eventseries.default.field_ticket_categories
@@ -74,6 +75,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_tags: true
   field_ticket_categories: true
   monthly_recurring_date: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.eventseries.default.field_event_partners
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
+    - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
     - field.field.eventseries.default.field_ticket_categories
@@ -105,6 +106,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 7
+    region: content
+  field_tags:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 14
     region: content
   field_teaser_image:
     type: entity_reference_entity_view

--- a/config/sync/core.entity_view_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -36,6 +37,14 @@ content:
       link: false
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_categories:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 13
     region: content
   field_event_address:
     type: address_default

--- a/config/sync/core.entity_view_display.eventseries.default.list.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.list.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventseries.default.field_event_partners
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
+    - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
     - field.field.eventseries.default.field_ticket_categories
@@ -57,6 +58,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   field_ticket_categories: true

--- a/config/sync/core.entity_view_display.eventseries.default.list.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.list.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventseries.list
+    - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -47,6 +48,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_categories: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.node.article.card.yml
+++ b/config/sync/core.entity_view_display.node.article.card.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.card
     - field.field.node.article.field_canonical_url
+    - field.field.node.article.field_categories
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
@@ -45,6 +46,7 @@ content:
     region: content
 hidden:
   field_canonical_url: true
+  field_categories: true
   field_override_author: true
   field_paragraphs: true
   field_show_override_author: true

--- a/config/sync/core.entity_view_display.node.article.card.yml
+++ b/config/sync/core.entity_view_display.node.article.card.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
     - field.field.node.article.field_subtitle
+    - field.field.node.article.field_tags
     - field.field.node.article.field_teaser_image
     - field.field.node.article.field_teaser_text
     - node.type.article
@@ -50,6 +51,7 @@ hidden:
   field_override_author: true
   field_paragraphs: true
   field_show_override_author: true
+  field_tags: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.article.field_canonical_url
+    - field.field.node.article.field_categories
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
@@ -18,6 +19,14 @@ targetEntityType: node
 bundle: article
 mode: default
 content:
+  field_categories:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 110
+    region: content
   field_override_author:
     type: string
     label: above

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
     - field.field.node.article.field_subtitle
+    - field.field.node.article.field_tags
     - field.field.node.article.field_teaser_image
     - field.field.node.article.field_teaser_text
     - node.type.article
@@ -51,6 +52,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 101
+    region: content
+  field_tags:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 111
     region: content
   field_teaser_image:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.article.full.yml
+++ b/config/sync/core.entity_view_display.node.article.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.article.field_canonical_url
+    - field.field.node.article.field_categories
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
@@ -20,6 +21,14 @@ targetEntityType: node
 bundle: article
 mode: full
 content:
+  field_categories:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_paragraphs:
     type: entity_reference_revisions_entity_view
     label: hidden
@@ -27,7 +36,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 0
+    weight: 2
     region: content
   field_subtitle:
     type: basic_string
@@ -39,7 +48,7 @@ content:
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 3
     region: content
 hidden:
   field_canonical_url: true
@@ -48,5 +57,4 @@ hidden:
   field_teaser_image: true
   field_teaser_text: true
   langcode: true
-  links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.full.yml
+++ b/config/sync/core.entity_view_display.node.article.full.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
     - field.field.node.article.field_subtitle
+    - field.field.node.article.field_tags
     - field.field.node.article.field_teaser_image
     - field.field.node.article.field_teaser_text
     - node.type.article
@@ -54,6 +55,7 @@ hidden:
   field_canonical_url: true
   field_override_author: true
   field_show_override_author: true
+  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.article.full.yml
+++ b/config/sync/core.entity_view_display.node.article.full.yml
@@ -37,7 +37,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   field_subtitle:
     type: basic_string
@@ -46,16 +46,23 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  field_tags:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
 hidden:
   field_canonical_url: true
   field_override_author: true
   field_show_override_author: true
-  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.article.field_canonical_url
+    - field.field.node.article.field_categories
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
@@ -26,6 +27,7 @@ content:
     region: content
 hidden:
   field_canonical_url: true
+  field_categories: true
   field_override_author: true
   field_paragraphs: true
   field_show_override_author: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_show_override_author
     - field.field.node.article.field_subtitle
+    - field.field.node.article.field_tags
     - field.field.node.article.field_teaser_image
     - field.field.node.article.field_teaser_text
     - node.type.article
@@ -32,6 +33,7 @@ hidden:
   field_paragraphs: true
   field_show_override_author: true
   field_subtitle: true
+  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   langcode: true

--- a/config/sync/core.entity_view_mode.taxonomy_term.full.yml
+++ b/config/sync/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,0 +1,12 @@
+uuid: 74546f26-4349-474c-9c4b-51da95efac42
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: '-PPKjsNQPvoIDjOuUAvlLocYD976MNjb9Zpgyz5_BWE'
+id: taxonomy_term.full
+label: 'Taxonomy term page'
+targetEntityType: taxonomy_term
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -103,7 +103,6 @@ module:
   views: 10
   paragraphs: 11
   paragraphs_ee: 15
-  twigsuggest: 100
   dpl_cms: 1000
 theme:
   claro: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -91,6 +91,7 @@ module:
   search_api_db: 0
   serialization: 0
   system: 0
+  taxonomy: 0
   text: 0
   token: 0
   toolbar: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -103,6 +103,7 @@ module:
   views: 10
   paragraphs: 11
   paragraphs_ee: 15
+  twigsuggest: 100
   dpl_cms: 1000
 theme:
   claro: 0

--- a/config/sync/field.field.eventinstance.default.field_categories.yml
+++ b/config/sync/field.field.eventinstance.default.field_categories.yml
@@ -1,0 +1,29 @@
+uuid: 2a99cbbe-7e49-477c-a49f-5a402152597a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventinstance.field_categories
+    - recurring_events.eventinstance_type.default
+    - taxonomy.vocabulary.categories
+id: eventinstance.default.field_categories
+field_name: field_categories
+entity_type: eventinstance
+bundle: default
+label: Categories
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      categories: categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.eventinstance.default.field_tags.yml
+++ b/config/sync/field.field.eventinstance.default.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: 2e81bf76-23e4-4fe2-8877-4eac3f1bad3b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventinstance.field_tags
+    - recurring_events.eventinstance_type.default
+    - taxonomy.vocabulary.categories
+id: eventinstance.default.field_tags
+field_name: field_tags
+entity_type: eventinstance
+bundle: default
+label: Tags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      categories: categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.eventseries.default.field_categories.yml
+++ b/config/sync/field.field.eventseries.default.field_categories.yml
@@ -1,0 +1,29 @@
+uuid: 4e10dab0-b170-4ec9-a55d-338d03a4d95c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventseries.field_categories
+    - recurring_events.eventseries_type.default
+    - taxonomy.vocabulary.categories
+id: eventseries.default.field_categories
+field_name: field_categories
+entity_type: eventseries
+bundle: default
+label: Categories
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      categories: categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.eventseries.default.field_tags.yml
+++ b/config/sync/field.field.eventseries.default.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: ed2b3cf7-f4d1-4167-94d0-50dbe95bdec4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventseries.field_tags
+    - recurring_events.eventseries_type.default
+    - taxonomy.vocabulary.tags
+id: eventseries.default.field_tags
+field_name: field_tags
+entity_type: eventseries
+bundle: default
+label: Tags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.article.field_categories.yml
+++ b/config/sync/field.field.node.article.field_categories.yml
@@ -1,0 +1,29 @@
+uuid: b7e901e0-5368-4092-ad15-3b52e5902503
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_categories
+    - node.type.article
+    - taxonomy.vocabulary.categories
+id: node.article.field_categories
+field_name: field_categories
+entity_type: node
+bundle: article
+label: Categories
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      categories: categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.article.field_tags.yml
+++ b/config/sync/field.field.node.article.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: 7517705a-3d86-45c1-a036-d1efb903ca3f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.article
+    - taxonomy.vocabulary.tags
+id: node.article.field_tags
+field_name: field_tags
+entity_type: node
+bundle: article
+label: Tags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.paragraph.card_grid_manual.field_grid_content.yml
+++ b/config/sync/field.field.paragraph.card_grid_manual.field_grid_content.yml
@@ -66,4 +66,7 @@ settings:
   user:
     handler: 'default:user'
     handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/config/sync/field.field.paragraph.content_slider.field_content_references.yml
+++ b/config/sync/field.field.paragraph.content_slider.field_content_references.yml
@@ -66,4 +66,7 @@ settings:
   user:
     handler: 'default:user'
     handler_settings: {  }
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings: {  }
 field_type: dynamic_entity_reference

--- a/config/sync/field.storage.eventinstance.field_categories.yml
+++ b/config/sync/field.storage.eventinstance.field_categories.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/field.storage.eventinstance.field_categories.yml
+++ b/config/sync/field.storage.eventinstance.field_categories.yml
@@ -1,0 +1,20 @@
+uuid: da47383d-eb2e-4943-8cf8-7f7919fa7def
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+    - taxonomy
+id: eventinstance.field_categories
+field_name: field_categories
+entity_type: eventinstance
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.eventinstance.field_tags.yml
+++ b/config/sync/field.storage.eventinstance.field_tags.yml
@@ -1,0 +1,20 @@
+uuid: a88eba08-fb9d-45b3-b770-020dfac9aaf8
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+    - taxonomy
+id: eventinstance.field_tags
+field_name: field_tags
+entity_type: eventinstance
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.eventseries.field_categories.yml
+++ b/config/sync/field.storage.eventseries.field_categories.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/field.storage.eventseries.field_categories.yml
+++ b/config/sync/field.storage.eventseries.field_categories.yml
@@ -1,0 +1,20 @@
+uuid: 1ea5e926-1b6f-4da1-9dc2-06b0a3310cb1
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+    - taxonomy
+id: eventseries.field_categories
+field_name: field_categories
+entity_type: eventseries
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.eventseries.field_tags.yml
+++ b/config/sync/field.storage.eventseries.field_tags.yml
@@ -1,0 +1,20 @@
+uuid: 918716d3-6683-4c08-be44-c9ca9600392e
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+    - taxonomy
+id: eventseries.field_tags
+field_name: field_tags
+entity_type: eventseries
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_categories.yml
+++ b/config/sync/field.storage.node.field_categories.yml
@@ -1,0 +1,20 @@
+uuid: 606b481a-f890-4c7d-90ca-4da2dacfb068
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_categories
+field_name: field_categories
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_tags.yml
+++ b/config/sync/field.storage.node.field_tags.yml
@@ -1,0 +1,20 @@
+uuid: f1c64683-d0d1-474e-9514-50396365f45d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_tags
+field_name: field_tags
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field_inheritance.field_inheritance.eventinstance_default_event_categories.yml
+++ b/config/sync/field_inheritance.field_inheritance.eventinstance_default_event_categories.yml
@@ -1,0 +1,14 @@
+uuid: 572336b9-66cf-4919-8d77-aac055afd6ea
+langcode: en
+status: true
+dependencies: {  }
+id: eventinstance_default_event_categories
+label: 'Event categories'
+type: fallback
+sourceEntityType: eventseries
+sourceEntityBundle: default
+sourceField: field_categories
+destinationEntityType: eventinstance
+destinationEntityBundle: default
+destinationField: field_categories
+plugin: entity_reference_inheritance

--- a/config/sync/field_inheritance.field_inheritance.eventinstance_default_event_tags.yml
+++ b/config/sync/field_inheritance.field_inheritance.eventinstance_default_event_tags.yml
@@ -1,0 +1,14 @@
+uuid: 9ec22a66-5c83-4616-a931-b4843559c7ac
+langcode: en
+status: true
+dependencies: {  }
+id: eventinstance_default_event_tags
+label: 'Event tags'
+type: fallback
+sourceEntityType: eventseries
+sourceEntityBundle: default
+sourceField: field_tags
+destinationEntityType: eventinstance
+destinationEntityBundle: default
+destinationField: field_tags
+plugin: entity_reference_inheritance

--- a/config/sync/language.content_settings.taxonomy_term.categories.yml
+++ b/config/sync/language.content_settings.taxonomy_term.categories.yml
@@ -1,0 +1,11 @@
+uuid: 6b95d1de-4ed2-413a-8acc-b4dfae14b83a
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.categories
+id: taxonomy_term.categories
+target_entity_type_id: taxonomy_term
+target_bundle: categories
+default_langcode: da
+language_alterable: false

--- a/config/sync/language.content_settings.taxonomy_term.tags.yml
+++ b/config/sync/language.content_settings.taxonomy_term.tags.yml
@@ -1,0 +1,11 @@
+uuid: 0b56acc2-af89-486e-936f-3e557a4ea03e
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags
+target_entity_type_id: taxonomy_term
+target_bundle: tags
+default_langcode: da
+language_alterable: false

--- a/config/sync/language/da/core.date_format.short.yml
+++ b/config/sync/language/da/core.date_format.short.yml
@@ -1,2 +1,1 @@
 label: 'Standard kort dato'
-pattern: 'm/d/Y - H:i'

--- a/config/sync/language/da/core.entity_view_mode.taxonomy_term.full.yml
+++ b/config/sync/language/da/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,0 +1,1 @@
+label: Termside

--- a/config/sync/language/da/system.action.taxonomy_term_publish_action.yml
+++ b/config/sync/language/da/system.action.taxonomy_term_publish_action.yml
@@ -1,0 +1,1 @@
+label: 'Publicér taksonomiterm'

--- a/config/sync/language/da/system.action.taxonomy_term_unpublish_action.yml
+++ b/config/sync/language/da/system.action.taxonomy_term_unpublish_action.yml
@@ -1,0 +1,1 @@
+label: 'Afpublicér taksonomiterm'

--- a/config/sync/language/da/views.view.files.yml
+++ b/config/sync/language/da/views.view.files.yml
@@ -26,6 +26,8 @@ display:
           label: Ændringsdato
         count:
           label: 'Brugt i'
+          alter:
+            path: 'admin/content/files/usage/{{ fid }}'
       pager:
         options:
           tags:

--- a/config/sync/language/da/views.view.taxonomy_term.yml
+++ b/config/sync/language/da/views.view.taxonomy_term.yml
@@ -1,0 +1,31 @@
+label: 'Ord i ordforråd'
+description: 'Indhold som er knyttet til en bestemt term.'
+display:
+  default:
+    display_title: Standard
+    display_options:
+      pager:
+        options:
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options_all_label: '- Alle -'
+            offset_label: Forskydning
+      exposed_form:
+        options:
+          submit_button: Udfør
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      arguments:
+        tid:
+          exception:
+            title: Alle
+          title: '{{ arguments.tid }}'
+  feed_1:
+    display_title: Feed
+  page_1:
+    display_title: Side

--- a/config/sync/language/da/views.view.user_admin_people.yml
+++ b/config/sync/language/da/views.view.user_admin_people.yml
@@ -19,6 +19,9 @@ display:
           label: Roller
         created:
           label: 'Medlem i'
+          settings:
+            future_format: '@interval'
+            past_format: '@interval'
         access:
           label: 'Seneste tilgang'
           settings:

--- a/config/sync/system.action.taxonomy_term_publish_action.yml
+++ b/config/sync/system.action.taxonomy_term_publish_action.yml
@@ -1,0 +1,13 @@
+uuid: 5b13b8a5-89fc-40ae-b5ca-3f13f8143df0
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: DoVt_VGgVLcDD4XmVbSFzr0K17SJy9imFiYusKkJBgY
+id: taxonomy_term_publish_action
+label: 'Publish taxonomy term'
+type: taxonomy_term
+plugin: 'entity:publish_action:taxonomy_term'
+configuration: {  }

--- a/config/sync/system.action.taxonomy_term_unpublish_action.yml
+++ b/config/sync/system.action.taxonomy_term_unpublish_action.yml
@@ -1,0 +1,13 @@
+uuid: 86663dc2-6f75-4b6a-b87d-039c0e495ced
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: z2sNRM3ECa7FPCGnSNje_9SmZJQgwhD_6fG_L4Mr8zI
+id: taxonomy_term_unpublish_action
+label: 'Unpublish taxonomy term'
+type: taxonomy_term
+plugin: 'entity:unpublish_action:taxonomy_term'
+configuration: {  }

--- a/config/sync/taxonomy.settings.yml
+++ b/config/sync/taxonomy.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: zKpaWT6cJc1tVQQaTqatGELaCqU_oyRym6zTl27Yias
+maintain_index_table: true
+override_selector: false
+terms_per_page_admin: 100

--- a/config/sync/taxonomy.vocabulary.categories.yml
+++ b/config/sync/taxonomy.vocabulary.categories.yml
@@ -1,0 +1,8 @@
+uuid: 6385cad1-f8f0-49b8-aaaa-37071747d8b3
+langcode: da
+status: true
+dependencies: {  }
+name: Categories
+vid: categories
+description: ''
+weight: 0

--- a/config/sync/taxonomy.vocabulary.tags.yml
+++ b/config/sync/taxonomy.vocabulary.tags.yml
@@ -1,0 +1,8 @@
+uuid: 32b05c42-513c-470f-95b4-c1518e6b91bb
+langcode: da
+status: true
+dependencies: {  }
+name: Tags
+vid: tags
+description: ''
+weight: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.image
     - node.type.article
     - node.type.campaign
+    - taxonomy.vocabulary.categories
   module:
     - block
     - dpl_instant_loan
@@ -23,6 +24,7 @@ dependencies:
     - openid_connect
     - recurring_events
     - system
+    - taxonomy
     - toolbar
     - update
 id: administrator
@@ -55,6 +57,7 @@ permissions:
   - 'create article content'
   - 'create campaign content'
   - 'create image media'
+  - 'create terms in categories'
   - 'delete any article content'
   - 'delete any campaign content'
   - 'delete any image media'
@@ -67,6 +70,7 @@ permissions:
   - 'delete own eventseries entity'
   - 'delete own files'
   - 'delete own image media'
+  - 'delete terms in categories'
   - 'edit any article content'
   - 'edit any campaign content'
   - 'edit any image media'
@@ -77,6 +81,7 @@ permissions:
   - 'edit own eventinstance entity'
   - 'edit own eventseries entity'
   - 'edit own image media'
+  - 'edit terms in categories'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'translate interface'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.image
     - node.type.article
     - node.type.campaign
+    - taxonomy.vocabulary.categories
   module:
     - file
     - filter
@@ -14,6 +15,7 @@ dependencies:
     - node
     - recurring_events
     - system
+    - taxonomy
     - toolbar
 id: editor
 label: Editor
@@ -30,6 +32,7 @@ permissions:
   - 'create article content'
   - 'create campaign content'
   - 'create image media'
+  - 'create terms in categories'
   - 'delete any article content'
   - 'delete any campaign content'
   - 'delete eventinstance entity'
@@ -40,6 +43,7 @@ permissions:
   - 'delete own eventseries entity'
   - 'delete own files'
   - 'delete own image media'
+  - 'delete terms in categories'
   - 'edit any article content'
   - 'edit any campaign content'
   - 'edit any image media'
@@ -50,6 +54,7 @@ permissions:
   - 'edit own eventinstance entity'
   - 'edit own eventseries entity'
   - 'edit own image media'
+  - 'edit terms in categories'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'use text format basic'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.image
     - node.type.article
     - node.type.campaign
+    - taxonomy.vocabulary.categories
   module:
     - dpl_instant_loan
     - dpl_library_agency
@@ -17,6 +18,7 @@ dependencies:
     - node
     - recurring_events
     - system
+    - taxonomy
     - toolbar
 id: local_administrator
 label: 'Local Administrator'
@@ -36,6 +38,7 @@ permissions:
   - 'create article content'
   - 'create campaign content'
   - 'create image media'
+  - 'create terms in categories'
   - 'delete any article content'
   - 'delete any campaign content'
   - 'delete any image media'
@@ -47,6 +50,7 @@ permissions:
   - 'delete own eventseries entity'
   - 'delete own files'
   - 'delete own image media'
+  - 'delete terms in categories'
   - 'edit any article content'
   - 'edit any campaign content'
   - 'edit any image media'
@@ -57,6 +61,7 @@ permissions:
   - 'edit own eventinstance entity'
   - 'edit own eventseries entity'
   - 'edit own image media'
+  - 'edit terms in categories'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'use text format basic'

--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -1,0 +1,319 @@
+uuid: 9b29782a-38f2-4315-a98f-ef2411a98425
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+  module:
+    - node
+    - taxonomy
+    - user
+_core:
+  default_config_hash: YKgw0f77GEmCu6_6Om9Mbig0mON9JdfVuMxTtd0WQaI
+id: taxonomy_term
+label: 'Taxonomy term'
+module: taxonomy
+description: 'Content belonging to a certain taxonomy term.'
+tag: default
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields: {  }
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: 0
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        sticky:
+          id: sticky
+          table: taxonomy_index
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: sticky
+          exposed: false
+        created:
+          id: created
+          table: taxonomy_index
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          default_action: 'not found'
+          exception:
+            value: ''
+            title_enable: false
+            title: All
+          title_enable: true
+          title: '{{ arguments.tid }}'
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:taxonomy_term'
+            fail: 'not found'
+          validate_options:
+            bundles: {  }
+            access: true
+            operation: view
+            multiple: 0
+          break_phrase: false
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+      filters:
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: taxonomy_index
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      link_display: page_1
+      link_url: ''
+      header:
+        entity_taxonomy_term:
+          id: entity_taxonomy_term
+          table: views
+          field: entity_taxonomy_term
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: entity
+          empty: true
+          target: '{{ raw_arguments.tid }}'
+          view_mode: full
+          tokenize: true
+          bypass_access: false
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  feed_1:
+    id: feed_1
+    display_title: Feed
+    display_plugin: feed
+    position: 2
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      style:
+        type: rss
+        options:
+          grouping: {  }
+          uses_fields: false
+          description: ''
+      row:
+        type: node_rss
+        options:
+          relationship: none
+          view_mode: default
+      query:
+        type: views_query
+        options: {  }
+      display_extenders: {  }
+      path: taxonomy/term/%/feed
+      displays:
+        page_1: page_1
+        default: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      query:
+        type: views_query
+        options: {  }
+      display_extenders: {  }
+      path: taxonomy/term/%
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,6 +13,8 @@ parameters:
     - '#_form_alter\(\) has parameter \$form with no value type specified in iterable type array\.#'
     # Drupal preprocess functions uses variables array which we cannot provide more detailed typing of.
     - '#Function .*_preprocess_.*\(\) has parameter \$variables with no value type specified in iterable type array\.#'
+    # Drupal theme suggestions uses arrays which we cannot provide more detailed typing of.
+    - '#Function .*_theme_suggestions_.*\(\) has parameter .* with no value type specified in iterable type array\.#'
     # Drupal hook_page_attachments functions uses page array which we cannot provide more detailed typing of.
     - '#Function .*_page_attachments\(\) has parameter \$page with no value type specified in iterable type array\.#'
     # Drupal hook_requirements() implementation returns array which we cannot provide more detailed typing of.

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -6,6 +6,7 @@ _meta:
   default_langcode: en
   depends:
     a3a4aa80-7380-4a87-aa02-a0ba240410ba: eventinstance
+    f457c4c2-dc28-45cd-9b6e-fda4248d9d45: taxonomy_term
     618e176a-a45a-4c36-a197-664230aa0a34: media
     dc33677f-8894-4717-b34b-d985f6ad875f: media
     65432ee1-43f1-4130-9565-5683467d4b5a: media
@@ -102,6 +103,9 @@ default:
   event_instances:
     -
       entity: a3a4aa80-7380-4a87-aa02-a0ba240410ba
+  field_categories:
+    -
+      entity: f457c4c2-dc28-45cd-9b6e-fda4248d9d45
   field_event_address:
     -
       langcode: en

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -10,6 +10,12 @@ _meta:
     618e176a-a45a-4c36-a197-664230aa0a34: media
     dc33677f-8894-4717-b34b-d985f6ad875f: media
     65432ee1-43f1-4130-9565-5683467d4b5a: media
+    1006441f-bb39-43b5-8c08-1a79344abf8b: taxonomy_term
+    53133c2e-1023-43a9-baf2-64a5081eea0f: taxonomy_term
+    190beb00-d5af-4c9a-be8d-65a646b37bbb: taxonomy_term
+    725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4: taxonomy_term
+    ec76c707-898d-4dfd-8cd2-e258aef1d6dd: taxonomy_term
+    0502836d-0f7b-4b21-9371-c40ae9e01495: taxonomy_term
 default:
   revision_uid:
     -
@@ -267,6 +273,19 @@ default:
   field_event_state:
     -
       value: Active
+  field_tags:
+    -
+      entity: 1006441f-bb39-43b5-8c08-1a79344abf8b
+    -
+      entity: 53133c2e-1023-43a9-baf2-64a5081eea0f
+    -
+      entity: 190beb00-d5af-4c9a-be8d-65a646b37bbb
+    -
+      entity: 725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4
+    -
+      entity: ec76c707-898d-4dfd-8cd2-e258aef1d6dd
+    -
+      entity: 0502836d-0f7b-4b21-9371-c40ae9e01495
   field_ticket_categories:
     -
       entity:

--- a/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
+++ b/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
@@ -5,6 +5,7 @@ _meta:
   bundle: article
   default_langcode: da
   depends:
+    92033694-15ac-4d9e-b275-ddfd18e48d9f: taxonomy_term
     aba3cea8-cee5-42c1-a152-e30c2ab135e2: media
     d97a25fd-a6ae-48b9-9a1a-7aec5372688e: media
     eef50571-39dc-461a-96ff-b6b7180ade61: media
@@ -41,6 +42,9 @@ default:
       attributes:
         name: title
         content: 'Jesper Stein vinder Læsernes Bogpris for Rampen | DPL CMS'
+  field_categories:
+    -
+      entity: 92033694-15ac-4d9e-b275-ddfd18e48d9f
   field_override_author:
     -
       value: 'Lene Kuhlmann Frandsen '

--- a/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
+++ b/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
@@ -11,6 +11,12 @@ _meta:
     eef50571-39dc-461a-96ff-b6b7180ade61: media
     dc33677f-8894-4717-b34b-d985f6ad875f: media
     f0204f0b-1f63-4c76-bb67-e3f7489ee392: media
+    1006441f-bb39-43b5-8c08-1a79344abf8b: taxonomy_term
+    53133c2e-1023-43a9-baf2-64a5081eea0f: taxonomy_term
+    190beb00-d5af-4c9a-be8d-65a646b37bbb: taxonomy_term
+    725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4: taxonomy_term
+    ec76c707-898d-4dfd-8cd2-e258aef1d6dd: taxonomy_term
+    0502836d-0f7b-4b21-9371-c40ae9e01495: taxonomy_term
 default:
   revision_uid:
     -
@@ -343,3 +349,16 @@ default:
   field_subtitle:
     -
       value: 'Jesper Stein har begået en hudløst ærlig og tankevækkende skildring af en skilsmisseramt familie. En selvbiografisk roman, som har ramt læserne  i hjertet.'
+  field_tags:
+    -
+      entity: 1006441f-bb39-43b5-8c08-1a79344abf8b
+    -
+      entity: 53133c2e-1023-43a9-baf2-64a5081eea0f
+    -
+      entity: 190beb00-d5af-4c9a-be8d-65a646b37bbb
+    -
+      entity: 725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4
+    -
+      entity: ec76c707-898d-4dfd-8cd2-e258aef1d6dd
+    -
+      entity: 0502836d-0f7b-4b21-9371-c40ae9e01495

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 0502836d-0f7b-4b21-9371-c40ae9e01495
+  bundle: tags
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: '3-8 årige'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: '3-8 årige | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/8'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 1006441f-bb39-43b5-8c08-1a79344abf8b
+  bundle: tags
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: dans
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'dans | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/3'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 190beb00-d5af-4c9a-be8d-65a646b37bbb
+  bundle: tags
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: modern
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'modern | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/5'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 53133c2e-1023-43a9-baf2-64a5081eea0f
+  bundle: tags
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: contemporary
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'contemporary | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/4'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4
+  bundle: tags
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: scenekunst
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'scenekunst | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/6'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 92033694-15ac-4d9e-b275-ddfd18e48d9f
+  bundle: categories
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: Netmedier
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Netmedier | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/2'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: ec76c707-898d-4dfd-8cd2-e258aef1d6dd
+  bundle: tags
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: digt
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'digt | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/7'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
@@ -1,0 +1,33 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: f457c4c2-dc28-45cd-9b6e-fda4248d9d45
+  bundle: categories
+  default_langcode: da
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: 'Design & Teknologi'
+  weight:
+    -
+      value: 0
+  parent:
+    -
+      target_id: 0
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Design & Teknologi | DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dapple-cms.docker/taxonomy/term/1'

--- a/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
@@ -42,3 +42,4 @@ default_content:
   taxonomy_term:
     # Category used by eventseries 1
     - f457c4c2-dc28-45cd-9b6e-fda4248d9d45
+    - 92033694-15ac-4d9e-b275-ddfd18e48d9f

--- a/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
@@ -43,3 +43,9 @@ default_content:
     # Category used by eventseries 1
     - f457c4c2-dc28-45cd-9b6e-fda4248d9d45
     - 92033694-15ac-4d9e-b275-ddfd18e48d9f
+    - 1006441f-bb39-43b5-8c08-1a79344abf8b
+    - 53133c2e-1023-43a9-baf2-64a5081eea0f
+    - 190beb00-d5af-4c9a-be8d-65a646b37bbb
+    - 725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4
+    - ec76c707-898d-4dfd-8cd2-e258aef1d6dd
+    - 0502836d-0f7b-4b21-9371-c40ae9e01495

--- a/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
@@ -39,3 +39,6 @@ default_content:
     - 6d5e9b4c-389d-4735-a8a3-82883f64aeb0
     # PDF used in article 1 and eventseries 1
     - 3403d0ba-cbdc-425d-93f4-6cdabb5378b1
+  taxonomy_term:
+    # Category used by eventseries 1
+    - f457c4c2-dc28-45cd-9b6e-fda4248d9d45

--- a/web/themes/custom/novel/novel.libraries.yml
+++ b/web/themes/custom/novel/novel.libraries.yml
@@ -29,3 +29,7 @@ swiper:
     theme:
       "https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css":
         { type: external }
+
+show-more:
+  js:
+    assets/dpl-design-system/js/show-more.js: {}

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -227,3 +227,18 @@ function novel_attach_identity_color_styles(array &$variables, Hsl $hslColor): v
     'novel_custom_identity_color',
   ];
 }
+
+/**
+ * Implements hook_theme_suggestions_field_alter().
+ */
+function novel_theme_suggestions_field_alter(array &$suggestions, array $variables) : void {
+  $element = $variables['element'];
+
+  // Add theme suggestions per view mode...
+  $suggestions[] = 'field__' . $element['#entity_type'] . '__' .
+    $element['#field_name'] . '__' . $element['#view_mode'];
+  // ... per bundle and view mode.
+  $suggestions[] = 'field__' . $element['#entity_type'] . '__' .
+    $element['#field_name'] . '__' . $element['#bundle'] . '__' .
+    $element['#view_mode'];
+}

--- a/web/themes/custom/novel/templates/components/full-event.html.twig
+++ b/web/themes/custom/novel/templates/components/full-event.html.twig
@@ -26,7 +26,9 @@
     <div class="event-description__content">
       <div class="event-description__description">{{ description }}</div>
       <div class="event-description__links">
-        <!-- horizontal-term-line -->
+        {% if tags.0 %}
+            {{ tags }}
+        {% endif %}
       </div>
     </div>
     <dl class="list-description event-description__info list-description--event">

--- a/web/themes/custom/novel/templates/components/full-event.html.twig
+++ b/web/themes/custom/novel/templates/components/full-event.html.twig
@@ -1,14 +1,14 @@
 <article {{ attributes.addClass('event-page') }}>
   <header class="event-header">
     <section class="event-header__content">
-      <!-- Tag -->
-
+      <div class="event-header__tags">
+        {{ categories }}
+      </div>
       {% if date %}
         <time class="event-header__date">
           {{ date }}
         </time>
       {% endif %}
-
       <h1 class="event-header__title">{{ label }}</h1>
       {{ event_link }}
     </section>

--- a/web/themes/custom/novel/templates/components/horizontal-term-line.html.twig
+++ b/web/themes/custom/novel/templates/components/horizontal-term-line.html.twig
@@ -1,0 +1,12 @@
+{% set heading = heading|default('h3') %}
+
+<div class="text-small-caption horizontal-term-line">
+  <{{ heading }} class="text-label-bold">
+    {{ title }}
+  </{{ heading }}>
+  {% for item in items %}
+    <span>
+      {{ item.content }}
+    </span>
+  {% endfor %}
+</div>

--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories--full.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories--full.html.twig
@@ -1,0 +1,4 @@
+{% for item in items %}
+  {% set item = item|merge({'attributes': item.attributes.addClass('tag--large')}) %}
+{% endfor %}
+{{ include('field--field-categories.html.twig') }}

--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories--list-teaser.html.twig
@@ -1,0 +1,3 @@
+{% include 'field--field-categories.html.twig' with {
+  item_attributes: create_attribute().addClass('event-list-item__tag')
+} %}

--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories--list-teaser.html.twig
@@ -1,4 +1,4 @@
 {% for item in items %}
-  {% set item = item|merge({'attributes': item.attributes.addClass('event-list-item__tag')}) %}
+  {% set item = item|merge({'attributes': item.attributes.addClass('tag--small').addClass('event-list-item__tag')}) %}
 {% endfor %}
 {% include 'field--field-categories.html.twig' %}

--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories--list-teaser.html.twig
@@ -1,3 +1,4 @@
-{% include 'field--field-categories.html.twig' with {
-  item_attributes: create_attribute().addClass('event-list-item__tag')
-} %}
+{% for item in items %}
+  {% set item = item|merge({'attributes': item.attributes.addClass('event-list-item__tag')}) %}
+{% endfor %}
+{% include 'field--field-categories.html.twig' %}

--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories.html.twig
@@ -1,2 +1,0 @@
-{# Reuse event field template #}
-{{ include('field--field-categories.html.twig') }}

--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-categories.html.twig
@@ -1,0 +1,2 @@
+{# Reuse event field template #}
+{{ include('field--field-categories.html.twig') }}

--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-tags.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-tags.html.twig
@@ -1,0 +1,2 @@
+{# Reuse event field template #}
+{{ include('field--field-tags.html.twig') }}

--- a/web/themes/custom/novel/templates/fields/field--eventseries--field-categories--full.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventseries--field-categories--full.html.twig
@@ -1,0 +1,4 @@
+{% for item in items %}
+  {% set item = item|merge({'attributes': item.attributes.addClass('tag--large')}) %}
+{% endfor %}
+{{ include('field--field-categories.html.twig') }}

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -2,7 +2,7 @@
 {% set show_more_text = '...'|t %}
 {% set show_less_text = 'Show less'|t %}
 
-{% set item_attributes = item_attributes ?? create_attribute() %}
+{% set item_attributes = item_attributes|default(create_attribute()) %}
 {% set item_classes = [
     'tag',
     'tag--fill',

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -1,0 +1,22 @@
+{{ attach_library('novel/show-more') }}
+{% set show_more_text = '...'|t %}
+{% set show_less_text = 'Show less'|t %}
+
+{% if items|length > 1 %}
+    <ul data-show-more-list>
+        {% for item in items %}
+            <li data-show-more-item class="tag tag--fill tag--small">
+                {{ item.content|raw }}
+            </li>
+        {% endfor %}
+      <button class="tag tag--fill tag--small cursor-pointer" aria-expanded="false" data-show-more-button data-show-more-text="{{ show_more_text }}" data-show-less-text="{{ show_less_text }}">
+          {{ show_more_text }}
+      </button>
+    </ul>
+{% else %}
+    {% for item in items %}
+        <span class="tag tag--fill tag--small">
+            {{ item.content|raw }}
+        </span>
+    {% endfor %}
+{% endif %}

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -2,10 +2,17 @@
 {% set show_more_text = '...'|t %}
 {% set show_less_text = 'Show less'|t %}
 
+{% set item_attributes = item_attributes ?? create_attribute() %}
+{% set item_classes = [
+    'tag',
+    'tag--fill',
+    'tag--small'
+  ] %}
+
 {% if items|length > 1 %}
     <ul data-show-more-list>
         {% for item in items %}
-            <li data-show-more-item class="tag tag--fill tag--small">
+            <li{{ item_attributes.setAttribute("data-show-more-item", true).addClass(item_classes) }}>
                 {{ item.content|raw }}
             </li>
         {% endfor %}
@@ -15,7 +22,7 @@
     </ul>
 {% else %}
     {% for item in items %}
-        <span class="tag tag--fill tag--small">
+        <span{{ item_attributes.addClass(item_classes) }}>
             {{ item.content|raw }}
         </span>
     {% endfor %}

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -5,7 +5,6 @@
 {% set item_classes = [
     'tag',
     'tag--fill',
-    'tag--small'
   ] %}
 
 {% if items|length > 1 %}

--- a/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-categories.html.twig
@@ -2,7 +2,6 @@
 {% set show_more_text = '...'|t %}
 {% set show_less_text = 'Show less'|t %}
 
-{% set item_attributes = item_attributes|default(create_attribute()) %}
 {% set item_classes = [
     'tag',
     'tag--fill',
@@ -12,7 +11,7 @@
 {% if items|length > 1 %}
     <ul data-show-more-list>
         {% for item in items %}
-            <li{{ item_attributes.setAttribute("data-show-more-item", true).addClass(item_classes) }}>
+            <li{{ item.attributes.setAttribute("data-show-more-item", true).addClass(item_classes) }}>
                 {{ item.content|raw }}
             </li>
         {% endfor %}
@@ -22,7 +21,7 @@
     </ul>
 {% else %}
     {% for item in items %}
-        <span{{ item_attributes.addClass(item_classes) }}>
+        <span{{ item.attributes.addClass(item_classes) }}>
             {{ item.content|raw }}
         </span>
     {% endfor %}

--- a/web/themes/custom/novel/templates/fields/field--field-tags.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-tags.html.twig
@@ -1,0 +1,10 @@
+<div class="text-small-caption horizontal-term-line">
+  <h2 class="text-label-bold">
+    {{ "Tags"|trans({}, {"context": "Tags"}) }}
+  </h2>
+  {% for item in items %}
+    <span>
+      {{ item.content }}
+    </span>
+  {% endfor %}
+</div>

--- a/web/themes/custom/novel/templates/fields/field--node--field-categories--full.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-categories--full.html.twig
@@ -1,0 +1,4 @@
+{% for item in items %}
+  {% set item = item|merge({'attributes': item.attributes.addClass('tag--large')}) %}
+{% endfor %}
+{% include 'field--field-categories.html.twig' %}

--- a/web/themes/custom/novel/templates/fields/field--node--field-tags--article--full.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-tags--article--full.html.twig
@@ -1,4 +1,5 @@
 {% include '@novel/components/horizontal-term-line.html.twig' with {
   'title': "Tags"|trans({}, {"context": "Tags"}),
+  'heading': "h2",
   'items': items,
 } only %}

--- a/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
@@ -30,5 +30,5 @@
   'date': content.date,
   'description': content.event_description,
   'description_items': description_items,
-  'categories': content.field_categories,
+  'categories': content.event_categories,
 } only %}

--- a/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
@@ -31,4 +31,5 @@
   'description': content.event_description,
   'description_items': description_items,
   'categories': content.event_categories,
+  'tags': content.event_tags,
 } only %}

--- a/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
@@ -29,5 +29,6 @@
   'paragraphs': content.event_paragraphs,
   'date': content.date,
   'description': content.event_description,
-  'description_items': description_items
+  'description_items': description_items,
+  'categories': content.field_categories,
 } only %}

--- a/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
@@ -7,6 +7,7 @@
   set instancelike_content = {
     "date": formatted_date,
     "event_address": content.field_event_address,
+    "event_categories": content.field_categories,
     "event_description": content.field_event_description,
     "event_image": content.field_event_image,
     "event_link": content.field_event_link,

--- a/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
@@ -14,7 +14,8 @@
     "event_paragraphs": content.field_event_paragraphs,
     "event_place": content.field_event_place,
     "event_state": content.field_event_state,
-    "event_ticket_categories": content.field_ticket_categories
+    "event_ticket_categories": content.field_ticket_categories,
+    "event_tags": content.field_tags,
   }
 %}
 {% include '@novel/layout/eventinstance--full.html.twig' with {

--- a/web/themes/custom/novel/templates/layout/node--article--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--article--full.html.twig
@@ -16,6 +16,11 @@
                 {{ node.created.value|format_date('date_full_month') }}
             </time>
         </p>
+        {% if (content.field_tags.0) %}
+          <div class="article_header--tags">
+            {{ content.field_tags }}
+          </div>
+        {% endif %}
     </header>
 
     {{ content.field_paragraphs }}

--- a/web/themes/custom/novel/templates/layout/node--article--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--article--full.html.twig
@@ -1,5 +1,10 @@
 <article class="article">
     <header class="article-header">
+        {% if (content.field_categories.0) %}
+          <div class="article-header__categories">
+            {{ content.field_categories }}
+          </div>
+        {% endif %}
         <h1 class="article-header__title">{{ label }}</h1>
 
         {{ content.field_subtitle }}

--- a/web/themes/custom/novel/templates/views/eventinstance--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/views/eventinstance--list-teaser.html.twig
@@ -5,7 +5,7 @@
     {% endif %}
   </div>
   <div class="event-list-item__content">
-    <div class="tag tag--fill cursor-pointer tag--small event-list-item__tag">foredrag</div>
+    {{ content.event_categories }}
     <div class="event-list-item__date">
       {{ content.date }}
     </div>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-130

#### Description

This PR adds two new taxonomies: Categories and tags, adds these to articles event series and instances with field inheritance setup between the two.

As this is in place we can now render categories for these. This PR adds it for articles, event series, instances and on the list page.

To make this easier to demo an category term is added to the example content.

This replaces #662 and depends on https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/452.

#### Screenshot of the result

Article

![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/6e35b396-2094-4ff3-9cf6-6b24a52f8a16)

Event Instance

![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/c010dd8f-7a8c-468a-a32b-dc4aee82923b)

Series

![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/dd9b6bc6-72cd-4faf-b5fe-cebd58b2c599)

List

![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/6f5c7742-4c46-45fd-b999-0bd8e308412d)

Term editing

![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/76394b75-f6ff-4180-8578-56251bac372d)


Event field

![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/86ae0b03-e747-4932-8e22-cecaf1feaaff)



#### Additional comments or questions
