### PR TITLE
Update items per page in events view + Add 12 more events to "Fars Legestue" event series

### DIFF
--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -101,7 +101,7 @@ display:
         type: infinite_scroll
         options:
           offset: 0
-          items_per_page: 10
+          items_per_page: 25
           total_pages: null
           id: 0
           tags:

--- a/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    482892d1-7295-4cf3-92e1-dce9222fd1fc: eventinstance
+    ae94c417-7d1f-46ca-8b13-01442e91c1cf: eventinstance
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f: media
 default:
@@ -100,7 +100,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: 482892d1-7295-4cf3-92e1-dce9222fd1fc
+      entity: ae94c417-7d1f-46ca-8b13-01442e91c1cf
   field_categories:
     -
       entity: 0fa7245a-3434-4d96-9793-a1848a22d37a

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    35cc4d57-5254-4bfd-aa7a-4590eba63ea3: eventinstance
+    acbba437-f1d9-492c-9082-59fca80b888b: eventinstance
     f457c4c2-dc28-45cd-9b6e-fda4248d9d45: taxonomy_term
     618e176a-a45a-4c36-a197-664230aa0a34: media
     dc33677f-8894-4717-b34b-d985f6ad875f: media
@@ -108,7 +108,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: 35cc4d57-5254-4bfd-aa7a-4590eba63ea3
+      entity: acbba437-f1d9-492c-9082-59fca80b888b
   field_categories:
     -
       entity: f457c4c2-dc28-45cd-9b6e-fda4248d9d45

--- a/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
@@ -5,18 +5,30 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    faa80653-b087-46d4-935f-e581ca44dd18: eventinstance
-    14aaf062-5b18-43b1-b97e-d89b35a0483b: eventinstance
-    65a11d38-baf8-4d9c-ad03-3c2867cc8dac: eventinstance
-    6a0ebbde-094b-4e5b-90e7-0a6caf112b23: eventinstance
-    a1df5c72-6812-4f76-af23-cf33d9375842: eventinstance
-    78840f3d-47bc-4b65-afcb-5d183fb3d2a7: eventinstance
-    6eb4d45f-5e08-45e7-992c-d18924390053: eventinstance
-    f5265211-775d-48ba-a7ef-e8889a1c70e5: eventinstance
-    1e613f60-0c6f-45bf-9026-5c6fabf578f0: eventinstance
-    9bc30f11-533d-45f6-9daf-e0ea574e0af7: eventinstance
-    c08b9fb9-9de4-4f15-89ad-6cd8cc674429: eventinstance
-    7e10af9e-b32e-4ac1-9e83-afb5d9b2a9a5: eventinstance
+    869d3270-4995-4311-973e-e99378425f33: eventinstance
+    bbc6c915-9bb3-4f3b-ade5-7be3c0fdba9e: eventinstance
+    922ad75e-7181-4f84-9119-14d20f507444: eventinstance
+    7ed49ae8-9002-4c9e-8f4d-a74d8ed5fa6c: eventinstance
+    260d3eb7-a1b4-4212-966b-93bc3b3709f5: eventinstance
+    7b4b8f4b-38ed-4d92-b91a-7ce31a0e7e47: eventinstance
+    f46ef444-e9a0-4359-b82a-3289ba751478: eventinstance
+    86047d7d-197c-4ce0-8ef0-333a122b4498: eventinstance
+    83bc8e33-eff0-4ee4-95e0-57b2120dd51c: eventinstance
+    ed09faca-008e-43ef-8110-4a615b57399a: eventinstance
+    5bfb8ecc-e3a4-46e5-9804-3d2cf16aefc8: eventinstance
+    2deba5f7-99e9-4891-a1df-f14f8278a5f3: eventinstance
+    a0cfd98c-b735-406c-adf5-5d3919bb52b6: eventinstance
+    5f360943-51b0-4077-8857-2c232195b89c: eventinstance
+    d9fe630b-4ac8-451e-930c-2031eeda1106: eventinstance
+    151255f6-2a76-4713-920c-808d539dc1d0: eventinstance
+    9f77b09a-2ae0-40e5-995f-7764c2a806ae: eventinstance
+    3e4cc749-feb5-4403-b54c-578aba06d178: eventinstance
+    9c47302c-616c-4485-8ddf-d6e4b50cbb4e: eventinstance
+    df29f7ee-7d97-4a12-b449-a8663e5cd45f: eventinstance
+    b946a15f-bb6b-41d5-8738-1f7e97ecdf46: eventinstance
+    536b3e87-9349-4b66-b8c7-b29348b32a3f: eventinstance
+    e94b10de-0a7e-4d87-ab43-c85b23bb4830: eventinstance
+    87bf37ff-3bd0-4219-8035-376b875b5932: eventinstance
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     ca329ad9-5a1c-4f55-b8a9-a60843b66466: media
     e4ce7616-976d-43fc-aed2-a01c42b67db9: media
