### PR TITLE
Hide unused/unwanted functioanlity from Menu UI. DDFFORM-221 

### DIFF
--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -89,7 +89,7 @@
 }
 
 /* Hide some fields on the edit menu UI. */
-/* Also hiding the ability to place menu item in levels. */
+/* Also hiding the ability to place main menu items in levels. */
 .menu-link-content-form .field--name-description,
 .menu-link-content-form .field--name-expanded,
 .menu-link-content-form .form-item--menu-parent,

--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -87,3 +87,12 @@
 .gin--edit-form .event-notification-message {
   display: none;
 }
+
+/* Hide some fields on the edit menu UI. */
+/* Also hiding the ability to place menu item in levels. */
+.menu-link-content-form .field--name-description,
+.menu-link-content-form .field--name-expanded,
+.menu-link-content-form .form-item--menu-parent,
+.menu-edit-form[action="/admin/structure/menu/manage/main"] > .form-item {
+  display: none;
+}

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\recurring_events\Entity\EventInstance;
 use Drupal\views\Plugin\views\field\EntityField;
 use Drupal\views\ViewExecutable;
@@ -227,4 +228,24 @@ function dpl_admin_datetime_set_format(array $element): array {
   // Remove seconds in browsers that support HTML5 type=date.
   $element['time']['#attributes']['step'] = 60;
   return $element;
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ *
+ * The editor can place links in the main menu in several levels, but we only
+ * display the first level in the frontend.
+ * If the editor still places a multi-level link, we'll give them a warning.
+ */
+function dpl_admin_menu_link_content_presave(MenuLinkContent $entity): void {
+  if ('main' !== $entity->getMenuName()) {
+    return;
+  }
+
+  if (!$entity->get('parent')->isEmpty()) {
+    \Drupal::messenger()->addWarning(t(
+      'You have added a menu link with a parent. Please notice that this menu link will not be displayed, as we do not support multi-levels in the main menu.',
+      [], ['context' => 'DPL admin UX']
+    ));
+  }
 }


### PR DESCRIPTION
Hide unused/unwanted functioanlity from Menu UI. DDFFORM-221

We want to avoid the editor setting up multi-level menus, as
the frontend does not support it.
We'll hide the options using CSS, but, if they do get around it,
it's not the end of the world as it just will have no effect.

----

Show warning if multi-level link is added to main menu. DDFFORM-221

<img width="846" alt="Screenshot 2024-02-12 at 13 49 02" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/0814ce9e-6aa0-4aba-8d63-2f1b99356376">
