### PR TITLE
Add support for scheduling recurring events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -271,6 +271,9 @@
             "drupal/purge": {
                 "3391383: Uninstalling module triggers ServiceNotFoundException exception": "https://git.drupalcode.org/project/purge/-/commit/88546a6e6c043f10832be43e02ae4ae65cf5ceb2.patch",
                 "Combat NoCorrespondingEntityClassException": "patches/purge-5340bcf-combat-nocorresponding-entity-exception.patch"
+            },
+            "drupal/recurring_events": {
+                "3178696: Make compatible with Scheduler": "https://git.drupalcode.org/project/recurring_events/-/merge_requests/86.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -271,9 +271,6 @@
             "drupal/purge": {
                 "3391383: Uninstalling module triggers ServiceNotFoundException exception": "https://git.drupalcode.org/project/purge/-/commit/88546a6e6c043f10832be43e02ae4ae65cf5ceb2.patch",
                 "Combat NoCorrespondingEntityClassException": "patches/purge-5340bcf-combat-nocorresponding-entity-exception.patch"
-            },
-            "drupal/recurring_events": {
-                "3415222: Wrong namespace for return values": "https://git.drupalcode.org/project/recurring_events/-/merge_requests/83.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf377ee1fb71440f7c5af851960d47af",
+    "content-hash": "71c01d1d353db839edcdcde10a032dcd",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -4712,17 +4712,17 @@
         },
         {
             "name": "drupal/recurring_events",
-            "version": "2.0.0-rc16",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/recurring_events.git",
-                "reference": "2.0.0-rc16"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/recurring_events-2.0.0-rc16.zip",
-                "reference": "2.0.0-rc16",
-                "shasum": "9e8f28e53e26aadbccd3b7f233c98fcb5aff853f"
+                "url": "https://ftp.drupal.org/files/projects/recurring_events-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "7bc7a42b18c02d88aaaa12b35ac6434140f9f432"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10",
@@ -4736,11 +4736,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-rc16",
-                    "datestamp": "1701464510",
+                    "version": "2.0.0",
+                    "datestamp": "1706902867",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "RC releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "71c01d1d353db839edcdcde10a032dcd",
+    "content-hash": "ec640ffdeea145f7cf608bd870dbe9f3",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -27,6 +27,7 @@ dependencies:
     - paragraphs_ee
     - paragraphs_features
     - recurring_events
+    - scheduler
     - text
 third_party_settings:
   field_group:
@@ -251,9 +252,20 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 52
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   recur_type:
     type: options_select
     weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduler_settings:
+    weight: 50
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -281,6 +293,12 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 54
+    region: content
+    settings: {  }
     third_party_settings: {  }
   weekly_recurring_date:
     type: weekly_recurring_date

--- a/config/sync/recurring_events.eventseries_type.default.yml
+++ b/config/sync/recurring_events.eventseries_type.default.yml
@@ -1,7 +1,23 @@
 uuid: 99d5eac0-4a8a-4689-8278-7a9f33a71111
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: 1
+    publish_past_date: error
+    publish_past_date_created: 0
+    publish_required: 0
+    publish_revision: 0
+    publish_touch: 1
+    show_message_after_update: 1
+    unpublish_enable: 1
+    unpublish_required: 0
+    unpublish_revision: 0
 _core:
   default_config_hash: WhOawYzY2jtIq8ND2DpY_hhidNwqx1DcS221RHT2Exk
 id: default

--- a/config/sync/recurring_events.eventseries_type.default.yml
+++ b/config/sync/recurring_events.eventseries_type.default.yml
@@ -13,7 +13,7 @@ third_party_settings:
     publish_past_date_created: 0
     publish_required: 0
     publish_revision: 0
-    publish_touch: 1
+    publish_touch: 0
     show_message_after_update: 1
     unpublish_enable: 1
     unpublish_required: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -28,6 +28,7 @@ dependencies:
     - node
     - openid_connect
     - recurring_events
+    - scheduler
     - simple_menu_permissions
     - system
     - taxonomy
@@ -111,6 +112,8 @@ permissions:
   - 'edit terms in tags'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
+  - 'schedule publishing of eventseries'
+  - 'schedule publishing of nodes'
   - 'translate interface'
   - 'update any media'
   - 'update media'
@@ -120,6 +123,8 @@ permissions:
   - 'view all eventseries revisions'
   - 'view main menu in menu list'
   - 'view own unpublished content'
+  - 'view scheduled content'
+  - 'view scheduled eventseries'
   - 'view the administration theme'
   - 'view unpublished eventinstance entity'
   - 'view unpublished eventseries entity'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -19,6 +19,7 @@ dependencies:
     - media
     - node
     - recurring_events
+    - scheduler
     - system
     - taxonomy
     - toolbar
@@ -78,6 +79,8 @@ permissions:
   - 'edit terms in tags'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
+  - 'schedule publishing of eventseries'
+  - 'schedule publishing of nodes'
   - 'update any media'
   - 'update media'
   - 'use text format basic'
@@ -85,6 +88,8 @@ permissions:
   - 'view all eventinstance revisions'
   - 'view all eventseries revisions'
   - 'view own unpublished content'
+  - 'view scheduled content'
+  - 'view scheduled eventseries'
   - 'view the administration theme'
   - 'view unpublished eventinstance entity'
   - 'view unpublished eventseries entity'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -22,6 +22,7 @@ dependencies:
     - media
     - node
     - recurring_events
+    - scheduler
     - simple_menu_permissions
     - system
     - taxonomy
@@ -90,6 +91,8 @@ permissions:
   - 'edit terms in tags'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
+  - 'schedule publishing of eventseries'
+  - 'schedule publishing of nodes'
   - 'update any media'
   - 'update media'
   - 'use text format basic'
@@ -98,6 +101,8 @@ permissions:
   - 'view all eventseries revisions'
   - 'view main menu in menu list'
   - 'view own unpublished content'
+  - 'view scheduled content'
+  - 'view scheduled eventseries'
   - 'view the administration theme'
   - 'view unpublished eventinstance entity'
   - 'view unpublished eventseries entity'

--- a/config/sync/user.role.mediator.yml
+++ b/config/sync/user.role.mediator.yml
@@ -18,6 +18,7 @@ dependencies:
     - media
     - node
     - recurring_events
+    - scheduler
     - system
     - taxonomy
     - toolbar
@@ -73,6 +74,8 @@ permissions:
   - 'edit terms in tags'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
+  - 'schedule publishing of eventseries'
+  - 'schedule publishing of nodes'
   - 'update any media'
   - 'update media'
   - 'use text format basic'
@@ -80,6 +83,8 @@ permissions:
   - 'view all eventinstance revisions'
   - 'view all eventseries revisions'
   - 'view own unpublished content'
+  - 'view scheduled content'
+  - 'view scheduled eventseries'
   - 'view the administration theme'
   - 'view unpublished eventinstance entity'
   - 'view unpublished eventseries entity'

--- a/config/sync/views.view.event_admin.yml
+++ b/config/sync/views.view.event_admin.yml
@@ -486,6 +486,73 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: 0
+        status:
+          id: status
+          table: eventinstance_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: eventinstance
+          entity_field: status
+          plugin_id: field
+          label: 'Publication status'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: ' Unpublished'
+            format_custom_true: Published
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         edit_eventseries:
           id: edit_eventseries
           table: eventseries

--- a/config/sync/views.view.event_admin.yml
+++ b/config/sync/views.view.event_admin.yml
@@ -900,6 +900,60 @@ display:
                   max: ''
                   value: today
                   type: offset
+        status:
+          id: status
+          table: eventinstance_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: eventinstance
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Publication status'
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+          is_grouped: true
+          group_info:
+            label: 'Published status'
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Published
+                operator: '='
+                value: '1'
+              2:
+                title: Unpublished
+                operator: '='
+                value: '0'
       filter_groups:
         operator: AND
         groups:

--- a/config/sync/views.view.event_admin.yml
+++ b/config/sync/views.view.event_admin.yml
@@ -761,23 +761,7 @@ display:
         type: tag
         options: {  }
       empty: {  }
-      sorts:
-        date__value:
-          id: date__value
-          table: eventinstance_field_data
-          field: date__value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: eventinstance
-          entity_field: date
-          plugin_id: datetime
-          order: ASC
-          expose:
-            label: 'Event Date'
-            field_identifier: date
-          exposed: true
-          granularity: second
+      sorts: {  }
       arguments: {  }
       filters:
         combine:
@@ -972,9 +956,11 @@ display:
             date__value_1: date__value_1
             date__value: date__value
             event_state: event_state
+            status: status
             edit_eventseries: edit_eventseries
             operations: operations
-          default: '-1'
+            title_1: title_1
+          default: date__value
           info:
             eventseries_id:
               sortable: false
@@ -1012,13 +998,20 @@ display:
               empty_column: false
               responsive: ''
             date__value:
-              sortable: false
+              sortable: true
               default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
             event_state:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
               sortable: false
               default_sort_order: asc
               align: ''
@@ -1033,6 +1026,13 @@ display:
               empty_column: false
               responsive: ''
             operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title_1:
+              sortable: false
+              default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
@@ -1075,8 +1075,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'url.query_args:sort_by'
-        - 'url.query_args:sort_order'
         - user.permissions
       tags: {  }
   overview:
@@ -1103,7 +1101,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'url.query_args:sort_by'
-        - 'url.query_args:sort_order'
         - user.permissions
       tags: {  }

--- a/config/sync/views.view.scheduler_scheduled_content.yml
+++ b/config/sync/views.view.scheduler_scheduled_content.yml
@@ -1,6 +1,6 @@
 uuid: 3328df58-27cd-4ff7-bf0b-9c1686ed40b3
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - system.menu.admin


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-271

#### Description

This PR adds support for scheduling recurring event series by patching the Recurring Events module. This change lead a number of other related changes.

- First the Recurring Events module is updated to the latest release to have a stable foundation for patching
- Then the module is patched though a merge request: https://www.drupal.org/project/recurring_events/issues/3178696
- Finally event series are configured to support scheduling. The Recurring Events module will ensure that publication status for event instances is kept in sync.

This change leads to some byproducts

- I have modified the events administration view to better support publication status
  - Publication status is added as a column
  - Publication status is added as a filter
  - Sortering is moved to table headers
- I have disabled the default scheduled content view for nodes as we do not have a corresponding view for events

#### Screenshot of the result

<img width="1392" alt="Monosnap Create Default Event | DPL CMS | Logged in 2024-02-14 12-06-08" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/d0fefcf2-e298-49bc-a08f-d6f091274926">

<img width="1392" alt="Monosnap Event - admin | DPL CMS | Logged in 2024-02-14 12-03-23" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/2266524a-9df6-48d4-acf1-f4dbdf7c8c7e">

#### Additional comments or questions

This is pretty hard to review as it consists of configuration and a merge request. Perhaps consider just testing it out. Note that you will have to run cron yourself.