### PR TITLE
Add 'user registration info' paragraph type [DDFLSBP-451]

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.user_registration_information.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.user_registration_information.default.yml
@@ -1,0 +1,60 @@
+uuid: bfbd08e7-a2f7-4646-98a8-820ef80d9a5a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.user_registration_information.field_anchor
+    - field.field.paragraph.user_registration_information.field_body
+    - field.field.paragraph.user_registration_information.field_link_target
+    - field.field.paragraph.user_registration_information.field_registration_link
+    - field.field.paragraph.user_registration_information.field_title
+    - paragraphs.paragraphs_type.user_registration_information
+  module:
+    - link
+    - text
+id: paragraph.user_registration_information.default
+targetEntityType: paragraph
+bundle: user_registration_information
+mode: default
+content:
+  field_anchor:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_body:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_link_target:
+    type: options_select
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_registration_link:
+    type: link_default
+    weight: 3
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_form_display.paragraph.user_registration_information.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.user_registration_information.default.yml
@@ -5,7 +5,9 @@ dependencies:
   config:
     - field.field.paragraph.user_registration_information.field_anchor
     - field.field.paragraph.user_registration_information.field_body
+    - field.field.paragraph.user_registration_information.field_display_in_navigation
     - field.field.paragraph.user_registration_information.field_link_target
+    - field.field.paragraph.user_registration_information.field_navigation_title
     - field.field.paragraph.user_registration_information.field_registration_link
     - field.field.paragraph.user_registration_information.field_title
     - paragraphs.paragraphs_type.user_registration_information
@@ -27,21 +29,36 @@ content:
     third_party_settings: {  }
   field_body:
     type: text_textarea
-    weight: 2
+    weight: 4
     region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  field_display_in_navigation:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_link_target:
     type: options_select
-    weight: 4
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_navigation_title:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_registration_link:
     type: link_default
-    weight: 3
+    weight: 5
     region: content
     settings:
       placeholder_url: ''
@@ -49,7 +66,7 @@ content:
     third_party_settings: {  }
   field_title:
     type: string_textfield
-    weight: 1
+    weight: 3
     region: content
     settings:
       size: 60

--- a/config/sync/core.entity_view_display.paragraph.user_registration_information.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.user_registration_information.default.yml
@@ -60,4 +60,5 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.user_registration_information.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.user_registration_information.default.yml
@@ -5,7 +5,9 @@ dependencies:
   config:
     - field.field.paragraph.user_registration_information.field_anchor
     - field.field.paragraph.user_registration_information.field_body
+    - field.field.paragraph.user_registration_information.field_display_in_navigation
     - field.field.paragraph.user_registration_information.field_link_target
+    - field.field.paragraph.user_registration_information.field_navigation_title
     - field.field.paragraph.user_registration_information.field_registration_link
     - field.field.paragraph.user_registration_information.field_title
     - paragraphs.paragraphs_type.user_registration_information
@@ -33,12 +35,30 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_display_in_navigation:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 5
+    region: content
   field_link_target:
     type: list_default
     label: above
     settings: {  }
     third_party_settings: {  }
     weight: 4
+    region: content
+  field_navigation_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 6
     region: content
   field_registration_link:
     type: link

--- a/config/sync/core.entity_view_display.paragraph.user_registration_information.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.user_registration_information.default.yml
@@ -1,0 +1,63 @@
+uuid: f5d13363-cb70-4706-90e9-d56574245d7f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.user_registration_information.field_anchor
+    - field.field.paragraph.user_registration_information.field_body
+    - field.field.paragraph.user_registration_information.field_link_target
+    - field.field.paragraph.user_registration_information.field_registration_link
+    - field.field.paragraph.user_registration_information.field_title
+    - paragraphs.paragraphs_type.user_registration_information
+  module:
+    - link
+    - options
+    - text
+id: paragraph.user_registration_information.default
+targetEntityType: paragraph
+bundle: user_registration_information
+mode: default
+content:
+  field_anchor:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_link_target:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_registration_link:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.paragraph.user_registration_information.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.user_registration_information.preview.yml
@@ -6,7 +6,9 @@ dependencies:
     - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.user_registration_information.field_anchor
     - field.field.paragraph.user_registration_information.field_body
