### PR TITLE
DDFLSBP-417 - Updated Library Token retriever function to be able to …

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,7 +10,7 @@ parameters:
     # Drupal Form API makes extensive use for arrays which we cannot provide
     # more detailed typing of.
     - '#.*\:\:(buildForm|getEditableConfigNames|submitForm|validateForm)\(\) .* no value type specified in iterable type array\.#'
-    - '#_form_alter\(\) has parameter \$form with no value type specified in iterable type array\.#'
+    - '#_alter\(\) has parameter \$form with no value type specified in iterable type array\.#'
     # Drupal preprocess functions uses variables array which we cannot provide more detailed typing of.
     - '#Function .*_preprocess_.*\(\) has parameter \$variables with no value type specified in iterable type array\.#'
     # Drupal hook_page_attachments functions uses page array which we cannot provide more detailed typing of.

--- a/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
@@ -72,15 +72,20 @@ class LibraryTokenHandler {
   /**
    * Retrieve token from external service and save it.
    */
-  public function retrieveAndStoreToken(): void {
-    // If no token stored.
-    if (!$this->getToken()) {
-      // Then try to fetch one.
-      if ($token = $this->fectchToken()) {
-        // And store it.
-        $this->setToken($token);
-      }
+  public function retrieveAndStoreToken(bool $force = FALSE): null|bool {
+    // If force is False and if token is already stored.
+    if (!$force && $this->getToken()) {
+      return NULL;
     }
+
+    // Try to fetch token, if not possible return false.
+    if (!$token = $this->fetchToken()) {
+      return FALSE;
+    }
+
+    // Otherwise set token.
+    $this->setToken($token);
+    return TRUE;
   }
 
   /**
@@ -116,7 +121,7 @@ class LibraryTokenHandler {
    * @return \Drupal\dpl_library_token\LibraryToken|null
    *   If token was fetched it is returned. Otherwise NULL.
    */
-  public function fectchToken(): ?LibraryToken {
+  public function fetchToken(): ?LibraryToken {
     $token = NULL;
 
     try {

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -211,9 +211,8 @@ function dpl_login_openid_connect_admin_settings_submit(array &$form, FormStateI
   if ($form_state->getValue('agency_id') != $agency_id) {
     /** @var Drupal\dpl_library_token\LibraryTokenHandler $handler */
     $handler = Drupal::service('dpl_library_token.handler');
-    $result = $handler->retrieveAndStoreToken(TRUE);
 
-    if ($result === FALSE) {
+    if (!$handler->retrieveAndStoreToken(TRUE)) {
       $messenger->addMessage(t('Unable to retrieve token from Adgangsplatformen. Please check if the provided Agency ID is correct.', [], ['context' => 'openId connect settings']), 'error');
     }
   }

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -10,6 +10,7 @@
 use DanskernesDigitaleBibliotek\FBS\ApiException;
 use DanskernesDigitaleBibliotek\FBS\Model\BlockStatus;
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\dpl_fbs\Patron\BlockedReason;
@@ -177,5 +178,43 @@ function dpl_login_dpl_react_apps_data(array &$data, array &$variables): void {
 function dpl_login_preprocess_html(array &$variables): void {
   if (\Drupal::currentUser()->isAuthenticated()) {
     $variables['head_title'][] = t('Logged in', [], ['context' => 'dpl_login']);
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function dpl_login_form_openid_connect_admin_settings_alter(array &$form, FormStateInterface $form_state): void {
+
+  $form['#submit'][] = 'dpl_login_openid_connect_admin_settings_submit';
+}
+
+/**
+ * Custom submit handler for openid_connect_admin_settings form.
+ *
+ * @param array<mixed> $form
+ *   An associative array containing the structure of the form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ *
+ * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
+ */
+function dpl_login_openid_connect_admin_settings_submit(array &$form, FormStateInterface $form_state): void {
+  $messenger = \Drupal::messenger();
+
+  /** @var \Drupal\dpl_login\Adgangsplatformen\Config $adgangsplatformen_config */
+  $adgangsplatformen_config = \Drupal::service('dpl_login.adgangsplatformen.config');
+  $agency_id = $adgangsplatformen_config->getAgencyId();
+
+  // If agency_id is different from the already stored, we want to
+  // force a new token to be created that belongs to the new agency.
+  if ($form_state->getValue('agency_id') != $agency_id) {
+    /** @var Drupal\dpl_library_token\LibraryTokenHandler $handler */
+    $handler = Drupal::service('dpl_library_token.handler');
+    $result = $handler->retrieveAndStoreToken(TRUE);
+
+    if ($result === FALSE) {
+      $messenger->addMessage(t('Unable to retrieve token from Adgangsplatformen. Please check if the provided Agency ID is correct.', [], ['context' => 'openId connect settings']), 'error');
+    }
   }
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-417

#### Description

This PR adds the possibility to do a "Force" retrieval of Library tokens.  This way we do not have to wait for the old token to expire before setting the new one using the new settings in OpenID Connect configuration.

This is helpful when you want to switch between different Library Agencies. This is especially helpful when debugging locally or when the client wants to do testing on demo environments. 

The PR adds hook_form_FORM_ID_alter and a custom submit handler for openid_connect_admin_settings form. The submit handler will now do a "Force" retrieval of a new token whenever a new Agency ID value is set.
