### PR TITLE
Use `.paragraphs__item` instead of `.paragraph`

### DIFF
--- a/web/themes/custom/novel/templates/fields/field--field-paragraphs.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-paragraphs.html.twig
@@ -1,6 +1,6 @@
 <section class="paragraphs">
   {% for item in items %}
-    <div class="paragraph paragraph--{{ item.content['#paragraph'].bundle() }}">
+    <div class="paragraphs__item paragraphs__item--{{ item.content['#paragraph'].bundle() }}">
       {{ item.content }}
     </div>
   {% endfor %}


### PR DESCRIPTION
.. to avoid that we style on a class name that Drupal might use in situations we are not interested in.


Requires https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/441 to be merged.