### PR TITLE
Add patch for entity_clone, that allows redirect to edit. DDFFORM-373

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -258,6 +258,9 @@
                 "3405253: Update the FieldType category for clarity": "https://git.drupalcode.org/project/dynamic_entity_reference/-/commit/3f048d296f671906d15b0cdfbbadbea38f5f3c8b.patch",
                 "3396393: Entity with a dynamic entity reference field can't be cloned using entity_clone": "https://www.drupal.org/files/issues/2023-10-24/3396393-2.patch"
             },
+            "drupal/entity_clone": {
+                "2708731: Allow redirect to edit form after cloning": "https://www.drupal.org/files/issues/2022-11-15/improve-workflow-of-cloned-entity-2708731-39.patch"
+            },
             "drupal/field_inheritance": {
                 "3330386: field_inheritance_form_alter should enforce module permissions": "https://git.drupalcode.org/project/field_inheritance/-/commit/bc3d26cdce8c09d5b6275fc126e35bc7e239c7d1.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82528db8a5aeaa836faa0d0edb60ccde",
+    "content-hash": "41eb23920f1cb30a1b5c6f9899fab976",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/entity_clone.settings.yml
+++ b/config/sync/entity_clone.settings.yml
@@ -51,5 +51,32 @@ form_settings:
     default_value: false
     disable: false
     hidden: false
+form_settings_after_clone:
+  taxonomy_term:
+    redirect_to: edit-form
+  file:
+    redirect_to: edit-form
+  node:
+    redirect_to: edit-form
+  user:
+    redirect_to: edit-form
+  menu_link_content:
+    redirect_to: edit-form
+  crop:
+    redirect_to: edit-form
+  job_schedule:
+    redirect_to: edit-form
+  media:
+    redirect_to: edit-form
+  path_alias:
+    redirect_to: edit-form
+  eventseries:
+    redirect_to: edit-form
+  eventinstance:
+    redirect_to: edit-form
+  search_api_task:
+    redirect_to: edit-form
+  paragraph:
+    redirect_to: edit-form
 no_suffix: false
 take_ownership: true


### PR DESCRIPTION
When cloning / using a entity template, the user is redirected to the view of the content.
This is pretty confusing, especially in the context of the using templates to create new content.
I've found a patch that adds it as a module option, to set the redirect to the edit page instead of canoncial.

https://www.drupal.org/project/entity_clone/issues/2708731#comment-13224285

<img width="791" alt="Screenshot 2024-02-26 at 16 40 24" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/01e92ef2-a605-48a1-bfd4-f64e0eb7f94e">
