### PR TITLE
Allow editors to setup the main menu, and add it in frontend DDFFORM-221

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,7 @@
         "drupal/restui": "^1.21",
         "drupal/search_api": "^1.31",
         "drupal/selective_better_exposed_filters": "^3.0",
+        "drupal/simple_menu_permissions": "^2.0",
         "drupal/twig_tweak": "^3.2.1",
         "drupal/upgrade_status": "^4.0",
         "drupal/uuid_url": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7dd464536a22839f3d099207390f3c4",
+    "content-hash": "1204c554459281e364fd3dbbb00e8d55",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -5129,6 +5129,50 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/selective_better_exposed_filters",
                 "issues": "https://www.drupal.org/project/issues/selective_better_exposed_filters"
+            }
+        },
+        {
+            "name": "drupal/simple_menu_permissions",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/simple_menu_permissions.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/simple_menu_permissions-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "75796f4cd15a4661c146904796c738de8b4c5918"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1675522195",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Ewout Goosmann",
+                    "homepage": "https://www.drupal.org/user/3138239"
+                }
+            ],
+            "description": "Defines permissions for each menu. Such as the edit and delete permission. Also defines a permission to create new menus.",
+            "homepage": "https://www.drupal.org/project/simple_menu_permissions",
+            "support": {
+                "source": "https://git.drupalcode.org/project/simple_menu_permissions"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -71,6 +71,7 @@ module:
   media_library: 0
   media_library_edit: 0
   menu_link_content: 0
+  menu_ui: 0
   metatag: 0
   multiple_fields_remove_button: 0
   mysql: 0
@@ -96,6 +97,7 @@ module:
   search_api: 0
   search_api_db: 0
   serialization: 0
+  simple_menu_permissions: 0
   system: 0
   taxonomy: 0
   text: 0

--- a/config/sync/menu_ui.settings.yml
+++ b/config/sync/menu_ui.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: SqMarzIjxC3F8dZo9FEOxfqDKD_sdW1tbcFTV1BA2zU
+override_parent_selector: false

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -28,6 +28,7 @@ dependencies:
     - node
     - openid_connect
     - recurring_events
+    - simple_menu_permissions
     - system
     - taxonomy
     - toolbar
@@ -48,6 +49,7 @@ permissions:
   - 'access toolbar'
   - 'access user profiles'
   - 'add eventseries entity'
+  - 'add new links to main menu'
   - 'administer blocks'
   - 'administer dpl_mapp configuration'
   - 'administer instant loan configuration'
@@ -76,6 +78,7 @@ permissions:
   - 'delete any page content'
   - 'delete eventinstance entity'
   - 'delete eventseries entity'
+  - 'delete links in main menu'
   - 'delete media'
   - 'delete orphan revisions'
   - 'delete own article content'
@@ -95,6 +98,8 @@ permissions:
   - 'edit any video media'
   - 'edit eventinstance entity'
   - 'edit eventseries entity'
+  - 'edit links in main menu'
+  - 'edit main menu'
   - 'edit own article content'
   - 'edit own campaign content'
   - 'edit own document media'
@@ -113,6 +118,7 @@ permissions:
   - 'use text format limited'
   - 'view all eventinstance revisions'
   - 'view all eventseries revisions'
+  - 'view main menu in menu list'
   - 'view own unpublished content'
   - 'view the administration theme'
   - 'view unpublished eventinstance entity'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -22,6 +22,7 @@ dependencies:
     - media
     - node
     - recurring_events
+    - simple_menu_permissions
     - system
     - taxonomy
     - toolbar
@@ -37,6 +38,7 @@ permissions:
   - 'access taxonomy overview'
   - 'access toolbar'
   - 'add eventseries entity'
+  - 'add new links to main menu'
   - 'administer instant loan configuration'
   - 'administer library agency configuration'
   - 'administer url proxy configuration'
@@ -56,6 +58,7 @@ permissions:
   - 'delete any page content'
   - 'delete eventinstance entity'
   - 'delete eventseries entity'
+  - 'delete links in main menu'
   - 'delete media'
   - 'delete own article content'
   - 'delete own campaign content'
@@ -74,6 +77,8 @@ permissions:
   - 'edit any video media'
   - 'edit eventinstance entity'
   - 'edit eventseries entity'
+  - 'edit links in main menu'
+  - 'edit main menu'
   - 'edit own article content'
   - 'edit own campaign content'
   - 'edit own document media'
@@ -91,6 +96,7 @@ permissions:
   - 'use text format limited'
   - 'view all eventinstance revisions'
   - 'view all eventseries revisions'
+  - 'view main menu in menu list'
   - 'view own unpublished content'
   - 'view the administration theme'
   - 'view unpublished eventinstance entity'

--- a/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
@@ -97,7 +97,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   event_instances:
     -
       entity: ddd9453d-56bc-4ad1-b10d-1e9615fe2c00

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -105,7 +105,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   event_instances:
     -
       entity: cb0b18d2-eb87-4dcd-ae98-efd0e657473a

--- a/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
@@ -97,7 +97,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   event_instances:
     -
       entity: ebf61b95-99a3-4263-a2e5-76030362cfa2

--- a/web/modules/custom/dpl_example_content/content/media/618e176a-a45a-4c36-a197-664230aa0a34.yml
+++ b/web/modules/custom/dpl_example_content/content/media/618e176a-a45a-4c36-a197-664230aa0a34.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_byline:
     -
       value: 'Af Ahmad Odeh / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/65432ee1-43f1-4130-9565-5683467d4b5a.yml
+++ b/web/modules/custom/dpl_example_content/content/media/65432ee1-43f1-4130-9565-5683467d4b5a.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_byline:
     -
       value: 'Af Admad Odeh / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/7b9d1894-7f9a-4f96-a7dc-efa3af5fc902.yml
+++ b/web/modules/custom/dpl_example_content/content/media/7b9d1894-7f9a-4f96-a7dc-efa3af5fc902.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_media_image:
     -
       entity: 50b4d50b-9c75-4698-b803-a125b46daaac

--- a/web/modules/custom/dpl_example_content/content/media/a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f.yml
+++ b/web/modules/custom/dpl_example_content/content/media/a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_media_image:
     -
       entity: 24244298-ff4d-4662-bc7f-5b9aa529f89e

--- a/web/modules/custom/dpl_example_content/content/media/a6a77786-07db-48d8-98ff-3bda54f231bf.yml
+++ b/web/modules/custom/dpl_example_content/content/media/a6a77786-07db-48d8-98ff-3bda54f231bf.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_media_image:
     -
       entity: 7fb4d332-81ef-4dc0-af9a-dfcd29ecf367

--- a/web/modules/custom/dpl_example_content/content/media/aba3cea8-cee5-42c1-a152-e30c2ab135e2.yml
+++ b/web/modules/custom/dpl_example_content/content/media/aba3cea8-cee5-42c1-a152-e30c2ab135e2.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_byline:
     -
       value: 'Af Jilbert Ebrahimi / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/d6d67fd2-775c-46e7-a1bf-6af46290a5c8.yml
+++ b/web/modules/custom/dpl_example_content/content/media/d6d67fd2-775c-46e7-a1bf-6af46290a5c8.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_media_image:
     -
       entity: ed301960-e40f-42b5-9229-4ac20fd07a7e

--- a/web/modules/custom/dpl_example_content/content/media/d97a25fd-a6ae-48b9-9a1a-7aec5372688e.yml
+++ b/web/modules/custom/dpl_example_content/content/media/d97a25fd-a6ae-48b9-9a1a-7aec5372688e.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_byline:
     -
       value: 'Af Becca Tapert / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/dc33677f-8894-4717-b34b-d985f6ad875f.yml
+++ b/web/modules/custom/dpl_example_content/content/media/dc33677f-8894-4717-b34b-d985f6ad875f.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_media_file:
     -
       entity: 3403d0ba-cbdc-425d-93f4-6cdabb5378b1

--- a/web/modules/custom/dpl_example_content/content/media/eef50571-39dc-461a-96ff-b6b7180ade61.yml
+++ b/web/modules/custom/dpl_example_content/content/media/eef50571-39dc-461a-96ff-b6b7180ade61.yml
@@ -32,7 +32,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_byline:
     -
       value: 'Af Jon Tyson / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/f0204f0b-1f63-4c76-bb67-e3f7489ee392.yml
+++ b/web/modules/custom/dpl_example_content/content/media/f0204f0b-1f63-4c76-bb67-e3f7489ee392.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/user/login'
+        href: '/user/login'
   field_media_oembed_video:
     -
       value: 'https://www.youtube.com/watch?v=CmzKQ3PSrow'

--- a/web/modules/custom/dpl_example_content/content/menu_link_content/a25ebb74-e87f-4b2c-8156-b622dc23844e.yml
+++ b/web/modules/custom/dpl_example_content/content/menu_link_content/a25ebb74-e87f-4b2c-8156-b622dc23844e.yml
@@ -44,4 +44,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dpl-cms.docker/user/login'
+        href: '/user/login'

--- a/web/modules/custom/dpl_example_content/content/menu_link_content/a25ebb74-e87f-4b2c-8156-b622dc23844e.yml
+++ b/web/modules/custom/dpl_example_content/content/menu_link_content/a25ebb74-e87f-4b2c-8156-b622dc23844e.yml
@@ -1,0 +1,47 @@
+_meta:
+  version: '1.0'
+  entity_type: menu_link_content
+  uuid: a25ebb74-e87f-4b2c-8156-b622dc23844e
+  bundle: menu_link_content
+  default_langcode: en
+default:
+  enabled:
+    -
+      value: true
+  title:
+    -
+      value: 'Biblioteker & åbningstider'
+  menu_name:
+    -
+      value: main
+  link:
+    -
+      uri: 'internal:/'
+      title: ''
+      options: {  }
+  external:
+    -
+      value: false
+  rediscover:
+    -
+      value: true
+  weight:
+    -
+      value: 0
+  expanded:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: '| DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dpl-cms.docker/user/login'

--- a/web/modules/custom/dpl_example_content/content/menu_link_content/c060dc61-87e2-4203-9f17-731f766f5b9b.yml
+++ b/web/modules/custom/dpl_example_content/content/menu_link_content/c060dc61-87e2-4203-9f17-731f766f5b9b.yml
@@ -1,7 +1,7 @@
 _meta:
   version: '1.0'
   entity_type: menu_link_content
-  uuid: ff6db3ce-49e0-4107-b283-3403e22c5e6d
+  uuid: c060dc61-87e2-4203-9f17-731f766f5b9b
   bundle: menu_link_content
   default_langcode: en
 default:
@@ -10,13 +10,13 @@ default:
       value: true
   title:
     -
-      value: 'Det sker'
+      value: 'Børn & forældre'
   menu_name:
     -
       value: main
   link:
     -
-      uri: 'internal:/events'
+      uri: 'internal:/'
       title: ''
       options: {  }
   external:
@@ -27,7 +27,7 @@ default:
       value: true
   weight:
     -
-      value: -1
+      value: 4
   expanded:
     -
       value: false

--- a/web/modules/custom/dpl_example_content/content/menu_link_content/c10227b4-50ed-4ab8-9d6a-a14889f7fb01.yml
+++ b/web/modules/custom/dpl_example_content/content/menu_link_content/c10227b4-50ed-4ab8-9d6a-a14889f7fb01.yml
@@ -1,7 +1,7 @@
 _meta:
   version: '1.0'
   entity_type: menu_link_content
-  uuid: ff6db3ce-49e0-4107-b283-3403e22c5e6d
+  uuid: c10227b4-50ed-4ab8-9d6a-a14889f7fb01
   bundle: menu_link_content
   default_langcode: en
 default:
@@ -10,13 +10,13 @@ default:
       value: true
   title:
     -
-      value: 'Det sker'
+      value: Litteratur
   menu_name:
     -
       value: main
   link:
     -
-      uri: 'internal:/events'
+      uri: 'internal:/'
       title: ''
       options: {  }
   external:
@@ -27,7 +27,7 @@ default:
       value: true
   weight:
     -
-      value: -1
+      value: 3
   expanded:
     -
       value: false

--- a/web/modules/custom/dpl_example_content/content/menu_link_content/c391079e-a4f5-4d29-992f-92ed1a2dd96c.yml
+++ b/web/modules/custom/dpl_example_content/content/menu_link_content/c391079e-a4f5-4d29-992f-92ed1a2dd96c.yml
@@ -44,4 +44,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dpl-cms.docker/user/login'
+        href: '/user/login'

--- a/web/modules/custom/dpl_example_content/content/menu_link_content/c391079e-a4f5-4d29-992f-92ed1a2dd96c.yml
+++ b/web/modules/custom/dpl_example_content/content/menu_link_content/c391079e-a4f5-4d29-992f-92ed1a2dd96c.yml
@@ -1,0 +1,47 @@
+_meta:
+  version: '1.0'
+  entity_type: menu_link_content
+  uuid: c391079e-a4f5-4d29-992f-92ed1a2dd96c
+  bundle: menu_link_content
+  default_langcode: en
+default:
+  enabled:
+    -
+      value: true
+  title:
+    -
+      value: 'Digitale tilbud'
+  menu_name:
+    -
+      value: main
+  link:
+    -
+      uri: 'internal:/'
+      title: ''
+      options: {  }
+  external:
+    -
+      value: false
+  rediscover:
+    -
+      value: true
+  weight:
+    -
+      value: 0
+  expanded:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: '| DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dpl-cms.docker/user/login'

--- a/web/modules/custom/dpl_example_content/content/menu_link_content/ff6db3ce-49e0-4107-b283-3403e22c5e6d.yml
+++ b/web/modules/custom/dpl_example_content/content/menu_link_content/ff6db3ce-49e0-4107-b283-3403e22c5e6d.yml
@@ -1,0 +1,47 @@
+_meta:
+  version: '1.0'
+  entity_type: menu_link_content
+  uuid: ff6db3ce-49e0-4107-b283-3403e22c5e6d
+  bundle: menu_link_content
+  default_langcode: en
+default:
+  enabled:
+    -
+      value: true
+  title:
+    -
+      value: 'Det sker'
+  menu_name:
+    -
+      value: main
+  link:
+    -
+      uri: 'internal:/'
+      title: ''
+      options: {  }
+  external:
+    -
+      value: false
+  rediscover:
+    -
+      value: true
+  weight:
+    -
+      value: 0
+  expanded:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: '| DPL CMS'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://dpl-cms.docker/user/login'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/9'
+        href: '/taxonomy/term/9'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/1'
+        href: '/taxonomy/term/1'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/4'
+        href: '/taxonomy/term/4'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/6'
+        href: '/taxonomy/term/6'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/5'
+        href: '/taxonomy/term/5'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/7'
+        href: '/taxonomy/term/7'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/2'
+        href: '/taxonomy/term/2'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/3'
+        href: '/taxonomy/term/3'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/8'
+        href: '/taxonomy/term/8'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
@@ -30,4 +30,4 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: 'http://dapple-cms.docker/taxonomy/term/10'
+        href: '/taxonomy/term/10'

--- a/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
@@ -56,3 +56,7 @@ default_content:
     - 0502836d-0f7b-4b21-9371-c40ae9e01495
     - 0fa7245a-3434-4d96-9793-a1848a22d37a
     - 807e6053-86ed-4dce-b6a9-a48b566b5910
+  menu_link_content:
+    - ff6db3ce-49e0-4107-b283-3403e22c5e6d
+    - c391079e-a4f5-4d29-992f-92ed1a2dd96c
+    - a25ebb74-e87f-4b2c-8156-b622dc23844e

--- a/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
@@ -60,3 +60,5 @@ default_content:
     - ff6db3ce-49e0-4107-b283-3403e22c5e6d
     - c391079e-a4f5-4d29-992f-92ed1a2dd96c
     - a25ebb74-e87f-4b2c-8156-b622dc23844e
+    - c060dc61-87e2-4203-9f17-731f766f5b9b
+    - c10227b4-50ed-4ab8-9d6a-a14889f7fb01

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -16,33 +16,8 @@
                        {{ logo }}
                     </div>
                 </div>
-                <ul class="header__menu-navigation">
-                    <li class="header__menu-navigation-item">
-                        <a href="/" class="header__menu-navigation-link hide-linkstyle">
-                            Det sker
-                        </a>
-                    </li>
-                    <li class="header__menu-navigation-item">
-                        <a href="/" class="header__menu-navigation-link hide-linkstyle">
-                            Biblioteker &amp; åbningstider
-                        </a>
-                    </li>
-                    <li class="header__menu-navigation-item">
-                        <a href="/" class="header__menu-navigation-link hide-linkstyle">
-                            Digitale tilbud
-                        </a>
-                    </li>
-                    <li class="header__menu-navigation-item">
-                        <a href="/" class="header__menu-navigation-link hide-linkstyle">
-                            Litteratur
-                        </a>
-                    </li>
-                    <li class="header__menu-navigation-item">
-                        <a href="/" class="header__menu-navigation-link hide-linkstyle">
-                            Børn &amp; forældre
-                        </a>
-                    </li>
-                </ul>
+
+                {{ drupal_menu('main') }}
             </div>
       {{ patron_menu }}
             <div class="header__menu-bookmarked header__button">

--- a/web/themes/custom/novel/templates/layout/menu--main.html.twig
+++ b/web/themes/custom/novel/templates/layout/menu--main.html.twig
@@ -1,11 +1,7 @@
-
 <ul class="header__menu-navigation">
-{% for item in items %}
-  <li class="header__menu-navigation-item">
-    <a href="{{ item.url }}" class="header__menu-navigation-link text-body-medium-regular hide-linkstyle">
-      {{ item.title }}
-    </a>
-  </li>
-
-{% endfor %}
+  {% for item in items %}
+    <li class="header__menu-navigation-item">
+      {{ link(item.title, item.url, item.attributes.addClass('header__menu-navigation-link', 'hide-linkstyle')) }}
+    </li>
+  {% endfor %}
 </ul>

--- a/web/themes/custom/novel/templates/layout/menu--main.html.twig
+++ b/web/themes/custom/novel/templates/layout/menu--main.html.twig
@@ -1,0 +1,11 @@
+
+<ul class="header__menu-navigation">
+{% for item in items %}
+  <li class="header__menu-navigation-item">
+    <a href="{{ item.url }}" class="header__menu-navigation-link text-body-medium-regular hide-linkstyle">
+      {{ item.title }}
+    </a>
+  </li>
+
+{% endfor %}
+</ul>


### PR DESCRIPTION

Allow editors to setup the main menu, and add it in frontend DDFFORM-221

This includes a contrib module, for setting up permissions per
menu, so we avoid that the editors can edit other menus.

-----

Hide unused/unwanted functioanlity from Menu UI. DDFFORM-221

We want to avoid the editor setting up multi-level menus, as
the frontend does not support it.
We'll hide the options using CSS, but, if they do get around it,
it's not the end of the world as it just will have no effect.

-----

Setup main menu default content.

----
