### PR TITLE
fix icon path for links

### DIFF
--- a/web/themes/custom/novel/templates/paragraphs/paragraph--links.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--links.html.twig
@@ -2,7 +2,7 @@
   <a href="{{ link.href }}" target="{{ link.target }}"
      class="link-with-icon arrow__hover--right-small">
     <div class="link-with-icon__icon {{ link.linkIconClass }}">
-      <img class="invert" src="/{{ baseIconPath }}/{{ link.iconFolder }}/{{ link.iconFile }}.svg" alt="" />
+      <img class="invert" src="{{ baseIconPath }}/{{ link.iconFolder }}/{{ link.iconFile }}.svg" alt="" />
     </div>
     {{ link.linkText }}
     {{ source(baseIconPath ~ '/arrow-ui/icon-arrow-ui-small-right.svg') }}


### PR DESCRIPTION

- Remove extra '/' in img path.


#### Description

Icon was not showing on links 'cause of a double slash. 

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/0beb2309-374b-417a-af3c-cddf1ba8a6b8)
