### PR TITLE
Replace Reviewdog with CS2PR

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,16 +35,15 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ env.PHP_VERSION }}
-        tools: composer:${{ env.COMPOSER_VERSION }}
+        tools: composer:${{ env.COMPOSER_VERSION }}, cs2pr
         coverage: none
         extensions: gd
     - name: Install Dependencies
       run: |
         composer install --no-interaction --no-progress
-    - name: Run phpcs
-      uses: reload/action-phpcs@main
-      with:
-        reviewdog_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run Twig CS Fixer
+      run: |
+        vendor/bin/phpcs -q --report=checkstyle | cs2pr
 
   TwigCsFixer:
     name: Check Twig code style

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -21,6 +21,8 @@ class FeesListSettingsForm extends ConfigFormBase {
    *   The factory for configuration objects.
    * @param \Drupal\dpl_react\DplReactConfigInterface $configService
    *   The instant loan config service.
+   * @param \Drupal\dpl_fees\DplFeesSettings $feesSettings
+   *   The DPL fee settings.
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,

--- a/web/modules/custom/dpl_library_agency/src/Form/ListSizeSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/ListSizeSettingsForm.php
@@ -57,17 +57,9 @@ class ListSizeSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state): array {
-    return parent::buildForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     parent::submitForm($form, $form_state);
     $this->config($this->configService->getConfigKey())->save();
   }
 
 }
-


### PR DESCRIPTION
#### Description

Reviewdog will filter checkstyle results based one files changed in a pull request and modify the return code and thus success/failure of a run accordingly. This can cause problems e.g. if errors occur many lines of code away from a specific change. Such errors will pop op locally where we do not used Reviewdog. This causes causing frustration for the next developer.

To avoid this we drop Reviewdog entirely. Instead we use the CS2PR tool to convert checkstyle results from PHPCS to GitHub pull request annotations.

As the tool is only relevant in GitHub Actions we only install it there by adding it as a tool in setup-php-action.

This is the same approach as suggested by setup-php-action: https://github.com/marketplace/actions/setup-php-action#tools-with-checkstyle-support

#### Screenshot of the result

After this change errors checks fail and current errors are reported:

![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/597fb441-fd57-452c-85b9-6075c9a2e86d)

[99ae723](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/677/commits/99ae7238d848419630220e3603c70cb4e89957a6) fixes the issues.