+    - field.field.paragraph.user_registration_information.field_display_in_navigation
     - field.field.paragraph.user_registration_information.field_link_target
+    - field.field.paragraph.user_registration_information.field_navigation_title
     - field.field.paragraph.user_registration_information.field_registration_link
     - field.field.paragraph.user_registration_information.field_title
     - paragraphs.paragraphs_type.user_registration_information
@@ -27,7 +29,9 @@ content:
     region: content
 hidden:
   field_anchor: true
+  field_display_in_navigation: true
   field_link_target: true
+  field_navigation_title: true
   field_registration_link: true
   field_title: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.user_registration_information.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.user_registration_information.preview.yml
@@ -30,3 +30,4 @@ hidden:
   field_link_target: true
   field_registration_link: true
   field_title: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.user_registration_information.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.user_registration_information.preview.yml
@@ -1,0 +1,32 @@
+uuid: 7539eae3-037c-4bc3-9198-345ccd11a847
+langcode: en
+status: false
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.user_registration_information.field_anchor
+    - field.field.paragraph.user_registration_information.field_body
+    - field.field.paragraph.user_registration_information.field_link_target
+    - field.field.paragraph.user_registration_information.field_registration_link
+    - field.field.paragraph.user_registration_information.field_title
+    - paragraphs.paragraphs_type.user_registration_information
+  module:
+    - text
+id: paragraph.user_registration_information.preview
+targetEntityType: paragraph
+bundle: user_registration_information
+mode: preview
+content:
+  field_body:
+    type: text_trimmed
+    label: above
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_anchor: true
+  field_link_target: true
+  field_registration_link: true
+  field_title: true

--- a/config/sync/field.field.paragraph.user_registration_information.field_anchor.yml
+++ b/config/sync/field.field.paragraph.user_registration_information.field_anchor.yml
@@ -1,0 +1,19 @@
+uuid: 58fcd297-df32-4745-93f1-7f4f457bfef4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_anchor
+    - paragraphs.paragraphs_type.user_registration_information
+id: paragraph.user_registration_information.field_anchor
+field_name: field_anchor
+entity_type: paragraph
+bundle: user_registration_information
+label: Anchor
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.user_registration_information.field_body.yml
+++ b/config/sync/field.field.paragraph.user_registration_information.field_body.yml
@@ -1,0 +1,24 @@
+uuid: b63c3957-bdee-4598-85a9-a88722fb0d61
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_body
+    - filter.format.basic
+    - paragraphs.paragraphs_type.user_registration_information
+  module:
+    - text
+id: paragraph.user_registration_information.field_body
+field_name: field_body
+entity_type: paragraph
+bundle: user_registration_information
+label: Body
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic
+field_type: text_long

