### PR TITLE
WIP: Add dynamic toggle for alt-text on image

### DIFF
--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.image.field_byline
+    - field.field.media.image.field_is_decorative
     - field.field.media.image.field_media_image
     - image.style.focal_point_preview
     - media.type.image
@@ -22,9 +23,16 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_is_decorative:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_media_image:
     type: image_focal_point
-    weight: 2
+    weight: 3
     region: content
     settings:
       progress_indicator: throbber

--- a/config/sync/core.entity_form_display.media.image.media_library.yml
+++ b/config/sync/core.entity_form_display.media.image.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.image.field_byline
+    - field.field.media.image.field_is_decorative
     - field.field.media.image.field_media_image
     - image.style.focal_point_preview
     - media.type.image
@@ -28,6 +29,7 @@ content:
 hidden:
   created: true
   field_byline: true
+  field_is_decorative: true
   langcode: true
   name: true
   publish_on: true

--- a/config/sync/core.entity_view_display.media.image.default.yml
+++ b/config/sync/core.entity_view_display.media.image.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.image.field_byline
+    - field.field.media.image.field_is_decorative
     - field.field.media.image.field_media_image
     - image.style.paragraph_wide
     - media.type.image
@@ -21,6 +22,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_is_decorative:
+    type: boolean
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 2
     region: content
   field_media_image:
     type: image

--- a/config/sync/core.entity_view_display.media.image.hero_wide.yml
+++ b/config/sync/core.entity_view_display.media.image.hero_wide.yml
@@ -4,6 +4,8 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.hero_wide
+    - field.field.media.image.field_byline
+    - field.field.media.image.field_is_decorative
     - field.field.media.image.field_media_image
     - image.style.hero_wide
     - media.type.image
@@ -28,6 +30,7 @@ content:
 hidden:
   created: true
   field_byline: true
+  field_is_decorative: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.media.image.media_library.yml
+++ b/config/sync/core.entity_view_display.media.image.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.media_library
     - field.field.media.image.field_byline
+    - field.field.media.image.field_is_decorative
     - field.field.media.image.field_media_image
     - image.style.media_library
     - media.type.image
@@ -36,6 +37,7 @@ content:
     region: content
 hidden:
   created: true
+  field_is_decorative: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.media.image.paragraph_squared.yml
+++ b/config/sync/core.entity_view_display.media.image.paragraph_squared.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.paragraph_squared
     - field.field.media.image.field_byline
+    - field.field.media.image.field_is_decorative
     - field.field.media.image.field_media_image
     - image.style.paragraph_squared
     - media.type.image
@@ -36,6 +37,7 @@ content:
     region: content
 hidden:
   created: true
+  field_is_decorative: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.media.image.paragraph_wide.yml
+++ b/config/sync/core.entity_view_display.media.image.paragraph_wide.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.paragraph_wide
     - field.field.media.image.field_byline
+    - field.field.media.image.field_is_decorative
     - field.field.media.image.field_media_image
     - image.style.paragraph_wide
     - media.type.image
@@ -36,6 +37,7 @@ content:
     region: content
 hidden:
   created: true
+  field_is_decorative: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/config/sync/field.field.media.image.field_is_decorative.yml
+++ b/config/sync/field.field.media.image.field_is_decorative.yml
@@ -1,0 +1,21 @@
+uuid: 04ddca84-3233-4f9b-b8a0-83ace224b0da
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_is_decorative
+    - media.type.image
+id: media.image.field_is_decorative
+field_name: field_is_decorative
+entity_type: media
+bundle: image
+label: 'Is decorative'
+description: 'If the image is only for decorative purposes, it should not have an alt text. Otherwise, the image should have an alt text that describes the image for SEO and screen readers'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'Image is decorative'
+  off_label: 'Image is not decorative'
+field_type: boolean

--- a/config/sync/field.storage.media.field_is_decorative.yml
+++ b/config/sync/field.storage.media.field_is_decorative.yml
@@ -1,0 +1,18 @@
+uuid: 3cbbfc5b-5a86-470d-8f9b-1262d7b3bf6d
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_is_decorative
+field_name: field_is_decorative
+entity_type: media
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/da/views.view.files.yml
+++ b/config/sync/language/da/views.view.files.yml
@@ -26,6 +26,8 @@ display:
           label: Ændringsdato
         count:
           label: 'Brugt i'
+          alter:
+            path: 'admin/content/files/usage/{{ fid }}'
       pager:
         options:
           tags:

--- a/web/modules/custom/dpl_admin/assets/toggle-alt-text.js
+++ b/web/modules/custom/dpl_admin/assets/toggle-alt-text.js
@@ -1,0 +1,18 @@
+const toggle = document.getElementById("edit-field-is-decorative-value");
+const imageAlt = document.getElementById("edit-field-media-image-0-alt");
+const imageAltField = document.querySelector(
+  ".form-item--field-media-image-0-alt"
+);
+
+const updateAltFieldState = (isChecked) => {
+  imageAltField.style.display = isChecked ? "none" : "block";
+  imageAlt.toggleAttribute("required", !isChecked);
+  imageAlt.toggleAttribute("aria-required", !isChecked);
+};
+
+// Set initial states based on the toggle's initial state
+updateAltFieldState(toggle.checked);
+
+toggle.addEventListener("change", () => {
+  updateAltFieldState(toggle.checked);
+});

--- a/web/modules/custom/dpl_admin/dpl_admin.libraries.yml
+++ b/web/modules/custom/dpl_admin/dpl_admin.libraries.yml
@@ -9,3 +9,6 @@ frontend:
   css:
     theme:
       assets/dpl_frontend.css: {}
+toggle-alt-text:
+  js:
+    assets/toggle-alt-text.js: {}

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -227,6 +227,12 @@ function dpl_admin_form_alter(array &$form, FormStateInterface $form_state, stri
   if (in_array($form_id, ['node_page_form', 'node_page_edit_form'])) {
     _dpl_admin_form_alter_node_page($form, $form_state, $form_id);
   }
+
+  if ($form_id == 'media_image_edit_form') {
+    // This should also be attached to the media library upload form.
+    // But this not work: media-library-add-form-upload
+    $form['#attached']['library'][] = 'dpl_admin/toggle-alt-text';
+  }
 }
 
 /**


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-301

#### Description
This pull request introduces a toggle feature to hide and remove the required attribute from the alt text on images. The functionality operates as expected when editing an already uploaded image. However, there are issues when adding a media paragraph and uploading a new image, as I am unable to hook into the form correctly. I attempted to use `media-library-add-form-upload`, but it was unsuccessful.

*Note: This task was time-boxed, and no additional time could be allocated.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/1e91b931-64f6-4ef2-b946-8d9cdc4d8a51

