### PR TITLE
More event instance fields

### DIFF
--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -36,7 +37,7 @@ third_party_settings:
       label: 'Teaser card'
       region: content
       parent_name: ''
-      weight: 13
+      weight: 14
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -59,19 +60,19 @@ content:
     third_party_settings: {  }
   field_categories:
     type: options_select
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   field_event_address:
     type: address_default
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   field_event_description:
     type: text_textarea
-    weight: 5
+    weight: 6
     region: content
     settings:
       rows: 5
@@ -79,14 +80,14 @@ content:
     third_party_settings: {  }
   field_event_image:
     type: media_library_widget
-    weight: 11
+    weight: 12
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_event_link:
     type: link_default
-    weight: 7
+    weight: 8
     region: content
     settings:
       placeholder_url: ''
@@ -94,7 +95,7 @@ content:
     third_party_settings: {  }
   field_event_paragraphs:
     type: paragraphs
-    weight: 12
+    weight: 13
     region: content
     settings:
       title: Paragraph
@@ -122,7 +123,7 @@ content:
           dialog_style: tiles
   field_event_partners:
     type: string_textfield
-    weight: 10
+    weight: 11
     region: content
     settings:
       size: 60
@@ -130,7 +131,7 @@ content:
     third_party_settings: {  }
   field_event_place:
     type: string_textfield
-    weight: 9
+    weight: 10
     region: content
     settings:
       size: 60
@@ -142,9 +143,17 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_event_title:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 4
+    weight: 5
     region: content
     settings:
       match_operator: CONTAINS
@@ -169,7 +178,7 @@ content:
     third_party_settings: {  }
   field_ticket_categories:
     type: paragraphs
-    weight: 6
+    weight: 7
     region: content
     settings:
       title: Paragraph

--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -26,6 +26,7 @@ dependencies:
     - paragraphs
     - paragraphs_ee
     - paragraphs_features
+    - text
 third_party_settings:
   field_group:
     group_teaser_card:
@@ -35,7 +36,7 @@ third_party_settings:
       label: 'Teaser card'
       region: content
       parent_name: ''
-      weight: 12
+      weight: 13
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -64,20 +65,28 @@ content:
     third_party_settings: {  }
   field_event_address:
     type: address_default
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_event_description:
+    type: text_textarea
+    weight: 5
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_event_image:
     type: media_library_widget
-    weight: 10
+    weight: 11
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_event_link:
     type: link_default
-    weight: 6
+    weight: 7
     region: content
     settings:
       placeholder_url: ''
@@ -85,7 +94,7 @@ content:
     third_party_settings: {  }
   field_event_paragraphs:
     type: paragraphs
-    weight: 11
+    weight: 12
     region: content
     settings:
       title: Paragraph
@@ -113,7 +122,7 @@ content:
           dialog_style: tiles
   field_event_partners:
     type: string_textfield
-    weight: 9
+    weight: 10
     region: content
     settings:
       size: 60
@@ -121,7 +130,7 @@ content:
     third_party_settings: {  }
   field_event_place:
     type: string_textfield
-    weight: 8
+    weight: 9
     region: content
     settings:
       size: 60
@@ -160,7 +169,7 @@ content:
     third_party_settings: {  }
   field_ticket_categories:
     type: paragraphs
-    weight: 5
+    weight: 6
     region: content
     settings:
       title: Paragraph
@@ -195,4 +204,3 @@ content:
     third_party_settings: {  }
 hidden:
   body: true
-  field_event_description: true

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -110,6 +111,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_event_title: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -174,6 +175,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_event_title: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -176,6 +177,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_event_title: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -160,6 +161,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_event_title: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -81,6 +82,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_event_title: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_partners
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -74,6 +75,7 @@ hidden:
   field_event_partners: true
   field_event_place: true
   field_event_state: true
+  field_event_title: true
   field_tags: true
   field_teaser_image: true
   field_ticket_categories: true

--- a/config/sync/field.field.eventinstance.default.field_event_title.yml
+++ b/config/sync/field.field.eventinstance.default.field_event_title.yml
@@ -1,0 +1,19 @@
+uuid: 197770b3-1721-4cd9-beba-307c6af0d0b3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventinstance.field_event_title
+    - recurring_events.eventinstance_type.default
+id: eventinstance.default.field_event_title
+field_name: field_event_title
+entity_type: eventinstance
+bundle: default
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.eventinstance.field_event_title.yml
+++ b/config/sync/field.storage.eventinstance.field_event_title.yml
@@ -1,0 +1,21 @@
+uuid: f93a6ae2-1b7f-4b3a-ba76-8b806303f06d
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+id: eventinstance.field_event_title
+field_name: field_event_title
+entity_type: eventinstance
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field_inheritance.field_inheritance.eventinstance_default_title.yml
+++ b/config/sync/field_inheritance.field_inheritance.eventinstance_default_title.yml
@@ -5,12 +5,12 @@ dependencies: {  }
 _core:
   default_config_hash: xP8VaY91nmnEknUt9pfeZr8IEUne06c2mr3Svb-VZhQ
 id: eventinstance_default_title
-label: Title
-type: inherit
+label: 'Event title'
+type: fallback
 sourceEntityType: eventseries
 sourceEntityBundle: default
 sourceField: title
 destinationEntityType: eventinstance
 destinationEntityBundle: default
-destinationField: null
+destinationField: field_event_title
 plugin: default_inheritance

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -64,7 +64,7 @@ function dpl_admin_menu_local_actions_alter(&$local_actions) : void {
  *
  * Preprocesses the output of a field in the "event_admin" view.
  * Altering the output to generate a unique indicator with a link to the
- * eventseries edit form.
+ * eventseries.
  *
  * {@inheritDoc}
  */
@@ -91,7 +91,7 @@ function dpl_admin_preprocess_views_view_field(array &$variables): void {
   // background image further down.
   $id = $output->__toString();
   $unique_hsl_value = ((intval($id) * 100) % 360);
-  $url = Url::fromRoute('entity.eventseries.edit_form', ['eventseries' => $id]);
+  $url = Url::fromRoute('entity.eventseries.canonical', ['eventseries' => $id]);
 
   $sanitized_id = htmlspecialchars($id, ENT_QUOTES, 'UTF-8');
   $markup = '<a class="dpl-admin__unique-indicator" style="background-color: hsl(' . $unique_hsl_value . ', 70%, 50%);" href="' . $url->toString() . '">' . $sanitized_id . '</a>';


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-266

#### Description

Currently it is not possible to override the title or description of event series on event instances. This is contrary to other fields.

To address this we do the following:

-Readd the description form element to event instances
-Add title field for event instances and update inheritance 

I also took the library of updating the series ID link to point to the display of the series instead of the edit form.

Please check out the commits for additional commentary.

#### Screenshot of the result

<img width="1392" alt="Monosnap Event - admin | DPL CMS | Logged in 2024-02-14 15-43-45" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/a06ced3b-dca0-4d87-b981-956e5abdb07c">

<img width="1392" alt="Monosnap | DPL CMS 2024-02-14 15-43-07" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/8cb04707-3b0a-4563-b0de-04e8b2705419">

#### Additional comments or questions

This is purely configuration. If you want to try it out I suggest the following:

- Create an eventseries with daily events over spans 3 days
- Edit event instance 2 to set a custom title
- Edit event instance 3 to set a custom title and description
- See that the custom event titles is reflected in the event admin
- Go to the event series page and see that the custom titles are shown in the list of events at the bottom