### PR TITLE
Add opening hours link to General Settings Form and display it in the header - Ddfform 370

### DIFF
--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.module
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.module
@@ -1,6 +1,17 @@
 <?php
 
+use Drupal\dpl_library_agency\GeneralSettings;
+
 /**
  * @file
  * Contains dpl_library_agency.module.
  */
+
+
+ /**
+ * Implements hook_preprocess_page().
+ */
+function dpl_library_agency_preprocess_page(&$variables) {
+  $config = \Drupal::config('dpl_library_agency.general_settings');
+  $variables['opening_hours_url'] = $config->get('opening_hours_url') ?? GeneralSettings::OPENING_HOURS_URL;
+}

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.module
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.module
@@ -7,11 +7,10 @@ use Drupal\dpl_library_agency\GeneralSettings;
  * Contains dpl_library_agency.module.
  */
 
-
- /**
+/**
  * Implements hook_preprocess_page().
  */
-function dpl_library_agency_preprocess_page(&$variables) {
+function dpl_library_agency_preprocess_page(array &$variables): void {
   $config = \Drupal::config('dpl_library_agency.general_settings');
   $variables['opening_hours_url'] = $config->get('opening_hours_url') ?? GeneralSettings::OPENING_HOURS_URL;
 }

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -185,6 +185,20 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('pause_reservation_info_url') ?? GeneralSettings::PAUSE_RESERVATION_INFO_URL,
     ];
 
