### PR TITLE
DDFFORM 109

### DIFF
--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.links.menu.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.links.menu.yml
@@ -9,6 +9,7 @@ dpl_library_agency.general_settings_form:
   description: "Administer various settings for a library agency."
   route_name: dpl_library_agency.general_settings
   parent: dpl_library_agency.settings
+  weight: -999
 
 dpl_library_agency.list_size_settings_form:
   title: "List Size Settings"

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.links.menu.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.links.menu.yml
@@ -2,7 +2,7 @@ dpl_library_agency.settings:
   title: "Library Agency"
   route_name: dpl_library_agency.settings
   parent: system.admin_config
-  weight: 0
+  weight: -1000
 
 dpl_library_agency.general_settings_form:
   title: "General Settings"

--- a/web/modules/custom/dpl_patron_redirect/dpl_patron_redirect.links.menu.yml
+++ b/web/modules/custom/dpl_patron_redirect/dpl_patron_redirect.links.menu.yml
@@ -2,4 +2,4 @@ dpl_patron_redirect.settings_form:
   title: "Patron redirect settings"
   route_name: dpl_patron_redirect.settings
   description: "Set auth redirect paths for patrons"
-  parent: user.admin_index
+  parent: dpl_library_agency.settings

--- a/web/modules/custom/dpl_patron_reg/dpl_patron_reg.links.menu.yml
+++ b/web/modules/custom/dpl_patron_reg/dpl_patron_reg.links.menu.yml
@@ -2,4 +2,4 @@ dpl_patron_reg.settings_form:
   title: "Patron registration"
   route_name: dpl_patron_reg.settings
   description: "Change patron registration settings"
-  parent: user.admin_index
+  parent: dpl_library_agency.settings

--- a/web/modules/custom/dpl_url_proxy/dpl_url_proxy.links.menu.yml
+++ b/web/modules/custom/dpl_url_proxy/dpl_url_proxy.links.menu.yml
@@ -2,4 +2,4 @@ dpl_url_proxy.admin_settings:
   title: "Url proxy settings"
   description: "Configure the host names and replacement patterns for proxy urls."
   route_name: dpl_url_proxy.configure
-  parent: "system.admin_config_services"
+  parent: dpl_library_agency.settings


### PR DESCRIPTION
- Place library settings at the top for configuration.
- Move url proxy settings into library settings.
- Move patron redirect settings to library settings.
- Move patron registration settings to library settings.
- Move general settings to the top of library settings.

#### Link to issue
[DDFFORM-109](https://reload.atlassian.net/browse/DDFFORM-109)


#### Description

This PR rearranges certain placement of settings in the backend for administrators. 
See the ticket for info. 

Feel free to comment if you think that certain settings should be changed further. 
