### PR TITLE
Allow self-signed certificates when checking Lagoon environments

### DIFF
--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -41,11 +41,15 @@ jobs:
           ref: ${{ github.head_ref }}
           logs: ${{ steps.environment.outputs.logs }}
           debug: ${{ runner.debug && 'true' || 'false' }}
+      - name: Generate wait-on config
+        # Retrieval of Let's Encrypt certificate sometimes fail in Lagoon.
+        # In this case a self-signed certificate will be used. Allow this.
+        run: |
+          echo "{\"strictSSL\": false}" > $RUNNER_TEMP/wait-on.config.json
       - name: Wait for environment to become available
-        uses: nev7n/wait_for_response@v1
+        uses: iFaxity/wait-on-action@v1.1.0
         with:
-          url: ${{ steps.environment.outputs.url }}
-          responseCode: 200
+          resource: ${{ steps.environment.outputs.url }}
           # Time in ms. Wait for 15 mins for deployment to complete. We have
           # seen deployments taking up to 12 mins.
           timeout: 600000
@@ -54,6 +58,7 @@ jobs:
           # is not complete. Reduce polling interval to the risk of this
           # happening.
           interval: 10000
+          config: ${{ runner.temp }}/wait-on.config.json
       - name: Finish deployment
         if: always()
         uses: bobheadxi/deployments@v1.4.0


### PR DESCRIPTION
#### Link to issue

This is a temporary fix for https://reload.atlassian.net/browse/DDFDRIFT-31

#### Description

Replace nev7n/wait_for_response with iFaxity/wait-on-action. This
action supports disabling strict SSL. This way our check will pass
even if Lagoon has not (yet) deployed a proper Let's Encrypt
certificate.

Users will still get a warning in their browsers but that is
preferable to GitHub Action checks randomly failing.

Dropping the action is not helpful as this helps us understand if the
resulting environment is broken and e.gf. returns error code 500 for
some reason.

wait-on-action configuration is very close to wait_for_response.
It does support setting a response code but that should not matter
for us.

To disable strict SSL check we have to provide a config file. To keep
things contained we create this as a part of the workflow.

#### Additional comments or questions

To see that this is working check out the environment for this PR.