### PR TITLE
Add task that enables us to set openid settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 COMPOSE_PROJECT_NAME=dpl-cms
 COMPOSER_MEMORY_LIMIT=-1
+#OPENID_CLIENT_ID=some-client-id
+#OPENID_CLIENT_SECRET=some-client-secret
+#OPENID_AGENCY_ID=some-agency-id

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -172,6 +172,17 @@ tasks:
       # Show a one-time login to the local site.
       - task dev:cli -- drush user-login
 
+  dev:openid:configure:
+    desc: Set openid connect settings based on .env variables. And run cron.
+    cmds:
+      - task dev:cli -- ./dev-scripts/cli-set-openid-settings.sh
+      - task dev:run-cron
+
+  dev:run-cron:
+    desc: Run cron in the container
+    cmds:
+      - task dev:cli -- drush cron
+
   dev:enable-dev-tools:
     desc: Enable dev modules and settings, which are not to be used in Prod. They are config-ignored
     cmds:

--- a/dev-scripts/cli-set-openid-settings.sh
+++ b/dev-scripts/cli-set-openid-settings.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -aeo pipefail; source .env; set +a
+
+# Check if all environment variables are defined
+if [[ -z $OPENID_CLIENT_ID ]]; then
+  echo "Error: OPENID_CLIENT_ID is missing!"
+  exit 1
+fi
+if [[ -z $OPENID_CLIENT_SECRET ]]; then
+  echo "Error: OPENID_CLIENT_SECRET is missing!"
+  exit 1
+fi
+if [[ -z $OPENID_AGENCY_ID ]]; then
+  echo "Error: OPENID_AGENCY_ID is missing!"
+  exit 1
+fi
+
+
+# Define the mapping of environment variables to keys
+declare -A mapping=(
+  ["OPENID_CLIENT_ID"]="client_id"
+  ["OPENID_CLIENT_SECRET"]="client_secret"
+  ["OPENID_AGENCY_ID"]="agency_id"
+)
+
+# Iterate over the mapping and execute the command
+for key in "${!mapping[@]}"; do
+  value="${mapping[$key]}"
+  command="drush cset -y openid_connect.settings.adgangsplatformen settings.$value ${!key}"
+  eval "$command"
+done


### PR DESCRIPTION
Add task that enables us to set openid settings (and runs cron)
In that way we do not have to do the tedious repeated configuration in the admin area every time we spin up a new version of the site locally.

It depends on variables set in .env file. See .env.example to see what is needed.

