### PR TITLE
Change the hardcoded text beneath the clock to "Opening Hours" [DDFLSBP-421] 

### DIFF
--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -59,8 +59,7 @@
         </div>
         <div class="header__clock-items">
             <img loading="lazy" width="58" height="58" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" class="mb-8" alt="clock icon"/>
-            <span class="text-small-caption">Onsdag</span>
-            <span class="text-small-caption">7 februar</span>
+            <span class="text-small-caption">Åbningstider</span>
         </div>
     </div>
 </header>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-421

#### Description

Changes the hardcoded text beneath the clock to "Opening Hours" instead of a date

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/105956/8fba5dd7-d725-40a7-8923-aa6d0c5d34c6)

#### Additional comments or questions

*