### PR TITLE
Move 'Blocked user link for modal' setting from 'General settings' to 'Fees settings' [DDFLSBP-372] 

### DIFF
--- a/web/modules/custom/dpl_fees/src/DplFeesSettings.php
+++ b/web/modules/custom/dpl_fees/src/DplFeesSettings.php
@@ -14,6 +14,7 @@ class DplFeesSettings extends DplReactConfigBase {
   const PAYMENT_SITE_BUTTON_LABEL = '';
   const FEES_LIST_SIZE_DESKTOP = 25;
   const FEES_LIST_SIZE_MOBILE = 25;
+  const BLOCKED_PATRON_E_LINK_URL = '';
 
   use StringTranslationTrait;
 
@@ -120,6 +121,39 @@ class DplFeesSettings extends DplReactConfigBase {
       "pageSizeMobile" => $this->getListSizeMobile(),
       "paymentSiteButtonLabel" => $this->getFeeListPaymentSiteButtonLabel(),
     ];
+  }
+
+  /**
+   * Get urls for blocked patrons.
+   *
+   * @param string|null $name
+   *   The name of the url to get.
+   *
+   * @return string|mixed[]|null
+   *   String if one url is asked for or null if not found.
+   *   If no name is provided then all available urls.
+   */
+  protected function getBlockedPatronUrls($name = NULL): string|array|null {
+    $urls = [
+      'blocked-patron-e-link' => $this->loadConfig()->get('blocked_patron_e_link_url') ?? self::BLOCKED_PATRON_E_LINK_URL,
+    ];
+
+    if ($name) {
+      return $urls[$name] ?? NULL;
+    }
+
+    return $urls;
+  }
+
+  /**
+   * Get url for the blocked patron of type E.
+   *
+   * @return string
+   *   The url.
+   */
+  public function getBlockedPatronElinkUrl(): string {
+    $url = $this->getBlockedPatronUrls('blocked-patron-e-link');
+    return is_string($url) ? $url : '';
   }
 
 }

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -142,7 +142,7 @@ class FeesListSettingsForm extends ConfigFormBase {
       ],
       '#default_value' => $config->get('blocked_patron_e_link_url') ?? GeneralSettings::BLOCKED_PATRON_E_LINK_URL,
     ];
-    
+
     return parent::buildForm($form, $form_state);
   }
 

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -140,7 +140,7 @@ class FeesListSettingsForm extends ConfigFormBase {
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',
       ],
-      '#default_value' => $config->get('blocked_patron_e_link_url') ?? GeneralSettings::BLOCKED_PATRON_E_LINK_URL,
+      '#default_value' => $config->get('blocked_patron_e_link_url') ?? DplFeesSettings::BLOCKED_PATRON_E_LINK_URL,
     ];
 
     return parent::buildForm($form, $form_state);

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -6,7 +6,6 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\dpl_fees\DplFeesSettings;
-use Drupal\dpl_library_agency\GeneralSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\dpl_fees\DplFeesSettings;
+use Drupal\dpl_library_agency\GeneralSettings;
 use Drupal\dpl_react\DplReactConfigInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -120,6 +121,28 @@ class FeesListSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('payment_site_button_label'),
     ];
 