@@ -58,8 +70,8 @@ default:
       duration_or_end_time: duration
   weekly_recurring_date:
     -
-      value: '2024-01-01T09:52:58'
-      end_value: '2030-01-01T09:52:58'
+      value: '2024-01-01T14:46:12'
+      end_value: '2030-01-01T14:46:12'
       time: '08:00 am'
       duration: 900
       end_time: '08:00 am'
@@ -67,8 +79,8 @@ default:
       days: monday
   monthly_recurring_date:
     -
-      value: '2034-01-01T09:52:58'
-      end_value: '2035-01-01T09:52:58'
+      value: '2034-01-01T14:46:12'
+      end_value: '2036-01-01T14:46:12'
       time: '10:00 am'
       duration: 18000
       end_time: '08:00 am'
@@ -114,29 +126,53 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: faa80653-b087-46d4-935f-e581ca44dd18
+      entity: 869d3270-4995-4311-973e-e99378425f33
     -
-      entity: 14aaf062-5b18-43b1-b97e-d89b35a0483b
+      entity: bbc6c915-9bb3-4f3b-ade5-7be3c0fdba9e
     -
-      entity: 65a11d38-baf8-4d9c-ad03-3c2867cc8dac
+      entity: 922ad75e-7181-4f84-9119-14d20f507444
     -
-      entity: 6a0ebbde-094b-4e5b-90e7-0a6caf112b23
+      entity: 7ed49ae8-9002-4c9e-8f4d-a74d8ed5fa6c
     -
-      entity: a1df5c72-6812-4f76-af23-cf33d9375842
+      entity: 260d3eb7-a1b4-4212-966b-93bc3b3709f5
     -
-      entity: 78840f3d-47bc-4b65-afcb-5d183fb3d2a7
+      entity: 7b4b8f4b-38ed-4d92-b91a-7ce31a0e7e47
     -
-      entity: 6eb4d45f-5e08-45e7-992c-d18924390053
+      entity: f46ef444-e9a0-4359-b82a-3289ba751478
     -
-      entity: f5265211-775d-48ba-a7ef-e8889a1c70e5
+      entity: 86047d7d-197c-4ce0-8ef0-333a122b4498
     -
-      entity: 1e613f60-0c6f-45bf-9026-5c6fabf578f0
+      entity: 83bc8e33-eff0-4ee4-95e0-57b2120dd51c
     -
-      entity: 9bc30f11-533d-45f6-9daf-e0ea574e0af7
+      entity: ed09faca-008e-43ef-8110-4a615b57399a
     -
-      entity: c08b9fb9-9de4-4f15-89ad-6cd8cc674429
+      entity: 5bfb8ecc-e3a4-46e5-9804-3d2cf16aefc8
     -
