### PR TITLE
Add fee-list-already-paid-second-info-text to FeeListBlock

### DIFF
--- a/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
+++ b/web/modules/custom/dpl_fees/src/Plugin/Block/FeesListBlock.php
@@ -73,6 +73,7 @@ class FeesListBlock extends BlockBase implements ContainerFactoryPluginInterface
       'fee-details-modal-description-text' => $this->t("Modal containing information about this element or group of elements fees", [], ['context' => 'Fees list']),
       'fee-details-modal-screen-reader-text' => $this->t("A modal containing details about a fee", [], ['context' => 'Fees list']),
       'fee-list-already-paid-info-text' => $this->t("Already paid? It can take up to 72 hours register the transaction.", [], ['context' => 'Fees list']),
+      'fee-list-already-paid-second-info-text' => $this->t("Already paid? It can take up to 72 hours register the transaction. (not payable by user)", [], ['context' => 'Fees list']),
       'fee-list-body-text' => $this->feesSettings->getFeeListBodyText(),
       'fee-list-days-text' => $this->t("Days", [], ['context' => 'Fees list']),
       'fee-list-headline-text' => $this->t("Fees & replacement costs", [], ['context' => 'Fees list']),


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-387

#### Description
Adding texts added in [THIS PR](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/889)
#### Screenshot of the result
-
#### Additional comments or questions
-