### PR TITLE
DDFFORM 228

### DIFF
--- a/web/modules/custom/dpl_admin/dpl_admin.links.menu.yml
+++ b/web/modules/custom/dpl_admin/dpl_admin.links.menu.yml
@@ -1,0 +1,29 @@
+dpl_admin.add_content:
+  title: "Add content"
+  parent: system.admin_content
+  route_name: node.add_page
+  weight: 5
+
+dpl_admin.add_content_article:
+  title: "Add article"
+  parent: dpl_admin.add_content
+  route_name: node.add
+  route_parameters:
+    node_type: "article"
+  weight: 1
+
+dpl_admin.add_content_campaign:
+  title: "Add campaign"
+  parent: dpl_admin.add_content
+  route_name: node.add
+  route_parameters:
+    node_type: "campaign"
+  weight: 2
+
+dpl_admin.add_content_page:
+  title: "Add page"
+  parent: dpl_admin.add_content
+  route_name: node.add
+  route_parameters:
+    node_type: "page"
+  weight: 3


### PR DESCRIPTION

- Add menu links for adding content types in content menu.

#### Link to issue

[Jira link](https://reload.atlassian.net/browse/DDFFORM-228)

#### Description

This PR adds a menu link for "add content", with a sub menu for adding an article, campaign and page. 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/a9e09fa7-a65a-4754-8fa9-922fdfd1a274)
