### PR TITLE
Patch date_range_formatter: Avoid crash on identical start/end date.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -235,6 +235,9 @@
                 "2259567: Support SVG files for theme logo setting": "https://www.drupal.org/files/issues/2023-05-08/2259567-168.patch",
                 "Always assume chmod succeeds": "patches/core-304fd8b-chmod-true.patch"
             },
+            "drupal/date_range_formatter": {
+                "3309324: Fails when start and end date are identical": "https://www.drupal.org/files/issues/2023-12-22/date_range_formatter_3309324_1.patch"
+            },
             "drupal/default_content": {
                 "3200212: Overwrite files on import": "https://git.drupalcode.org/project/default_content/-/merge_requests/8.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf377ee1fb71440f7c5af851960d47af",
+    "content-hash": "cb25751d069004663963e7d02cdaa007",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2742,17 +2742,17 @@
         },
         {
             "name": "drupal/date_range_formatter",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/date_range_formatter.git",
-                "reference": "4.0.1"
+                "reference": "4.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/date_range_formatter-4.0.1.zip",
-                "reference": "4.0.1",
-                "shasum": "d218f325c9a1e144ede86d34b87002330a4e8709"
+                "url": "https://ftp.drupal.org/files/projects/date_range_formatter-4.0.2.zip",
+                "reference": "4.0.2",
+                "shasum": "0d953912148e384aed6a6cee64115faf170319c0"
             },
             "require": {
                 "drupal/core": "^8 || ^9 || ^10"
@@ -2760,8 +2760,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.0.1",
-                    "datestamp": "1661752209",
+                    "version": "4.0.2",
+                    "datestamp": "1703156621",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Patch date_range_formatter: Avoid crash on identical start/end date.

If an editor chooses a start and end date on the exact same day/time,
the actual display of the event instance will fail with a WSOD.
This both updates the module to the latest version, and adds
a patch. Logically, the patch should not be necessary, but no matter
what i do, the error still happens unless the patch is also added.

DDFFORM-265

------

I originally did a fix in https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/744 but that was cause i thought it was a direct issue with reccuring dates.
It turns out it was a problem with date_range_formatter, as @kasperg pointed out :)