### PR TITLE
Add 'cancel' button to event-series-date-confirm flow. DDFFORM-284

### DIFF
--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\dpl_event\EventState;
 use Drupal\file\Entity\File;
@@ -308,5 +309,35 @@ function dpl_event_preprocess_eventinstance__list_teaser(array &$variables): voi
     if ($end_date instanceof DrupalDateTime) {
       $variables['end_date'] = $date_formatter->format($end_date->getTimestamp(), 'custom', 'H:i');
     }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Altering the form for EDITING (not creating) an event series.
+ */
+function dpl_event_form_eventseries_default_edit_form_alter(array &$form, FormStateInterface $form_state): void {
+  // When saving a series, and changing the dates, the recurring_events module
+  // will make a "custom" submit button, showing a 'are you sure' button.
+  // However, this does not include a 'cancel' button. This is because cancel
+  // basically just means navigating away, but, this is confusing for editors.
+  // We'll add our own "button", that is really just a link the same edit page.
+  if (!empty($form['diff']['confirm'])) {
+    $form['diff']['cancel'] = [
+      '#type' => 'link',
+      '#title' => t('Cancel all changes', [], ['context' => 'DPL admin UX']),
+      '#url' => Url::fromRoute('<current>'),
+      '#attributes' => [
+        'class' => [
+          'action-link', 'action-link--danger', 'action-link--icon-trash',
+        ],
+      ],
+    ];
+
+    // The save/delete buttons on the page does nothing, when a diff confirm
+    // is relevant. We'll hide them, just to make it less confusing for the
+    // editors.
+    unset($form['actions']);
   }
 }


### PR DESCRIPTION
When saving a series, and changing the dates, the recurring_events module will make a "custom" submit button, showing a 'are you sure' confirm. However, this does not include a 'cancel' button. This is because cancel basically just means navigating away, but, this is confusing for editors. We'll add our own "button", that is really just a link to the content overview page.
<img width="1462" alt="Screenshot 2024-02-12 at 17 28 36" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/a3a65cf8-68a4-41c8-bb29-4281778d43c4">
