### PR TITLE
Remove 'Link Text' from Hero Link

### DIFF
--- a/config/sync/field.field.paragraph.hero.field_hero_link.yml
+++ b/config/sync/field.field.paragraph.hero.field_hero_link.yml
@@ -18,6 +18,6 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  title: 1
+  title: 0
   link_type: 17
 field_type: link


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-281

#### Description
This pull request removes the link text within the hero form. Currently, all hero content is encapsulated within an 'a' tag. Given this structure, the existing 'Link Text' is redundant and has not been utilized in any functional capacity.


#### Screenshot of the result
<img width="1298" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/b6e5904e-12df-4ae3-88ec-2bd304827432">
