### PR TITLE
Optimize github action ressource usage.

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,9 +1,16 @@
 # These workflows takes care of various CI tests.
-on: pull_request
 name: CI Tests
+
+on: pull_request
 env:
   PHP_VERSION: 8.1
   COMPOSER_VERSION: v2
+
+# Detect if this action is already running, and cancel it.
+# This most likely happened because a second push has been made to a branch.
+concurrency:
+  group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ValidateComposer:
@@ -105,6 +112,12 @@ jobs:
 
   LightHouse:
     name: Test site performance using Lighthouse
+
+    # Don't run action if the pull request is a draft.
+    # This is an expensive job to run, so we only want to run it when the
+    # PR is actually ready to be reviewed.
+    if: ${{ github.event.pull_request.draft == false }}
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -128,6 +141,12 @@ jobs:
 
   Pa11y:
     name: Test accessibility using Pa11y
+
+    # Don't run action if the pull request is a draft.
+    # This is an expensive job to run, so we only want to run it when the
+    # PR is actually ready to be reviewed.
+    if: ${{ github.event.pull_request.draft == false }}
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -152,6 +171,12 @@ jobs:
 
   Cypress:
     name: Run Cypress functional tests
+
+    # Don't run action if the pull request is a draft.
+    # This is an expensive job to run, so we only want to run it when the
+    # PR is actually ready to be reviewed.
+    if: ${{ github.event.pull_request.draft == false }}
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -238,6 +263,12 @@ jobs:
 
   CheckOpenApiSpec:
     name: Check OpenAPI specification
+
+    # Don't run action if the pull request is a draft.
+    # This is an expensive job to run, so we only want to run it when the
+    # PR is actually ready to be reviewed.
+    if: ${{ github.event.pull_request.draft == false }}
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -260,6 +291,12 @@ jobs:
 
   CheckDrupalConfig:
     name: Check Drupal Config
+
+    # Don't run action if the pull request is a draft.
+    # This is an expensive job to run, so we only want to run it when the
+    # PR is actually ready to be reviewed.
+    if: ${{ github.event.pull_request.draft == false }}
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -1,3 +1,5 @@
+name: Lagoon integration
+
 on:
   pull_request:
     # We have two groups of jobs in this workflow that reacts on actions:
@@ -10,7 +12,12 @@ on:
     #
     # 2. We forward all events to lagoon via InformLagoon
     types: [ opened, synchronize, reopened, closed, edited ]
-name: Lagoon integration
+
+# Detect if this action is already running, and cancel it.
+# This most likely happened because a second push has been made to a branch.
+concurrency:
+  group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   LAGOON_HOST: "dplplat01.dpl.reload.dk"

--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -2,6 +2,13 @@
 name: Publish source
 on:
   create
+
+# Detect if this action is already running, and cancel it.
+# This most likely happened because a second push has been made to a branch.
+concurrency:
+  group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/translate-source.yml
+++ b/.github/workflows/translate-source.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - develop
 
+# Detect if this action is already running, and cancel it.
+# This most likely happened because a second push has been made to a branch.
+concurrency:
+  group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   SendToPoeditor:


### PR DESCRIPTION
- Only run the most ressource heavy jobs on non-draft PRs. Stuff like Chromatic deployment only makes sense once the pull request has actually been marked as ready for review, as other times, you might push several times to the branch
- Add a concurrency checker for all jobs, cancelling on-going jobs if a new push to the same branch has been detected.
