### PR TITLE
Ddfform 297 stack visning af event serier

### DIFF
--- a/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
@@ -36,10 +36,10 @@ content:
       timezone_override: ''
       date_format: 'Y-m-d\TH:i:s'
       separator: '-'
-      one_day: 'd F Y'
-      one_month: 'd - {d} F Y'
-      several_months: 'd F - {d} {F} Y'
-      several_years: 'd F Y - {d} {F} {Y}'
+      one_day: 'd. M Y'
+      one_month: 'd. - {d}. M Y'
+      several_months: 'd. M - {d}. {M} Y'
+      several_years: 'd. M Y - {d}. {M} {Y}'
     third_party_settings: {  }
     weight: 0
     region: content

--- a/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
@@ -1,0 +1,95 @@
+uuid: b72ccbb3-ffcb-4db2-ae04-80e3e9f5ac5c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.eventinstance.stacked_event
+    - field.field.eventinstance.default.field_categories
+    - field.field.eventinstance.default.field_event_address
+    - field.field.eventinstance.default.field_event_description
+    - field.field.eventinstance.default.field_event_image
+    - field.field.eventinstance.default.field_event_link
+    - field.field.eventinstance.default.field_event_paragraphs
+    - field.field.eventinstance.default.field_event_partners
+    - field.field.eventinstance.default.field_event_place
+    - field.field.eventinstance.default.field_event_state
+    - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_tags
+    - field.field.eventinstance.default.field_teaser_image
+    - field.field.eventinstance.default.field_teaser_text
+    - field.field.eventinstance.default.field_ticket_categories
+    - recurring_events.eventinstance_type.default
+  module:
+    - date_range_formatter
+    - link
+_core:
+  default_config_hash: lFFUFIZPBUZQjrIYYvP6U1hzVLGjKMl0DYK93zPM_80
+id: eventinstance.default.stacked_event
+targetEntityType: eventinstance
+bundle: default
+mode: stacked_event
+content:
+  date:
+    type: date_range_without_time
+    label: hidden
+    settings:
+      timezone_override: ''
+      date_format: 'Y-m-d\TH:i:s'
+      separator: '-'
+      one_day: 'd F Y'
+      one_month: 'd - {d} F Y'
+      several_months: 'd F - {d} {F} Y'
+      several_years: 'd F Y - {d} {F} {Y}'
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  event_addres:
+    type: address_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  event_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  body: true
+  description: true
+  event_address: true
+  event_categories: true
+  event_description: true
+  event_image: true
+  event_paragraphs: true
+  event_partners: true
+  event_place: true
+  event_state: true
+  event_tags: true
+  event_teaser_image: true
+  event_teaser_text: true
+  event_ticket_categories: true
+  field_categories: true
+  field_event_address: true
+  field_event_description: true
+  field_event_image: true
+  field_event_link: true
+  field_event_paragraphs: true
+  field_event_partners: true
+  field_event_place: true
+  field_event_state: true
+  field_event_title: true
+  field_tags: true
+  field_teaser_image: true
+  field_teaser_text: true
+  field_ticket_categories: true
+  search_api_excerpt: true
+  title: true

--- a/config/sync/core.entity_view_mode.eventinstance.stacked_event.yml
+++ b/config/sync/core.entity_view_mode.eventinstance.stacked_event.yml
@@ -1,0 +1,10 @@
+uuid: 56294afa-19bc-4e52-8076-b9fb2fbea43f
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+id: eventinstance.stacked_event
+label: 'Stacked event'
+targetEntityType: eventinstance
+cache: true

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -312,6 +312,39 @@ function dpl_event_preprocess_eventinstance__list_teaser(array &$variables): voi
 }
 
 /**
+ * Implements hook_preprocess_eventinstance__stacked_event().
+ *
+ * Preprocesses variables for the 'list_teaser' view mode of eventinstance.
+ * - Generating the URL for the full view of the event instance.
+ * - Processing start and end dates from the 'date' field and formatting them
+ *   in the site's timezone.
+ */
+function dpl_event_preprocess_eventinstance__stacked_event(array &$variables): void {
+  $eventInstance = $variables['eventinstance'];
+  /** @var \Drupal\Core\Datetime\DateFormatterInterface $date_formatter */
+  $date_formatter = \Drupal::service('date.formatter');
+
+  // Extract the event url.
+  $variables['eventinstance_url'] = Url::fromRoute('entity.eventinstance.canonical', ['eventinstance' => $eventInstance->id()])->toString();
+
+  // Extract start_time, end_time and datetime attributes.
+  if (!$eventInstance->get('date')->isEmpty()) {
+    $date_field = $eventInstance->get('date')->first();
+
+    $start_time = $date_field->start_date;
+    $end_time = $date_field->end_date;
+
+    if ($start_time instanceof DrupalDateTime) {
+      $variables['start_time'] = $date_formatter->format($start_time->getTimestamp(), 'custom', 'H:i');
+      $variables['datetime_attribute'] = $date_formatter->format($start_time->getTimestamp(), DATE_ATOM);
+    }
+    if ($end_time instanceof DrupalDateTime) {
+      $variables['end_time'] = $date_formatter->format($end_time->getTimestamp(), 'custom', 'H:i');
+    }
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  *
  * Altering the form for EDITING (not creating) an event series.

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -294,19 +294,19 @@ function dpl_event_preprocess_eventinstance__list_teaser(array &$variables): voi
     }
   }
 
