### PR TITLE
Feature/ddflspb 418/update branches when changing agency

### DIFF
--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -98,7 +98,7 @@ class GeneralSettingsForm extends ConfigFormBase {
 
     try {
       $branches = $this->branchRepository->getBranches();
-      // Sort branches by ID/ISIL number. This order should mimick the expected
+      // Sort branches by ID/ISIL number. This order should mimic the expected
       // order of the branches used elsewhere by library staff.
       usort($branches, function (Branch $a, Branch $b) {
         return strcmp($a->id, $b->id);

--- a/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
@@ -83,7 +83,7 @@ class LibraryTokenHandler {
       return FALSE;
     }
 
-    // Otherwise set token.
+    // Set token.
     $this->setToken($token);
     return TRUE;
   }
@@ -98,7 +98,7 @@ class LibraryTokenHandler {
     // Set token and expire time to half the given one.
     // In that way we are sure that the token is always valid.
     $this->tokenCollection
-      ->setWithExpireIfNotExists(
+      ->setWithExpire(
         self::LIBRARY_TOKEN_KEY,
         $token->token,
         (int) round($token->expire / 2)

--- a/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
+++ b/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
@@ -20,7 +20,6 @@ use Drupal\dpl_library_token\LibraryTokenHandler;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\KeyValueStore\KeyValueStoreExpirableInterface;
 use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
-use Drupal\dpl_library_token\Exception\MissingConfigurationException;
 use function Safe\json_encode as json_encode;
 
 /**
@@ -31,7 +30,7 @@ class LibraryTokenHandlerTest extends UnitTestCase {
   /**
    * Test behaviour when no token has been stored yet.
    */
-  public function testIfNoTokenHasBeenStoredaNewOneIsFetched(): void {
+  public function testIfNoTokenHasBeenStoredANewOneIsFetched(): void {
     $collection = $this->prophesize(KeyValueStoreExpirableInterface::class);
     // Simulate that we don't have any token in data store.
     $collection
@@ -39,7 +38,7 @@ class LibraryTokenHandlerTest extends UnitTestCase {
       ->willReturn(NULL)
       ->shouldBeCalledTimes(1);
     // After a request to external service we expect the new token to be set.
-    $collection->setWithExpireIfNotExists(
+    $collection->setWithExpire(
         LibraryTokenHandler::LIBRARY_TOKEN_KEY,
         Argument::cetera()
       )

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -203,12 +203,11 @@ function dpl_login_openid_connect_admin_settings_validate(array &$form, FormStat
 
   /** @var \Drupal\dpl_login\Adgangsplatformen\Config $adgangsplatformen_config */
   $adgangsplatformen_config = \Drupal::service('dpl_login.adgangsplatformen.config');
-  $agency_id = $adgangsplatformen_config->getAgencyId();
-  $values = $form_state->getValues();
+  $stored_agency_id = $adgangsplatformen_config->getAgencyId();
 
   // If agency_id is different from the already stored, we want to
   // force a new token to be created that belongs to the new agency.
-  if ($values['clients']['adgangsplatformen']['settings']['agency_id'] != $agency_id) {
+  if ($form_state->getValue('clients')['adgangsplatformen']['settings']['agency_id'] != $stored_agency_id) {
     /** @var Drupal\dpl_library_token\LibraryTokenHandler $handler */
     $handler = Drupal::service('dpl_library_token.handler');
 

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -185,12 +185,11 @@ function dpl_login_preprocess_html(array &$variables): void {
  * Implements hook_form_FORM_ID_alter().
  */
 function dpl_login_form_openid_connect_admin_settings_alter(array &$form, FormStateInterface $form_state): void {
-
-  $form['#submit'][] = 'dpl_login_openid_connect_admin_settings_submit';
+  $form['#validate'][] = 'dpl_login_openid_connect_admin_settings_validate';
 }
 
 /**
- * Custom submit handler for openid_connect_admin_settings form.
+ * Custom validate handler for openid_connect_admin_settings form.
  *
  * @param array<mixed> $form
  *   An associative array containing the structure of the form.
@@ -199,21 +198,22 @@ function dpl_login_form_openid_connect_admin_settings_alter(array &$form, FormSt
  *
  * @throws \Drupal\dpl_login\Exception\MissingConfigurationException
  */
-function dpl_login_openid_connect_admin_settings_submit(array &$form, FormStateInterface $form_state): void {
+function dpl_login_openid_connect_admin_settings_validate(array &$form, FormStateInterface $form_state): void {
   $messenger = \Drupal::messenger();
 
   /** @var \Drupal\dpl_login\Adgangsplatformen\Config $adgangsplatformen_config */
   $adgangsplatformen_config = \Drupal::service('dpl_login.adgangsplatformen.config');
   $agency_id = $adgangsplatformen_config->getAgencyId();
+  $values = $form_state->getValues();
 
   // If agency_id is different from the already stored, we want to
   // force a new token to be created that belongs to the new agency.
-  if ($form_state->getValue('agency_id') != $agency_id) {
+  if ($values['clients']['adgangsplatformen']['settings']['agency_id'] != $agency_id) {
     /** @var Drupal\dpl_library_token\LibraryTokenHandler $handler */
     $handler = Drupal::service('dpl_library_token.handler');
 
     if (!$handler->retrieveAndStoreToken(TRUE)) {
-      $messenger->addMessage(t('Unable to retrieve token from Adgangsplatformen. Please check if the provided Agency ID is correct.', [], ['context' => 'openId connect settings']), 'error');
+      $messenger->addMessage(t('Unable to retrieve token from Adgangsplatformen. Please check if the provided Agency ID is correct.', [], ['context' => 'OpenId Connect Settings']), 'error');
     }
   }
 }

--- a/web/modules/custom/dpl_login/src/Plugin/OpenIDConnectClient/Adgangsplatformen.php
+++ b/web/modules/custom/dpl_login/src/Plugin/OpenIDConnectClient/Adgangsplatformen.php
@@ -41,7 +41,7 @@ class Adgangsplatformen extends OpenIDConnectClientBase {
    *   Drupal form state.
    *
    * @return mixed[]
-   *   Drupla form array.
+   *   Drupal form array.
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildConfigurationForm($form, $form_state);

--- a/web/modules/custom/dpl_login/src/Plugin/OpenIDConnectClient/Adgangsplatformen.php
+++ b/web/modules/custom/dpl_login/src/Plugin/OpenIDConnectClient/Adgangsplatformen.php
@@ -68,7 +68,8 @@ class Adgangsplatformen extends OpenIDConnectClientBase {
     ];
     $form['agency_id'] = [
       '#title' => $this->t('Agency ID', [], ['context' => 'Dpl Login']),
-      '#type' => 'textfield',
+      '#type' => 'number',
+      '#min' => 0,
       '#default_value' => $this->configuration['agency_id'],
     ];
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-418

#### Description

This PR changes the way we set Library Tokens. The main problem why the branches did not update when fetching a new Library Token, was that we actually did not fetch a new Library Token as we were using the function `setWithExpireIfNotExists`.

1. Instead of using `setWithExpireIfNotExists` we now use `setWithExpire`. This is done as we are already checking if a token is set elsewhere earlier in the flow, so we will only get to here if we want to bypass the token checker and force fetch a new token.

2. Instead of using a custom submit hook, we are now using a custom validate hook to check if the Agency ID provided on form_save is different to the already saved on. This way we avoid fetching a new Token unnecessary. 