--- a/config/sync/field.field.paragraph.user_registration_information.field_display_in_navigation.yml
+++ b/config/sync/field.field.paragraph.user_registration_information.field_display_in_navigation.yml
@@ -1,0 +1,23 @@
+uuid: 5462d843-0535-4e77-a513-a45b3c528b63
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_display_in_navigation
+    - paragraphs.paragraphs_type.user_registration_information
+id: paragraph.user_registration_information.field_display_in_navigation
+field_name: field_display_in_navigation
+entity_type: paragraph
+bundle: user_registration_information
+label: 'Display in navigation'
+description: 'Enable this option to display a button at the top of the page for easier navigation.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.paragraph.user_registration_information.field_link_target.yml
+++ b/config/sync/field.field.paragraph.user_registration_information.field_link_target.yml
@@ -1,0 +1,23 @@
+uuid: 452b69ba-be8d-40bc-8991-10048d6dc15d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link_target
+    - paragraphs.paragraphs_type.user_registration_information
+  module:
+    - options
+id: paragraph.user_registration_information.field_link_target
+field_name: field_link_target
+entity_type: paragraph
+bundle: user_registration_information
+label: 'Link target'
+description: 'Specify how a linked document should be opened when clicked by a user.'
+required: true
+translatable: false
+default_value:
+  -
+    value: _self
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.paragraph.user_registration_information.field_navigation_title.yml
+++ b/config/sync/field.field.paragraph.user_registration_information.field_navigation_title.yml
@@ -1,0 +1,19 @@
+uuid: fb311d37-5e0e-46e2-bced-0f65e4ac896b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_navigation_title
+    - paragraphs.paragraphs_type.user_registration_information
+id: paragraph.user_registration_information.field_navigation_title
+field_name: field_navigation_title
+entity_type: paragraph
+bundle: user_registration_information
+label: 'Navigation button title'
+description: 'If the navigation button title is left blank, it will automatically default to the paragraph title.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.user_registration_information.field_registration_link.yml
+++ b/config/sync/field.field.paragraph.user_registration_information.field_registration_link.yml
@@ -1,0 +1,23 @@
+uuid: 35d26822-e06f-4b39-b921-d1bffd5ebdab
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_registration_link
+    - paragraphs.paragraphs_type.user_registration_information
+  module:
+    - link
+id: paragraph.user_registration_information.field_registration_link
+field_name: field_registration_link
+entity_type: paragraph
+bundle: user_registration_information
+label: 'Registration Link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/config/sync/field.field.paragraph.user_registration_information.field_title.yml
+++ b/config/sync/field.field.paragraph.user_registration_information.field_title.yml
@@ -1,0 +1,19 @@
+uuid: baac1953-83d8-4e99-bd7f-176157928cc3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.user_registration_information
+id: paragraph.user_registration_information.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: user_registration_information
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.paragraph.field_anchor.yml
+++ b/config/sync/field.storage.paragraph.field_anchor.yml
@@ -1,0 +1,21 @@
+uuid: 1f81fae8-f9fb-403e-84b1-94f719310c66
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_anchor
+field_name: field_anchor
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_display_in_navigation.yml
+++ b/config/sync/field.storage.paragraph.field_display_in_navigation.yml
@@ -1,0 +1,18 @@
+uuid: 2c41909a-8ea2-455d-9000-d1d811763e3e
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_display_in_navigation
+field_name: field_display_in_navigation
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_link_target.yml
+++ b/config/sync/field.storage.paragraph.field_link_target.yml
@@ -1,0 +1,27 @@
+uuid: 7a4fdace-0cc4-4501-9226-dc2305ee98df
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_link_target
+field_name: field_link_target
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: _self
+      label: 'Open the linked document in the same window or tab (default)'
+    -
+      value: _blank
+      label: 'Open the linked document in a new window or tab'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_navigation_title.yml
+++ b/config/sync/field.storage.paragraph.field_navigation_title.yml
@@ -1,0 +1,21 @@
+uuid: 4f0073f0-d62f-40ac-9502-0730dac3c392
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_navigation_title
+field_name: field_navigation_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_registration_link.yml
+++ b/config/sync/field.storage.paragraph.field_registration_link.yml
@@ -1,0 +1,19 @@
+uuid: 251d674f-039b-4abc-b196-ca40dccb2b01
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_registration_link
+field_name: field_registration_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/paragraphs.paragraphs_type.user_registration_information.yml
+++ b/config/sync/paragraphs.paragraphs_type.user_registration_information.yml
@@ -1,0 +1,10 @@
+uuid: 0fb8be70-1cd1-4956-b01c-6e9eef601374
+langcode: en
+status: true
+dependencies: {  }
+id: user_registration_information
+label: 'User Registration Information'
+icon_uuid: null
+icon_default: null
+description: 'The "User Registration Information" paragraph type is used to display relevant information about the user registration process.'
+behavior_plugins: {  }

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\recurring_events\Entity\EventInstance;
 use Drupal\views\Plugin\views\field\EntityField;
 use Drupal\views\ViewExecutable;
