### PR TITLE
Add 'language selector' paragraph type [DDFLSBP-452]

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.language_selector.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.language_selector.default.yml
@@ -1,0 +1,36 @@
+uuid: 3b3559cb-e75d-47d1-868c-9782f4f447cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.language_selector.field_language_icon
+    - field.field.paragraph.language_selector.field_link_language
+    - image.style.flag_icon
+    - paragraphs.paragraphs_type.language_selector
+  module:
+    - image
+    - link
+id: paragraph.language_selector.default
+targetEntityType: paragraph
+bundle: language_selector
+mode: default
+content:
+  field_language_icon:
+    type: image_image
+    weight: 3
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: flag_icon
+    third_party_settings: {  }
+  field_link_language:
+    type: link_default
+    weight: 0
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_view_display.paragraph.language_selector.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.language_selector.default.yml
@@ -1,0 +1,38 @@
+uuid: de5cc9bb-52f6-492e-b0e2-e9be7140fe3b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.language_selector.field_language_icon
+    - field.field.paragraph.language_selector.field_link_language
+    - paragraphs.paragraphs_type.language_selector
+  module:
+    - image
+    - link
+id: paragraph.language_selector.default
+targetEntityType: paragraph
+bundle: language_selector
+mode: default
+content:
+  field_language_icon:
+    type: image_url
+    label: hidden
+    settings:
+      image_style: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_link_language:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/field.field.paragraph.language_selector.field_language_icon.yml
+++ b/config/sync/field.field.paragraph.language_selector.field_language_icon.yml
@@ -1,0 +1,38 @@
+uuid: 1109e308-69b8-4988-9b8c-de5e8ff63126
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_language_icon
+    - paragraphs.paragraphs_type.language_selector
+  module:
+    - image
+id: paragraph.language_selector.field_language_icon
+field_name: field_language_icon
+entity_type: paragraph
+bundle: language_selector
+label: 'Language icon'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/sync/field.field.paragraph.language_selector.field_link_language.yml
+++ b/config/sync/field.field.paragraph.language_selector.field_link_language.yml
@@ -1,0 +1,23 @@
+uuid: ef12242f-1f45-4fca-a5b3-c075cb6c0404
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link_language
+    - paragraphs.paragraphs_type.language_selector
+  module:
+    - link
+id: paragraph.language_selector.field_link_language
+field_name: field_link_language
+entity_type: paragraph
+bundle: language_selector
+label: 'Link to a different language'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 1
+field_type: link

--- a/config/sync/field.storage.paragraph.field_language_icon.yml
+++ b/config/sync/field.storage.paragraph.field_language_icon.yml
@@ -1,0 +1,30 @@
+uuid: 37bf31a8-b52e-4c96-906f-5f0b64dbee47
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+id: paragraph.field_language_icon
+field_name: field_language_icon
+entity_type: paragraph
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_link_language.yml
+++ b/config/sync/field.storage.paragraph.field_link_language.yml
@@ -1,0 +1,19 @@
+uuid: d7213e3b-e52c-436e-a6b5-bc3b29b22a60
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_link_language
+field_name: field_link_language
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/image.style.flag_icon.yml
+++ b/config/sync/image.style.flag_icon.yml
@@ -1,0 +1,15 @@
+uuid: 575eadf7-1b4d-4b80-bf4b-264fe644c632
+langcode: en
+status: true
+dependencies: {  }
+name: flag_icon
+label: 'Flag icon'
+effects:
+  060afe06-1bf3-4538-a28a-0372ca84b055:
+    uuid: 060afe06-1bf3-4538-a28a-0372ca84b055
+    id: image_scale
+    weight: 1
+    data:
+      width: 75
+      height: null
+      upscale: false

--- a/config/sync/paragraphs.paragraphs_type.language_selector.yml
+++ b/config/sync/paragraphs.paragraphs_type.language_selector.yml
@@ -1,0 +1,10 @@
+uuid: e5cc6336-ae2f-4546-a4d9-1bae0aa15ce6
+langcode: en
+status: true
+dependencies: {  }
+id: language_selector
+label: 'Language selector'
+icon_uuid: null
+icon_default: null
+description: 'Enables website visitors to choose their preferred language.'
+behavior_plugins: {  }

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--language-selector.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--language-selector.html.twig
@@ -1,0 +1,10 @@
+{% if content.field_link_language and content.field_language_icon.0 %}
+  {% set link_url = content.field_link_language[0]['#url'] %}
+  {% set link_title = content.field_link_language[0]['#title'] %}
+  {% set image_entity = paragraph.fields.field_language_icon.0 %}
+
+  <a class="language-selector link-with-icon " href="{{ link_url }}" title="{{ link_title }}">
+    {{ drupal_image(image_entity.target_id, 'flag_icon', {class: 'language-selector__icon'}) }}
+    {{ link_title }}
+  </a>
+{% endif %}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-452

#### Description

- Introduces a new paragraph type called 'language selector' and includes a template that goes along with it.
- This PR includes the implementation of basic styling. However, we are still waiting for the final design to be provided before making further adjustments.

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/105956/c7743349-8cfd-42c4-a23c-541a9e838fa7)

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/105956/9f046de1-44c8-454a-9b48-5da848bcea4d)

#### Additional comments or questions

*