-  // Extract start_date, end_date and datetime attributes.
+  // Extract start_time, end_time and datetime attributes.
   if (!$eventInstance->get('date')->isEmpty()) {
     $date_field = $eventInstance->get('date')->first();
 
-    $start_date = $date_field->start_date;
-    $end_date = $date_field->end_date;
+    $start_time = $date_field->start_date;
+    $end_time = $date_field->end_date;
 
-    if ($start_date instanceof DrupalDateTime) {
-      $variables['start_date'] = $date_formatter->format($start_date->getTimestamp(), 'custom', 'H:i');
-      $variables['datetime_attribute'] = $date_formatter->format($start_date->getTimestamp(), DATE_ATOM);
+    if ($start_time instanceof DrupalDateTime) {
+      $variables['start_time'] = $date_formatter->format($start_time->getTimestamp(), 'custom', 'H:i');
+      $variables['datetime_attribute'] = $date_formatter->format($start_time->getTimestamp(), DATE_ATOM);
     }
-    if ($end_date instanceof DrupalDateTime) {
-      $variables['end_date'] = $date_formatter->format($end_date->getTimestamp(), 'custom', 'H:i');
+    if ($end_time instanceof DrupalDateTime) {
+      $variables['end_time'] = $date_formatter->format($end_time->getTimestamp(), 'custom', 'H:i');
     }
   }
 }

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\recurring_events\Entity\EventInstance;
 use Spatie\Color\Hex;
 use Spatie\Color\Hsl;
 use function Safe\file_get_contents;
@@ -274,5 +275,32 @@ function novel_theme_suggestions_select_alter(array &$suggestions, array $variab
   }
   else {
     $suggestions[] = 'select__single';
+  }
+}
+
+/**
+ *
+ */
+function novel_preprocess_views_view_unformatted(&$variables) {
+  $rows = &$variables['rows'];
+
+  foreach ($rows as $index => &$row) {
+    if (isset($row['content']['#eventinstance'])) {
+      /** @var \Drupal\recurring_events\Entity\EventInstance $eventInstance */
+      $eventInstance = $row['content']['#eventinstance'];
+
+      if ($eventInstance instanceof EventInstance) {
+        $eventSeriesId = $eventInstance->getEventSeries()->id();
+
+        // Check if not the first row and if event_series_id matches the previous row.
+        $isStacked = $index > 0 && $eventSeriesId == $rows[$index - 1]['content']['#eventinstance']->getEventSeries()->id();
+
+        $row['isStacked'] = $isStacked;
+
+        if ($isStacked) {
+          $row['content']['#view_mode'] = 'stacked_event';
+        }
+      }
+    }
   }
 }

--- a/web/themes/custom/novel/templates/views/eventinstance--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/views/eventinstance--list-teaser.html.twig
@@ -20,7 +20,7 @@
     </div>
     <div class="event-list-item__schedule">
       <time class="event-list-item__time" datetime="{{ datetime_attribute }}">
-        {{ start_date }} - {{ end_date }}
+        {{ start_time }} - {{ end_time }}
       </time>
         {% if ticket_price_display is defined %}
         <p class="event-list-item__pricing">{{ ticket_price_display }}</p>

--- a/web/themes/custom/novel/templates/views/eventinstance--stacked-event.html.twig
+++ b/web/themes/custom/novel/templates/views/eventinstance--stacked-event.html.twig
@@ -1,0 +1,8 @@
+
+<a href="{{ eventinstance_url }}" class="event-list-item-stacked arrow__hover--right-small">
+  <time class="event-list-item-stacked__content" datetime="{{ datetime_attribute }}">
+    <span class="event-list-item-stacked__date">{{ content.date }}</span>
+    <span class="event-list-item-stacked__time">{{ start_time }} - {{ end_time }}</span>
+  </time>
+  {{ source(directory ~ '/assets/dpl-design-system/icons/arrow-ui/icon-arrow-ui-small-right.svg') }}
+</a>

--- a/web/themes/custom/novel/templates/views/views-view-unformatted--events.html.twig
+++ b/web/themes/custom/novel/templates/views/views-view-unformatted--events.html.twig
@@ -1,6 +1,6 @@
 <ul class="event-list">
   {% for row in rows %}
-    <li class="event-list__item">
+    <li class="event-list__item{{ row.isStacked ? ' event-list__item--stacked' }}">
       {{ row.content }}
     </li>
   {% endfor %}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-297

#### Description
This Pull Request introduces a new display mode named Stacked Event along with the logic. When multiple events from the same series occur consecutively without any intervening events, we aim to avoid repetitive display of the teaser card. Therefore, we have implemented a 'Stacked Event' link that will only show the date and time of these events.


#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/387f1488-de89-4cdb-b11d-439d439d7335)