### PR TITLE
Reenable config ignore

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -1,0 +1,22 @@
+_core:
+  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
+ignored_config_entities:
+  - dpl_dashboard.settings
+  - dpl_favorites_list.settings
+  - dpl_fbs.settings
+  - dpl_fees.settings
+  - dpl_instant_loan.settings
+  - dpl_library_agency.general_settings
+  - dpl_library_agency.general_settings.branches
+  - dpl_loans.settings
+  - dpl_patron_menu.settings
+  - dpl_patron_page.settings
+  - dpl_patron_redirect.settings
+  - dpl_patron_reg.settings
+  - dpl_publizon.settings
+  - dpl_recommender.settings
+  - dpl_reservation_list.settings
+  - dpl_url_proxy.settings
+  - novel.settings
+  - openid_connect.settings.adgangsplatformen
+  - system.site

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -9,6 +9,7 @@ module:
   breakpoint: 0
   ckeditor5: 0
   config_filter: 0
+  config_ignore: 0
   crop: 0
   customerror: 0
   date_range_formatter: 0

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -109,7 +109,6 @@ permissions:
   - 'edit own video media'
   - 'edit terms in categories'
   - 'edit terms in tags'
-  - 'link to any page'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'revert all revisions'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -133,7 +133,6 @@ permissions:
   - 'edit terms in tags'
   - 'edit themes novel'
   - 'edit users by role'
-  - 'link to any page'
   - 'revert all eventinstance revisions'
   - 'revert all eventseries revisions'
   - 'revert all revisions'

--- a/config/sync/user.role.mediator.yml
+++ b/config/sync/user.role.mediator.yml
@@ -90,7 +90,6 @@ permissions:
   - 'edit own page content'
   - 'edit own video media'
   - 'edit terms in tags'
-  - 'link to any page'
   - 'schedule publishing of eventseries'
   - 'schedule publishing of nodes'
   - 'update any media'


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-361

#### Description

To allow local administrators to modify configuration and avoid this
from being overridden we use the config_ignore module.

As we do not need to handle configuration from arbitrary modules yet
we can use config_ignore with a list of configuration entries that
should be ignored during config import.

These settings are a result of:
- Logging in as a local editor
- Updating all the elements under/admin/config that this role has
  access to + OpenID Adgangsplatformen config
- Exporting configuration
- Copy/pasting the configuration entries into the Config Ignore
  settings
- Exporting configuration again

Note that this PR also includes a small fix to the permission overall in [32b5b34](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/806/commits/32b5b344ffaed2f928d6f7371f2e7170a298c328).
