### PR TITLE
Patch Dynamic Entity Reference module to clarify field category

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -229,6 +229,9 @@
             "drupal/default_content": {
                 "3200212: Overwrite files on import": "https://git.drupalcode.org/project/default_content/-/merge_requests/8.patch"
             },
+            "drupal/dynamic_entity_reference": {
+                "3405253: Update the FieldType category for clarity": "https://git.drupalcode.org/project/dynamic_entity_reference/-/commit/3f048d296f671906d15b0cdfbbadbea38f5f3c8b.patch"
+            },
             "drupal/field_inheritance": {
                 "3330386: field_inheritance_form_alter should enforce module permissions": "https://git.drupalcode.org/project/field_inheritance/-/commit/bc3d26cdce8c09d5b6275fc126e35bc7e239c7d1.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c44e7c8ccd6e5ca0cecde66bb3e4452e",
+    "content-hash": "9e4375d80c9c627613d7c989cff24f69",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
#### Description

Current the Dynamic Entity Reference module uses the "reference" category. This causes confusion as other fields normally use the "Reference" category. If the Dynamic Entity Reference field is chosen by accident this can cause problems. One example is that this field type is not supported by Field Inheritance.

Patch the module so this does not happen.

The patch has already been merged into the 3.x branch but not released so we should be able to drop the patch once the next version is released.
https://www.drupal.org/node/3405253

#### Screenshot of the result

Before:

<img width="822" alt="Monosnap Monosnap 2024-01-19 21-39-01" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/981d5245-dc6e-4a63-95ca-134029ab0c48">

After:

<img width="995" alt="Monosnap Add field | DPL CMS | Logged in 2024-01-19 21-34-37" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/aef30e4a-a355-46d4-baed-26914cc6362a">

#### Additional comments or questions

This is what caused the problems you experienced @kasperbirch1 .