### PR TITLE
Set event reccurance as 'custom' by default. DDFFORM-217

### DIFF
--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -107,6 +107,11 @@ function dpl_admin_preprocess_views_view_field(array &$variables): void {
 function _dpl_admin_form_alter_eventseries(array &$form, FormStateInterface $form_state, string $form_id): void {
   $keys = ['weekly_recurring_date', 'monthly_recurring_date', 'yearly_recurring_date', 'daily_recurring_date'];
 
+  // Set the reccurance type to 'custom' by default, if nothing else is set.
+  if (isset($form['recur_type']['widget']['#default_value']) && empty($form['recur_type']['widget']['#default_value'])) {
+    $form['recur_type']['widget']['#default_value'] = 'custom';
+  }
+
   foreach ($keys as $key) {
     $form_element_date_start = $form[$key]['widget'][0]['value'] ?? NULL;
     $form_element_date_end = $form[$key]['widget'][0]['end_value'] ?? NULL;

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -8,7 +8,6 @@
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\dpl_event\EventState;
 use Drupal\file\Entity\File;
@@ -118,20 +117,6 @@ function dpl_event_set_occurred_callback(JobSchedule $job): void {
   if (dpl_event_eventinstance_is_active($event)) {
     $event->set("field_event_state", EventState::Occurred);
     $event->save();
-  }
-}
-
-/**
- * Implements hook_form_node_event_form_alter().
- */
-function dpl_event_form_node_event_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
-  // Use the generic "Access" value as the default for the first ticket
-  // category when creating events.
-  if (isset($form["field_ticket_categories"]["widget"][0]["subform"]["field_ticket_category_name"]["widget"][0]["value"])) {
-    $form["field_ticket_categories"]["widget"][0]["subform"]["field_ticket_category_name"]["widget"][0]["value"]["#default_value"] = t('Access', [], ['context' => 'dpl_event']);
-  }
-  else {
-    throw new DomainException("Unable to locate name field for first ticket category. Cannot set default value.");
   }
 }
 


### PR DESCRIPTION
- Set event reccurance as 'custom' by default. DDFFORM-217
- Remove unused hook, left over after node => eventseries reformatting.

------

https://reload.atlassian.net/browse/DDFFORM-217