+    $form['settings']['blocked_user'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Blocked user', [], ['context' => 'Library Agency Configuration']),
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $form['settings']['blocked_user']['blocked_patron_e_link_url'] = [
+      '#type' => 'linkit',
+      '#title' => $this->t('Blocked user link for modal', [], ['context' => 'Library Agency Configuration']),
+      '#description' => $this->t('If a user is blocked because of fees a modal appears. This field makes it possible to place a link in the modal to e.g. payment options or help page. <br>
+                                         If left empty, the link will not be shown. <br>
+                                         You can add a relative url (e.g. /takster). <br>
+                                         You can search for an internal url. <br>
+                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Library Agency Configuration']),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
+      '#default_value' => $config->get('blocked_patron_e_link_url') ?? GeneralSettings::BLOCKED_PATRON_E_LINK_URL,
+    ];
+    
     return parent::buildForm($form, $form_state);
   }
 
@@ -134,6 +157,7 @@ class FeesListSettingsForm extends ConfigFormBase {
       ->set('payment_site_url', $form_state->getValue('payment_site_url'))
       ->set('payment_site_button_label', $form_state->getValue('payment_site_button_label'))
       ->set('fee_list_body_text', $form_state->getValue('fee_list_body_text'))
+      ->set('blocked_patron_e_link_url', $form_state->getValue('blocked_patron_e_link_url'))
       ->save();
   }
 

--- a/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
+++ b/web/modules/custom/dpl_fees/src/Form/FeesListSettingsForm.php
@@ -122,19 +122,19 @@ class FeesListSettingsForm extends ConfigFormBase {
 
     $form['settings']['blocked_user'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Blocked user', [], ['context' => 'Library Agency Configuration']),
+      '#title' => $this->t('Blocked user', [], ['context' => 'Fees list settings form']),
       '#collapsible' => FALSE,
       '#collapsed' => FALSE,
     ];
 
     $form['settings']['blocked_user']['blocked_patron_e_link_url'] = [
       '#type' => 'linkit',
-      '#title' => $this->t('Blocked user link for modal', [], ['context' => 'Library Agency Configuration']),
+      '#title' => $this->t('Blocked user link for modal', [], ['context' => 'Fees list settings form']),
       '#description' => $this->t('If a user is blocked because of fees a modal appears. This field makes it possible to place a link in the modal to e.g. payment options or help page. <br>
                                          If left empty, the link will not be shown. <br>
                                          You can add a relative url (e.g. /takster). <br>
                                          You can search for an internal url. <br>
-                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Library Agency Configuration']),
+                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Fees list settings form']),
       '#autocomplete_route_name' => 'linkit.autocomplete',
       '#autocomplete_route_parameters' => [
         'linkit_profile_id' => 'default',

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -185,28 +185,6 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('pause_reservation_info_url') ?? GeneralSettings::PAUSE_RESERVATION_INFO_URL,
     ];
 
-    $form['settings']['blocked_user'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t('Blocked user', [], ['context' => 'Library Agency Configuration']),
-      '#collapsible' => FALSE,
-      '#collapsed' => FALSE,
-    ];
-
-    $form['settings']['blocked_user']['blocked_patron_e_link_url'] = [
-      '#type' => 'linkit',
-      '#title' => $this->t('Blocked user link for modal', [], ['context' => 'Library Agency Configuration']),
-      '#description' => $this->t('If a user is blocked because of fees a modal appears. This field makes it possible to place a link in the modal to e.g. payment options or help page. <br>
-                                         If left empty, the link will not be shown. <br>
-                                         You can add a relative url (e.g. /takster). <br>
-                                         You can search for an internal url. <br>
-                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Library Agency Configuration']),
-      '#autocomplete_route_name' => 'linkit.autocomplete',
-      '#autocomplete_route_parameters' => [
-        'linkit_profile_id' => 'default',
-      ],
-      '#default_value' => $config->get('blocked_patron_e_link_url') ?? GeneralSettings::BLOCKED_PATRON_E_LINK_URL,
-    ];
-
     $form['expiration_warning'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Expiration warning', [], ['context' => 'Library Agency Configuration']),
@@ -341,7 +319,6 @@ class GeneralSettingsForm extends ConfigFormBase {
       ->set('default_interest_period_config', $form_state->getValue('default_interest_period_config'))
       ->set('reservation_sms_notifications_enabled', $form_state->getValue('reservation_sms_notifications_enabled'))
       ->set('pause_reservation_info_url', $form_state->getValue('pause_reservation_info_url'))
-      ->set('blocked_patron_e_link_url', $form_state->getValue('blocked_patron_e_link_url'))
       ->set('ereolen_my_page_url', $form_state->getValue('ereolen_my_page_url'))
       ->set('ereolen_homepage_url', $form_state->getValue('ereolen_homepage_url'))
       ->set('fbi_profiles', [

--- a/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
@@ -18,7 +18,6 @@ class GeneralSettings extends DplReactConfigBase {
   ];
   const RESERVATION_SMS_NOTIFICATIONS_ENABLED = TRUE;
   const PAUSE_RESERVATION_INFO_URL = '';
-  const BLOCKED_PATRON_E_LINK_URL = '';
   // We define these urls so that the admins don't have to - e-reolen urls is
   // not expected to be changing often.
   const EREOLEN_MY_PAGE_URL = 'https://ereolen.dk/user/me';
@@ -151,39 +150,6 @@ class GeneralSettings extends DplReactConfigBase {
     return [
       'allowRemoveReadyReservations' => $allow_remove_ready_reservations,
     ];
-  }
-
-  /**
-   * Get urls for blocked patrons.
-   *
-   * @param string|null $name
-   *   The name of the url to get.
-   *
-   * @return string|mixed[]|null
-   *   String if one url is asked for or null if not found.
-   *   If no name is provided then all available urls.
-   */
-  protected function getBlockedPatronUrls($name = NULL): string|array|null {
-    $urls = [
-      'blocked-patron-e-link' => $this->loadConfig()->get('blocked_patron_e_link_url') ?? self::BLOCKED_PATRON_E_LINK_URL,
-    ];
-
-    if ($name) {
-      return $urls[$name] ?? NULL;
-    }
-
-    return $urls;
-  }
-
-  /**
-   * Get url for the blocked patron of type E.
-   *
-   * @return string
-   *   The url.
-   */
-  public function getBlockedPatronElinkUrl(): string {
-    $url = $this->getBlockedPatronUrls('blocked-patron-e-link');
-    return is_string($url) ? $url : '';
   }
 
 }

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -376,9 +376,9 @@ function dpl_react_apps_dpl_react_apps_data(array &$data, array &$variables): vo
     $fees_settings->getViewFeesAndCompensationRatesUrl(),
   ];
 
-  if (!empty($general_settings->getBlockedPatronElinkUrl())) {
+  if (!empty($fees_settings->getBlockedPatronElinkUrl())) {
     $data['urls'] += [
-      'blocked-patron-e-link' => $general_settings->getBlockedPatronElinkUrl(),
+      'blocked-patron-e-link' => $fees_settings->getBlockedPatronElinkUrl(),
     ];
   }
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-372

#### Description

This PR moves the "Blocked user link for modal" setting from the "General settings" section to the "Fees settings" section.

#### Screenshot of the result

<img width="729" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/105956/a284fc8b-150a-421b-9392-3c5501e26062">

#### Additional comments or questions

*