### PR TITLE
Patch Purge module to try to combat NoCorrespondingEntityClassException

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -264,6 +264,10 @@
                 "Use Drupal StaticReflectionParser with Drupal 10.1": "patches/potion-d10-1-staticreflection.patch",
                 "3413314: Include .links.menu.yml files in YamlExtractor.php": "https://www.drupal.org/files/issues/2024-01-08/potion-add_links_menu_yml_title_and_description_to_yaml_extractor-3413314-3.patch"
             },
+            "drupal/purge": {
+                "3391383: Uninstalling module triggers ServiceNotFoundException exception": "https://git.drupalcode.org/project/purge/-/commit/88546a6e6c043f10832be43e02ae4ae65cf5ceb2.patch",
+                "Combat NoCorrespondingEntityClassException": "patches/purge-5340bcf-combat-nocorresponding-entity-exception.patch"
+            },
             "drupal/recurring_events": {
                 "3415222: Wrong namespace for return values": "https://git.drupalcode.org/project/recurring_events/-/merge_requests/83.patch"
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "009047a30e76d8bd52dd10d7124e4cc0",
+    "content-hash": "114bd6cef6719cb9c0d4288f892117ed",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/patches/purge-5340bcf-combat-nocorresponding-entity-exception.patch
+++ b/patches/purge-5340bcf-combat-nocorresponding-entity-exception.patch
@@ -1,0 +1,38 @@
+From 5340bcf0086ead8c76c32984831fe995f9966174 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kasper=20Garn=C3=A6s?= <kasperg@users.noreply.github.com>
+Date: Tue, 13 Feb 2024 08:20:53 +0100
+Subject: [PATCH] Combat NoCorrespondingEntityClassException
+
+---
+ src/Plugin/Purge/Purger/PurgersService.php | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/Plugin/Purge/Purger/PurgersService.php b/src/Plugin/Purge/Purger/PurgersService.php
+index dcaf1d8..32ae910 100644
+--- a/src/Plugin/Purge/Purger/PurgersService.php
++++ b/src/Plugin/Purge/Purger/PurgersService.php
+@@ -4,6 +4,7 @@ namespace Drupal\purge\Plugin\Purge\Purger;
+ 
+ use Drupal\Component\Plugin\PluginManagerInterface;
+ use Drupal\Core\Config\ConfigFactoryInterface;
++use Drupal\Core\Entity\Exception\NoCorrespondingEntityClassException;
+ use Drupal\Core\Lock\LockBackendInterface;
+ use Drupal\purge\Logger\LoggerServiceInterface;
+ use Drupal\purge\Plugin\Purge\DiagnosticCheck\DiagnosticsServiceInterface;
+@@ -410,6 +411,13 @@ class PurgersService extends ServiceBase implements PurgersServiceInterface {
+         $this->logger->error("Error loading purger @id (@plugin_id): @error",
+           ['@id' => $id, '@plugin_id' => $plugin_id, '@error' => $e]);
+       }
++      // We have seen problems loading Varnish Purger configuration entities
++      // during some site installs on CI. We believe this may be temporary so
++      // try to combat these by logging the problem and continuing.
++      catch (NoCorrespondingEntityClassException $e) {
++        $this->logger->error("Error loading purger @id (@plugin_id): @error",
++          ['@id' => $id, '@plugin_id' => $plugin_id, '@error' => $e]);
++      }
+     }
+ 
+     // Pass the purger instance onto depending objects.
+-- 
+2.37.5
+


### PR DESCRIPTION
We have seen problems loading Varnish Purger configuration entities during some site installs on CI. This results in an error when running `task ci:reset`:

`The Drupal\varnish_purger\Entity\VarnishPurgerSettings class does not
correspond to an entity type.`

This occurs when running `drush cache:rebuild -y` immediately after running `drush site-install --existing-config -y`.

It is worth noting that we cannot replicate this locally and it does not occur for all actions which run `task ci:reset`.

[History shows that is may be related to the LateRuntimeProcessor](https://www.drupal.org/project/varnish_purge/issues/3346464).

We have tried to address this by [changing the order of the steps](#756), [disabling the LateRuntimeProcessor](#754) but without any success.

We believe this may be temporary so try to combat these by logging the problem and continuing the process.

The problem seems be resolved based on the fact that the error is only logged during [the first `drush cache:rebuild -y` in `task ci:reset`](https://github.com/danskernesdigitalebibliotek/dpl-cms/blob/6fe11bcbdc257becc955cb3bd9f9b7ee82a5dafa/Taskfile.yml#L156-L156) but not [the second](https://github.com/danskernesdigitalebibliotek/dpl-cms/blob/6fe11bcbdc257becc955cb3bd9f9b7ee82a5dafa/Taskfile.yml#L166-L166) when we see the log output in CI:

This patch works in the same area as an already merged but unreleased change so include this patch as well and base the current patch on this. This should make  it easier to move forward with our own change in the future.