### PR TITLE
Add new due date label for digital materials [DDFLSBP-337]

### DIFF
--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -127,6 +127,7 @@ function dpl_react_apps_texts(): array {
     'group-modal-due-date-header' => t('Due date @date', [], ['context' => 'Global']),
     'group-modal-due-date-link-to-page-with-fees' => t("Read more about fees", [], ['context' => 'Global']),
     'group-modal-due-date-material' => t("Due date @date", [], ['context' => 'Global']),
+    'group-modal-due-date-digital-material' => t("Expires @date", [], ['context' => 'Global']),
     'group-modal-due-date-renew-loan-close-modal-aria-label' => t('Close renew loans modal', [], ['context' => 'Global']),
     'group-modal-due-date-warning-loan-overdue' => t('The due date of return is exceeded, therefore you will be charged a fee, when the item is returned', [], ['context' => 'Global']),
     'group-modal-go-to-material' => t("Go to material details", [], ['context' => 'Global']),


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-337

#### Description

* Changes the status badge text from "To be returned" to "Expires" in the Group modal if the material is digital.
* `dpl-react` PR: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/925

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/92b9e43b-8db0-49a6-a130-0653a2494245)

#### Additional comments or questions

*

