### PR TITLE
Patch entity clone template module to fix error when creating branches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -261,6 +261,9 @@
             "drupal/entity_clone": {
                 "2708731: Allow redirect to edit form after cloning": "https://www.drupal.org/files/issues/2022-11-15/improve-workflow-of-cloned-entity-2708731-39.patch"
             },
+            "drupal/entity_clone_template": {
+                "3424597: Fix error when creating entity of type without templates": "https://git.drupalcode.org/project/entity_clone_template/-/merge_requests/3.patch"
+            },
             "drupal/field_inheritance": {
                 "3330386: field_inheritance_form_alter should enforce module permissions": "https://git.drupalcode.org/project/field_inheritance/-/commit/bc3d26cdce8c09d5b6275fc126e35bc7e239c7d1.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eca41aff5c37aab31b77519b8bffb517",
+    "content-hash": "b7e9ed9aae91346147f2b587676f716a",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-388

#### Description

The module has a bug when creating entities which are not configured to support templates. In this case a PHP warning is shown.

In our situation branches is such a type.

Patch the module to address this.