### PR TITLE
Add loan list skeleton page

### DIFF
--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -98,6 +98,19 @@ function novel_preprocess_dpl_react_app__search_result(array &$variables): void 
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ *
+ * @param mixed[] $variables
+ *   The variables for the theme hook.
+ */
+function novel_preprocess_dpl_react_app__loan_list(array &$variables): void {
+  $variables += [
+    'number_of_fake_loan_items_list_physical' => 2,
+    'number_of_fake_loan_items_list_digital' => 2,
+  ];
+}
+
+/**
  * Implements hook_preprocess_HOOK()
  *
  * Add the base icon path to the variables array.

--- a/web/themes/custom/novel/templates/components/skeleton-screens/loan-list-skeleton-item.html.twig
+++ b/web/themes/custom/novel/templates/components/skeleton-screens/loan-list-skeleton-item.html.twig
@@ -1,0 +1,21 @@
+  <div class="list-reservation my-32">
+    <div class="list-reservation__material">
+      <div><div class="ssc-square cover--size-small"></div></div>
+      <div class="list-reservation__information">
+        <div class="ssc-head-line w-30 mb-24"></div>
+        <div class="ssc-head-line w-100 mb-4"></div>
+        <div class="ssc-line w-70 mb-4"></div>
+        <div class="ssc-line w-60 mb-4"></div>
+      </div>
+    </div>
+    <div class="list-reservation__status">
+      <div class="list-reservation__counter">
+        <div class="ssc-circle w-100"></div>
+      </div>
+      <div class="list-reservation__deadline">
+        <div class="ssc-head-line w-30 mb-4"></div>
+        <div class="ssc-line w-20 mb-4"></div>
+        <div class="ssc-line w-20 mb-4"></div>
+      </div>
+    </div>
+  </div>

--- a/web/themes/custom/novel/templates/dpl-react-app--loan-list.html.twig
+++ b/web/themes/custom/novel/templates/dpl-react-app--loan-list.html.twig
@@ -1,0 +1,13 @@
+<div {{ attributes }}>
+<section class="loan-list-page ssc">
+  <div class="ssc-head-line w-60 mx-32 my-48"></div>
+  <div class="ssc-head-line w-10 mx-32 mt-64 mb-35"></div>
+  {% for i in 1..number_of_fake_loan_items_list_physical %}
+    {% include '@novel/components/skeleton-screens/loan-list-skeleton-item.html.twig' %}
+  {% endfor %}
+  <div class="ssc-head-line w-10 mx-32 mt-80"></div>
+  {% for i in 1..number_of_fake_loan_items_list_digital %}
+    {% include '@novel/components/skeleton-screens/loan-list-skeleton-item.html.twig' %}
+  {% endfor %}
+</section>
+</div>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-431

#### Description

Adds loan list skeleton page
For the initial skeleton rendering of the loan list page

#### Screenshot
There is skeleton design missing so the status circles look weird. And dpl-react skeleton is not kicking in because that has not been merged either. So... we can get a better impression when the other PR's have been merged as well. Let's keep this on hold until then...

![loan_skeleton](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/998889/d1f77f54-e977-41a0-b7a2-0de7cb6e4c0c)