@@ -192,5 +193,46 @@ function dpl_admin_form_alter(array &$form, FormStateInterface $form_state, stri
   if (in_array($form_id, ['eventinstance_default_add_form', 'eventinstance_default_edit_form'])) {
     _dpl_admin_form_alter_eventinstance($form, $form_state, $form_id);
 
+  }
+}
+
+/**
+ * Implements hook_field_widget_single_element_form_alter().
+ *
+ * Adjusts the visibility of field_navigation_title based on
+ * the state of field_display_in_navigation.
+ *
+ * @param array<mixed> &$element
+ *   The form element to be altered.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ * @param array<mixed> $context
+ *   An associative array containing contextual information about the field.
+ *
+ * @see hook_field_widget_single_element_form_alter()
+ */
+function dpl_admin_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context): void {
+
+  /** @var \Drupal\Core\Field\FieldItemListInterface $items */
+  $items = $context['items'];
+
+  // Retrieve the field definition from the context.
+  $field_definition = $items->getFieldDefinition();
+
+  // Check if the field definition is an instance of FieldConfig and matches
+  // the specific field ID.
+  if ($field_definition instanceof FieldConfig &&
+      $field_definition->id() === 'paragraph.user_registration_information.field_navigation_title') {
+
+    // Extract the delta value for the field content.
+    $field_content_delta = $element['value']['#field_parents'][1];
+
+    // Define states for the field element.
+    $element['value']['#states'] = [
+      // Conditionally hide the field based on the state of another field.
+      'invisible' => [
+        ':input[name="field_content[' . $field_content_delta . '][subform][field_display_in_navigation][value]"]' => ['checked' => FALSE],
+      ],
+    ];
   }
 }

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--user-registration-information.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--user-registration-information.html.twig
@@ -1,0 +1,19 @@
+
+{% set anchor_id = paragraph.field_anchor.value|default('')|escape %}
+
+<div{{ anchor_id ? ' id=' ~ anchor_id : '' }} class="user-registration-info">
+  <h2 class="user-registration-info__title">{{ content.field_title }}</h2>
+
+  <div class="user-registration-info__body">
+    {{ content.field_body }}
+  </div>
+
+  {% if paragraph.fields.field_registration_link %}
+    {% set url = paragraph.fields.field_registration_link.value[0]['uri'] %}
+    {% set title = paragraph.fields.field_registration_link.value[0]['title'] %}
+    {% set target = paragraph.field_link_target.value %}
+
+    {# Render the link #}
+    <a class="user-registration-info__link btn-primary btn-filled btn-large" href="{{ url }}" target="{{ target }}">{{ title }}</a>
+  {% endif %}
+</div>

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--user-registration-information.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--user-registration-information.html.twig
@@ -8,7 +8,7 @@
     {{ content.field_body }}
   </div>
 
-  {% if paragraph.fields.field_registration_link %}
+  {% if paragraph.fields.field_registration_link.value %}
     {% set url = paragraph.fields.field_registration_link.value[0]['uri'] %}
     {% set title = paragraph.fields.field_registration_link.value[0]['title'] %}
     {% set target = paragraph.field_link_target.value %}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-451

#### Description

* Introduces a new paragraph type called 'user registration info' and includes a template that goes along with it.
* This PR includes the implementation of basic styling. However, we are still waiting for the final design to be provided before making further adjustments.

#### Screenshot of the result

<img width="662" alt="Skærmbillede 2024-02-15 kl  10 48 18" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/105956/911bb0df-4a20-4e2c-ab60-88e03c750887">

![Skærmbillede 2024-02-15 kl  10 46 36](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/105956/c7243f24-75d2-4cda-acb2-e17f30715904)


"Display in navigation" disabled:

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/105956/3e435d65-be52-4065-8500-53a948d99c4e)

#### Additional comments or questions

*