-      entity: 7e10af9e-b32e-4ac1-9e83-afb5d9b2a9a5
+      entity: 2deba5f7-99e9-4891-a1df-f14f8278a5f3
+    -
+      entity: a0cfd98c-b735-406c-adf5-5d3919bb52b6
+    -
+      entity: 5f360943-51b0-4077-8857-2c232195b89c
+    -
+      entity: d9fe630b-4ac8-451e-930c-2031eeda1106
+    -
+      entity: 151255f6-2a76-4713-920c-808d539dc1d0
+    -
+      entity: 9f77b09a-2ae0-40e5-995f-7764c2a806ae
+    -
+      entity: 3e4cc749-feb5-4403-b54c-578aba06d178
+    -
+      entity: 9c47302c-616c-4485-8ddf-d6e4b50cbb4e
+    -
+      entity: df29f7ee-7d97-4a12-b449-a8663e5cd45f
+    -
+      entity: b946a15f-bb6b-41d5-8738-1f7e97ecdf46
+    -
+      entity: 536b3e87-9349-4b66-b8c7-b29348b32a3f
+    -
+      entity: e94b10de-0a7e-4d87-ab43-c85b23bb4830
+    -
+      entity: 87bf37ff-3bd0-4219-8035-376b875b5932
   field_categories:
     -
       entity: 0fa7245a-3434-4d96-9793-a1848a22d37a

--- a/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    da840471-0db5-40cc-bc68-19aad3b08aec: eventinstance
+    db8ec0b7-2514-4e69-ba59-27b9bef7c86a: eventinstance
     e539b26b-2992-406b-accf-03e549522c0d: taxonomy_term
     d6d67fd2-775c-46e7-a1bf-6af46290a5c8: media
     4704c566-afc2-4131-ab81-3d636f2451bf: taxonomy_term
@@ -101,7 +101,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: da840471-0db5-40cc-bc68-19aad3b08aec
+      entity: db8ec0b7-2514-4e69-ba59-27b9bef7c86a
   field_categories:
     -
       entity: e539b26b-2992-406b-accf-03e549522c0d

--- a/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
+++ b/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
@@ -5,6 +5,7 @@ _meta:
   bundle: article
   default_langcode: da
   depends:
+    e00e1460-169e-468d-9835-d664f06d0969: file
     92033694-15ac-4d9e-b275-ddfd18e48d9f: taxonomy_term
     aba3cea8-cee5-42c1-a152-e30c2ab135e2: media
     d97a25fd-a6ae-48b9-9a1a-7aec5372688e: media
@@ -45,6 +46,13 @@ default:
   entity_clone_template_active:
     -
       value: false
+  entity_clone_template_image:
+    -
+      entity: e00e1460-169e-468d-9835-d664f06d0969
+      alt: ''
+      title: ''
+      width: 640
+      height: 443
   metatag:
     -
       tag: meta

--- a/web/modules/custom/dpl_example_content/content/node/982e0d87-f6b8-4b84-8de8-c8c8bcfef557.yml
+++ b/web/modules/custom/dpl_example_content/content/node/982e0d87-f6b8-4b84-8de8-c8c8bcfef557.yml
@@ -5,6 +5,7 @@ _meta:
   bundle: article
   default_langcode: da
   depends:
+    e00e1460-169e-468d-9835-d664f06d0969: file
     eef50571-39dc-461a-96ff-b6b7180ade61: media
     d97a25fd-a6ae-48b9-9a1a-7aec5372688e: media
     7b9d1894-7f9a-4f96-a7dc-efa3af5fc902: media
@@ -38,6 +39,13 @@ default:
   entity_clone_template_active:
     -
       value: false
+  entity_clone_template_image:
+    -
+      entity: e00e1460-169e-468d-9835-d664f06d0969
+      alt: ''
+      title: ''
+      width: 640
+      height: 443
   metatag:
     -
       tag: meta

--- a/web/modules/custom/dpl_example_content/content/node/9cfd15df-32b4-4af9-b2da-56b039b5bf6b.yml
+++ b/web/modules/custom/dpl_example_content/content/node/9cfd15df-32b4-4af9-b2da-56b039b5bf6b.yml
@@ -4,6 +4,8 @@ _meta:
   uuid: 9cfd15df-32b4-4af9-b2da-56b039b5bf6b
   bundle: article
   default_langcode: da
