### PR TITLE
Remove Add Event link from events list

### DIFF
--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -41,6 +41,22 @@ function dpl_admin_local_tasks_alter(array &$local_tasks): void {
 }
 
 /**
+ * Implements hook_menu_local_actions_alter().
+ *
+ * Remove all tasks appearing on /events.
+ *
+ * @param array<mixed> $local_actions
+ *   See the $form in hook_local_actions_alter().
+ */
+function dpl_admin_menu_local_actions_alter(&$local_actions) : void {
+  array_walk($local_actions, function (array &$action) {
+    $action['appears_on'] = array_filter($action['appears_on'], function (string $route) {
+      return $route !== 'entity.eventinstance.collection';
+    });
+  });
+}
+
+/**
  * Implements template_preprocess_views_view_field().
  *
  * Preprocesses the output of a field in the "event_admin" view.


### PR DESCRIPTION
#### Description

We use the /events path for our events list. The same path is also
used by the recurring_events module with the
entity.eventinstance.collection route. Consequently we remove any
action which recurring event or other modules configure to appear
here.

See cms/web/modules/contrib/recurring_events/recurring_events.routing.yml

#### Screenshot of the result

Before:

<img width="1840" alt="Monosnap Events | DPL CMS 2024-01-19 21-16-19" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/ddb8b73b-1236-4f27-84d3-ded572b34950">
