### PR TITLE
Correct Variable Name for Ticket Price in 'Event'

### DIFF
--- a/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
@@ -6,7 +6,7 @@
   },
   {
     label: "Price"|trans,
-    value: content.ticket_categories.0 ? content.ticket_categories : null
+    value: content.event_ticket_categories.0 ? content.event_ticket_categories : null
   },
   {
     label: "Place"|trans,


### PR DESCRIPTION
#### Description


The variable for the ticket price in the 'event' was incorrectly named. This pull request corrects the variable name to `event_ticket_categories` in the `eventinstance--full.html.twig' file`

<img width="288" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/e7d25d84-1ae0-4436-afc5-0c2fc86824c5">