+  depends:
+    e00e1460-169e-468d-9835-d664f06d0969: file
 default:
   revision_uid:
     -
@@ -32,6 +34,13 @@ default:
   entity_clone_template_active:
     -
       value: false
+  entity_clone_template_image:
+    -
+      entity: e00e1460-169e-468d-9835-d664f06d0969
+      alt: ''
+      title: ''
+      width: 640
+      height: 443
   metatag:
     -
       tag: meta

--- a/web/modules/custom/dpl_example_content/content/node/fd774222-4b22-4803-ae45-2d4e80d84fac.yml
+++ b/web/modules/custom/dpl_example_content/content/node/fd774222-4b22-4803-ae45-2d4e80d84fac.yml
@@ -5,6 +5,7 @@ _meta:
   bundle: page
   default_langcode: da
   depends:
+    e00e1460-169e-468d-9835-d664f06d0969: file
     92033694-15ac-4d9e-b275-ddfd18e48d9f: taxonomy_term
     65432ee1-43f1-4130-9565-5683467d4b5a: media
     fb8b4d62-de14-4620-9ca1-be60cab74a65: eventseries
@@ -42,6 +43,13 @@ default:
   entity_clone_template_active:
     -
       value: false
+  entity_clone_template_image:
+    -
+      entity: e00e1460-169e-468d-9835-d664f06d0969
+      alt: ''
+      title: ''
+      width: 640
+      height: 443
   metatag:
     -
       tag: meta
@@ -67,6 +75,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_hero_categories:
             -
               entity: 92033694-15ac-4d9e-b275-ddfd18e48d9f
@@ -109,6 +120,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_body:
             -
               value: '<h2>Om Os</h2><p><br>Biblioteket er dit lokale center for viden, kultur og samfund. Vi tilbyder en bred vifte af bøger, e-bøger, lydbøger, tidsskrifter og mere. Kom og oplev vores studieområder, computerfaciliteter, og et varieret program af begivenheder og workshops</p>'
@@ -131,6 +145,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_body:
             -
               value: '<p><strong>Nyheder og Begivenheder</strong></p>'
@@ -153,6 +170,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_nav_spots_content:
             -
               entity: fb8b4d62-de14-4620-9ca1-be60cab74a65
@@ -176,6 +196,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_body:
             -
               value: '<p><strong>FAQ</strong></p>'
@@ -198,6 +221,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_accordion_description:
             -
               value: '<p>For at blive medlem af biblioteket skal du besøge biblioteket personligt eller oprette dig online via vores hjemmeside. Du skal medbringe gyldig identifikation og eventuelt bevis på din adresse.</p>'
@@ -224,6 +250,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_accordion_description:
             -
               value: '<p>Ja, du kan forny dine lånte materialer online ved at logge ind på din brugerkonto på vores hjemmeside. Der er dog visse begrænsninger for, hvor mange gange et materiale kan fornyes.</p>'
@@ -250,6 +279,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_accordion_description:
             -
               value: '<p>Du kan reservere bøger og andre materialer via vores online katalog. Når materialet er tilgængeligt, vil du modtage en notifikation.</p>'
@@ -276,6 +308,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_accordion_description:
             -
               value: '<p>Bøder for for sen aflevering varierer afhængigt af materialetypen. Du kan finde en detaljeret liste over bøder på vores hjemmeside.</p>'
@@ -302,6 +337,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_filter_content_types:
             -
               target_id: article
@@ -326,6 +364,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_content_references:
             -
               entity: f6aafa27-a538-44a3-ae1f-02f8efbfb068


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-63

#### Description
This pull request is to fulfill the wish to show 25 events on the `/events` list page: To still be able to show our pager at the bottom of the list, we have added more instances to "Fars Legestue"

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/eab560a8-5b79-41c7-aaf5-f5addc34981d)
