### PR TITLE
Remove required for Alt text on images

### DIFF
--- a/config/sync/field.field.media.image.field_media_image.yml
+++ b/config/sync/field.field.media.image.field_media_image.yml
@@ -26,7 +26,7 @@ settings:
   max_resolution: ''
   min_resolution: ''
   alt_field: true
-  alt_field_required: true
+  alt_field_required: false
   title_field: false
   title_field_required: false
   default_image:


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-301

#### Description
Images that are only for decorative purposes should be allowed to not have an alt text.


#### Additional comments or questions
I tried to make some dynamic toggle behavior here. but with no success: 
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/823

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/63f13e3b-a354-41e2-86d7-2f3e207576af)

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/50c853eb-76df-4892-92bd-767c85c6797c)
