### PR TITLE
Singular plural buttons distinction

### DIFF
--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -108,7 +108,13 @@ function dpl_react_apps_texts(): array {
         t('@count reservations were deleted', [], ['context' => 'Global']),
       ],
     ]),
-    'delete-reservation-modal-success-title' => t('You have deleted your reservation', [], ['context' => 'Global']),
+    'delete-reservation-modal-success-title' => json_encode([
+      'type' => 'plural',
+      'text' => [
+        t('Reservation deleted', [], ['context' => 'Global']),
+        t('Reservations deleted', [], ['context' => 'Global']),
+      ],
+    ]),
     'delete-reservation-modal-header' => json_encode([
       'type' => 'plural',
       'text' => [

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -219,7 +219,13 @@ function dpl_react_apps_texts(): array {
     'publizon-podcast' => t('Podcast', [], ['context' => 'Global']),
     'ready-for-loan-counter-label' => t('Ready', [], ['context' => 'Global']),
     'ready-for-loan' => t('Ready for pickup', [], ['context' => 'Global']),
-    'remove-all-reservations' => t('Remove reservations (@amount)', [], ['context' => 'Global']),
+    'remove-all-reservations' => json_encode([
+      'type' => 'plural',
+      'text' => [
+        t('Remove reservation (@amount)', [], ['context' => 'Global']),
+        t('Remove reservations (@amount)', [], ['context' => 'Global']),
+      ],
+    ]),
     'remove-from-favorites-aria-label' => t('remove @title from favorites list', [], ['context' => 'Global']),
     'renew-button' => t('Renew', [], ['context' => 'Renew loan']),
     'renew-cannot-be-renewed' => t('Cannot be renewed', [], ['context' => 'Renew loan']),


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-172

#### Description
In this PR we adjust two text string definitions for when the user is deleting their queued reservations from the dashboard. There was no distinction between singular and plural form depending on how many reservations were deleted before, which is now fixed. 

#### Screenshot of the result
-

#### Additional comments or questions
[Sibling PR](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/950)
