### PR TITLE
DDFFORM 230

### DIFF
--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -232,10 +232,9 @@ function dpl_event_preprocess_eventinstance(array &$variables): void {
 
   $eventInstance = $variables['eventinstance'];
 
-  if ($eventInstance->hasField('field_ticket_categories')) {
-    $ticket_categories = $eventInstance->get('field_ticket_categories')->referencedEntities();
+  if ($eventInstance->hasField('event_ticket_categories')) {
+    $ticket_categories = $eventInstance->get('event_ticket_categories')->referencedEntities();
     $prices = [];
-
     // Collect prices from ticket categories.
     foreach ($ticket_categories as $category) {
       if ($category->hasField('field_ticket_category_price') && !$category->get('field_ticket_category_price')->isEmpty()) {

--- a/web/themes/custom/novel/novel.libraries.yml
+++ b/web/themes/custom/novel/novel.libraries.yml
@@ -4,7 +4,6 @@ base:
       assets/dpl-design-system/css/base.css: {}
       css/novel.css: {}
   js:
-    assets/dpl-design-system/js/header-toggle.js: {}
     assets/dpl-design-system/js/header-sticky.js: {}
     assets/dpl-design-system/js/header-state.js: {}
     assets/dpl-design-system/js/header-sidebar-nav-js.js: {}


### PR DESCRIPTION

- Fix incorrect ticket categories check on eventInstance field
- Remove unsused  header-toggle.js from novel.libraries.

#### Link to issue

[DDFFORM-230](https://reload.atlassian.net/browse/DDFFORM-230)

#### Description

This PR fixes a bug for printing out the ticket categories on eventListItem. 

Additionally there is a small fix, which is removing the header-toggle.js file from libraries, as it no longer exists. This should've been part of PR: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/769 but wasn't caught. 


Please test that you can get different variations of ticket prices on the /events page. 