+    $form['opening_hours_url'] = [
+      '#type' => 'linkit',
+      '#title' => $this->t('Opening hours link', [], ['context' => 'Library Agency Configuration']),
+      '#description' => $this->t('The link with information about opening hours. <br>
+                                         You can add a relative url (e.g. /takster). <br>
+                                         You can search for an internal url. <br>
+                                         You can add an external url (starting with "http://" or "https://").', [], ['context' => 'Library Agency Configuration']),
+      '#autocomplete_route_name' => 'linkit.autocomplete',
+      '#autocomplete_route_parameters' => [
+        'linkit_profile_id' => 'default',
+      ],
+      '#default_value' => $config->get('opening_hours_url') ?? GeneralSettings::OPENING_HOURS_URL,
+    ];
+
     $form['expiration_warning'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Expiration warning', [], ['context' => 'Library Agency Configuration']),
@@ -321,6 +335,7 @@ class GeneralSettingsForm extends ConfigFormBase {
       ->set('pause_reservation_info_url', $form_state->getValue('pause_reservation_info_url'))
       ->set('ereolen_my_page_url', $form_state->getValue('ereolen_my_page_url'))
       ->set('ereolen_homepage_url', $form_state->getValue('ereolen_homepage_url'))
+      ->set('opening_hours_url', $form_state->getValue('opening_hours_url'))
       ->set('fbi_profiles', [
         'default' => $form_state->getValue('fbi_profile_default'),
         'search' => $form_state->getValue('fbi_profile_search'),

--- a/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
@@ -23,6 +23,7 @@ class GeneralSettings extends DplReactConfigBase {
   const EREOLEN_MY_PAGE_URL = 'https://ereolen.dk/user/me';
   const EREOLEN_HOMEPAGE_URL = 'https://ereolen.dk';
   const FBI_PROFILE = 'next';
+  const OPENING_HOURS_URL = '';
 
   /**
    * Gets the configuration key for general settings.

--- a/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
@@ -23,7 +23,7 @@ class GeneralSettings extends DplReactConfigBase {
   const EREOLEN_MY_PAGE_URL = 'https://ereolen.dk/user/me';
   const EREOLEN_HOMEPAGE_URL = 'https://ereolen.dk';
   const FBI_PROFILE = 'next';
-  const OPENING_HOURS_URL = '';
+  const OPENING_HOURS_URL = '/branches';
 
   /**
    * Gets the configuration key for general settings.

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\dpl_library_agency\GeneralSettings;
 use Drupal\recurring_events\Entity\EventInstance;
 use Spatie\Color\Hex;
 use Spatie\Color\Hsl;

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -7,8 +7,8 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\recurring_events\Entity\EventInstance;
 use Drupal\dpl_library_agency\GeneralSettings;
+use Drupal\recurring_events\Entity\EventInstance;
 use Spatie\Color\Hex;
 use Spatie\Color\Hsl;
 use function Safe\file_get_contents;
@@ -319,7 +319,7 @@ function novel_preprocess_views_view_unformatted(&$variables): void {
         // Check if not the first row and if event_series_id matches
         // the previous row.
         $isStacked = $index > 0 && $eventSeriesId == $rows[$index - 1]['content']['#eventinstance']->getEventSeries()
-            ->id();
+          ->id();
 
         $row['isStacked'] = $isStacked;
 

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -8,6 +8,7 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\recurring_events\Entity\EventInstance;
+use Drupal\dpl_library_agency\GeneralSettings;
 use Spatie\Color\Hex;
 use Spatie\Color\Hsl;
 use function Safe\file_get_contents;
@@ -122,6 +123,9 @@ function novel_preprocess_dpl_react_app__loan_list(array &$variables): void {
 function novel_preprocess(array &$variables): void {
   $directory = $variables['directory'] ?? 'web/themes/custom/novel';
   $variables['baseIconPath'] = "/{$directory}/assets/dpl-design-system/icons";
+
+  $config = \Drupal::config('dpl_library_agency.general_settings');
+  $variables['opening_hours_url'] = $config->get('opening_hours_url') ?? GeneralSettings::OPENING_HOURS_URL;
 }
 
 /**
@@ -258,7 +262,7 @@ function novel_attach_identity_color_styles(array &$variables, Hsl $hslColor): v
 /**
  * Implements hook_theme_suggestions_field_alter().
  */
-function novel_theme_suggestions_field_alter(array &$suggestions, array $variables) : void {
+function novel_theme_suggestions_field_alter(array &$suggestions, array $variables): void {
   $element = $variables['element'];
 
   // Add theme suggestions per view mode...
@@ -314,7 +318,8 @@ function novel_preprocess_views_view_unformatted(&$variables): void {
 
         // Check if not the first row and if event_series_id matches
         // the previous row.
-        $isStacked = $index > 0 && $eventSeriesId == $rows[$index - 1]['content']['#eventinstance']->getEventSeries()->id();
+        $isStacked = $index > 0 && $eventSeriesId == $rows[$index - 1]['content']['#eventinstance']->getEventSeries()
+            ->id();
 
         $row['isStacked'] = $isStacked;
 

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -123,9 +123,6 @@ function novel_preprocess_dpl_react_app__loan_list(array &$variables): void {
 function novel_preprocess(array &$variables): void {
   $directory = $variables['directory'] ?? 'web/themes/custom/novel';
   $variables['baseIconPath'] = "/{$directory}/assets/dpl-design-system/icons";
-
-  $config = \Drupal::config('dpl_library_agency.general_settings');
-  $variables['opening_hours_url'] = $config->get('opening_hours_url') ?? GeneralSettings::OPENING_HOURS_URL;
 }
 
 /**

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -38,7 +38,9 @@
         </div>
         <div class="header__clock-items">
             <img loading="lazy" width="58" height="58" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" class="mb-8" alt="clock icon"/>
-            <span class="text-small-caption">Åbningstider</span>
+            {% if opening_hours_url  %}
+              <a href="{{ opening_hours_url }}" class="link-tag text-small-caption">{{ "Open hours"|t }}</a>
+            {% endif %}
         </div>
     </div>
 </header>

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -36,12 +36,10 @@
         <div class="pagefold-parent--medium">
             <div class="pagefold-triangle--medium"></div>
         </div>
-        <div class="header__clock-items">
+        <a href="{{ opening_hours_url }}" class="header__clock-items">
             <img loading="lazy" width="58" height="58" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" class="mb-8" alt="clock icon"/>
-            {% if opening_hours_url %}
-              <a href="{{ opening_hours_url }}" class="link-tag text-small-caption">{{ "Opening hours"|t }}</a>
-            {% endif %}
-        </div>
+            <span  class="link-tag text-small-caption">{{ "Opening hours"|t }}</span>
+        </a>
     </div>
 </header>
 <div class="header-sidebar-nav" data-open="closed">

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -39,7 +39,7 @@
         <div class="header__clock-items">
             <img loading="lazy" width="58" height="58" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" class="mb-8" alt="clock icon"/>
             {% if opening_hours_url %}
-              <a href="{{ opening_hours_url }}" class="link-tag text-small-caption">{{ "Open hours"|t }}</a>
+              <a href="{{ opening_hours_url }}" class="link-tag text-small-caption">{{ "Opening hours"|t }}</a>
             {% endif %}
         </div>
     </div>

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -38,7 +38,7 @@
         </div>
         <a href="{{ opening_hours_url }}" class="header__clock-items">
             <img loading="lazy" width="58" height="58" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" class="mb-8" alt="clock icon"/>
-            <span  class="link-tag text-small-caption">{{ "Opening hours"|t }}</span>
+            <span  class="text-small-caption">{{ "Opening hours"|t }}</span>
         </a>
     </div>
 </header>

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -38,7 +38,7 @@
         </div>
         <div class="header__clock-items">
             <img loading="lazy" width="58" height="58" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" class="mb-8" alt="clock icon"/>
-            {% if opening_hours_url  %}
+            {% if opening_hours_url %}
               <a href="{{ opening_hours_url }}" class="link-tag text-small-caption">{{ "Open hours"|t }}</a>
             {% endif %}
         </div>

--- a/web/themes/custom/novel/templates/layout/page.html.twig
+++ b/web/themes/custom/novel/templates/layout/page.html.twig
@@ -50,6 +50,7 @@
     'search_header': search.header,
     'patron_menu': patron.menu,
     'logo': logo,
+    'opening_hours_url': opening_hours_url,
   } only %}
 
   {{ drupal_block('system_messages_block') }}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-370

#### Description
This pull request introduces a feature to include a link to the opening hours in the General Settings Form, which is then displayed in the website's header

I have also updated the design-system 
https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/539

#### Screenshot of the result
https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/81f6c864-d2d6-4028-8fcd-e197a73acd52