### PR TITLE
Version number on cms source images

### DIFF
--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -30,7 +30,9 @@ jobs:
       uses: arduino/setup-task@v1
       if: ${{ steps.detect_tag.outputs.IS_RELEASE_TAG == 'true' }}
     - name: Build and publish source
-      run: task source:deploy
+      run: |
+        echo "Publishing tag: $RELEASE_TAG"
+        RELEASE_IMAGE_TAG=$RELEASE_TAG task source:deploy
       if: ${{ steps.detect_tag.outputs.IS_RELEASE_TAG == 'true' }}
       env:
         CR_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -1,39 +1,38 @@
 # This workflow takes care of building and publishing the source code of the Danish Public Libraries CMS.
 name: Publish source
-on:
-  create
+on: create
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    # Validate the format of the tag. We only want to react on a precise pattern.
-    - name: Detect release tag
-      id: detect_tag
-      run: |
-        if [[ "${{ github.ref }}" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]
-        then
-          echo ::set-output name=IS_RELEASE_TAG::true
-        else
-          echo ::set-output name=IS_RELEASE_TAG::false
-        fi
-    # Extract version from tag.
-    - name: Get version
-      id: get_version
-      run: |
-        echo ::set-output name=RELEASE_TAG::$(echo ${GITHUB_REF#refs/tags/} | cut -d '_' -f 2)
-      if: ${{ steps.detect_tag.outputs.IS_RELEASE_TAG == 'true' }}
-    # Install go-task since we need it for building the source package.
-    - name: Install go-task
-      uses: arduino/setup-task@v1
-      if: ${{ steps.detect_tag.outputs.IS_RELEASE_TAG == 'true' }}
-    - name: Build and publish source
-      run: |
-        echo "Publishing tag: $RELEASE_TAG"
-        RELEASE_IMAGE_TAG=$RELEASE_TAG task source:deploy
-      if: ${{ steps.detect_tag.outputs.IS_RELEASE_TAG == 'true' }}
-      env:
-        CR_PAT: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_TAG: ${{ steps.get_version.outputs.RELEASE_TAG }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # Validate the format of the tag. We only want to react on a precise pattern.
+      - name: Detect release tag
+        id: detect_tag
+        run: |
+          if [[ "${{ github.ref }}" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          then
+            echo ::set-output name=IS_RELEASE_TAG::true
+          else
+            echo ::set-output name=IS_RELEASE_TAG::false
+          fi
+      # Extract version from tag.
+      - name: Get version
+        id: get_version
+        run: |
+          echo ::set-output name=RELEASE_TAG::$(echo ${GITHUB_REF#refs/tags/} | cut -d '_' -f 2)
+        if: ${{ steps.detect_tag.outputs.IS_RELEASE_TAG == 'true' }}
+      # Install go-task since we need it for building the source package.
+      - name: Install go-task
+        uses: arduino/setup-task@v1
+        if: ${{ steps.detect_tag.outputs.IS_RELEASE_TAG == 'true' }}
+      - name: Build and publish source
+        run: |
+          echo "Publishing tag: $RELEASE_TAG"
+          RELEASE_IMAGE_TAG=$RELEASE_TAG task source:deploy
+        if: ${{ steps.detect_tag.outputs.IS_RELEASE_TAG == 'true' }}
+        env:
+          CR_PAT: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.get_version.outputs.RELEASE_TAG }}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-435

#### Description

This change passes the created tag to the dpl-cms-source image. It was not happening before and therefore it defaulted to the total number of commits on the main branch.

Should be reviewed by looking at commits. One commit just cleans up formatting/indentation.

