### PR TITLE
Dont show event instance overview on event series page. DDFFORM-310

### DIFF
--- a/config/sync/core.entity_view_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.default.yml
@@ -30,15 +30,6 @@ targetEntityType: eventseries
 bundle: default
 mode: default
 content:
-  event_instances:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: card
-      link: false
-    third_party_settings: {  }
-    weight: 2
-    region: content
   field_categories:
     type: entity_reference_label
     label: hidden
@@ -161,6 +152,7 @@ hidden:
   consecutive_recurring_date: true
   custom_date: true
   daily_recurring_date: true
+  event_instances: true
   event_registration: true
   field_event_state: true
   monthly_recurring_date: true


### PR DESCRIPTION
Before this commit, we displayed the event instances on the bottom of the event series view, as a slider.
However - this confuses the users a lot, and the reason we use a slider is cause nothing else was ready at the time. We'll disable it for now, and find some more intuitive way of displaying it in the future.
