### PR TITLE
Create 'limited' WYSIWYG format, and use it for event description.

### DIFF
--- a/config/sync/editor.editor.limited.yml
+++ b/config/sync/editor.editor.limited.yml
@@ -1,0 +1,29 @@
+uuid: e3829ca4-c54b-4614-86de-f81e0d842834
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.limited
+  module:
+    - ckeditor5
+format: limited
+editor: ckeditor5
+settings:
+  toolbar:
+    items:
+      - bold
+      - italic
+      - specialCharacters
+      - link
+      - '|'
+      - undo
+      - redo
+      - removeFormat
+      - sourceEditing
+  plugins:
+    ckeditor5_sourceEditing:
+      allowed_tags: {  }
+    linkit_extension:
+      linkit_enabled: true
+      linkit_profile: default
+image_upload: {  }

--- a/config/sync/field.field.eventseries.default.field_event_description.yml
+++ b/config/sync/field.field.eventseries.default.field_event_description.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.eventseries.field_event_description
+    - filter.format.limited
     - recurring_events.eventseries_type.default
   module:
     - text
@@ -18,5 +19,6 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  allowed_formats: {  }
+  allowed_formats:
+    - limited
 field_type: text_long

--- a/config/sync/filter.format.limited.yml
+++ b/config/sync/filter.format.limited.yml
@@ -1,0 +1,17 @@
+uuid: 1b54df0f-7a46-4915-962d-a3de1170944e
+langcode: en
+status: true
+dependencies: {  }
+name: Limited
+format: limited
+weight: 0
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<br> <p> <strong> <em> <a href data-entity-type data-entity-uuid data-entity-substitution>'
+      filter_html_help: true
+      filter_html_nofollow: false

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - filter.format.basic
+    - filter.format.limited
     - media.type.image
     - node.type.article
     - node.type.campaign
@@ -86,6 +87,7 @@ permissions:
   - 'revert all eventseries revisions'
   - 'translate interface'
   - 'use text format basic'
+  - 'use text format limited'
   - 'view all eventinstance revisions'
   - 'view all eventseries revisions'
   - 'view own unpublished content'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - filter.format.basic
+    - filter.format.limited
     - media.type.image
     - node.type.article
     - node.type.campaign
@@ -58,6 +59,7 @@ permissions:
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'use text format basic'
+  - 'use text format limited'
   - 'view all eventinstance revisions'
   - 'view all eventseries revisions'
   - 'view own unpublished content'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - filter.format.basic
+    - filter.format.limited
     - media.type.image
     - node.type.article
     - node.type.campaign
@@ -65,6 +66,7 @@ permissions:
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'use text format basic'
+  - 'use text format limited'
   - 'view all eventinstance revisions'
   - 'view all eventseries revisions'
   - 'view own unpublished content'

--- a/config/sync/user.role.mediator.yml
+++ b/config/sync/user.role.mediator.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - filter.format.basic
+    - filter.format.limited
     - media.type.image
     - node.type.article
     - node.type.campaign
@@ -53,6 +54,7 @@ permissions:
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'use text format basic'
+  - 'use text format limited'
   - 'view all eventinstance revisions'
   - 'view all eventseries revisions'
   - 'view own unpublished content'

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -122,7 +122,7 @@ default:
   field_event_description:
     -
       value: '<p>Foreningen for Integreret Moderne Dans arbejder med at udvide normalitetsbegrebet i scenekunsten. For hvad er normalt? Rosenreglen og Mødrenes hus. I 2022 udgav hun også den stærkt politiske digtsamling Jeg vil have en statsminister.</p>'
-      format: basic
+      format: limited
   field_event_image:
     -
       entity: 618e176a-a45a-4c36-a197-664230aa0a34


### PR DESCRIPTION
Some times, we want to have WYSIWYG fields for basic formatting, such as bold, links etc., but not advanced stuff like lists, tables and headings.
This adds a simplified WYSIWYG format, and adds it to the even description, as requested by the client.

DDFFORM-227

https://reload.atlassian.net/browse/DDFFORM-227