### PR TITLE
Move event description from WYSIWYG to plain textarea. DDFFORM-298

### DIFF
--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.eventinstance.default.field_categories
+    - field.field.eventinstance.default.field_description
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -27,7 +28,6 @@ dependencies:
     - paragraphs
     - paragraphs_ee
     - paragraphs_features
-    - text
 third_party_settings:
   field_group:
     group_teaser_card:
@@ -81,19 +81,19 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_description:
+    type: string_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
   field_event_address:
     type: address_default
     weight: 7
     region: content
     settings: {  }
-    third_party_settings: {  }
-  field_event_description:
-    type: text_textarea
-    weight: 1
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
     third_party_settings: {  }
   field_event_image:
     type: media_library_widget
@@ -230,3 +230,4 @@ content:
     third_party_settings: {  }
 hidden:
   body: true
+  field_event_description: true

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.eventseries.default.field_categories
+    - field.field.eventseries.default.field_description
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -28,7 +29,6 @@ dependencies:
     - paragraphs_features
     - recurring_events
     - scheduler
-    - text
 third_party_settings:
   field_group:
     group_teaser_card:
@@ -114,19 +114,19 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_description:
+    type: string_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
   field_event_address:
     type: address_default
     weight: 10
     region: content
     settings: {  }
-    third_party_settings: {  }
-  field_event_description:
-    type: text_textarea
-    weight: 1
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
     third_party_settings: {  }
   field_event_image:
     type: media_library_widget
@@ -315,4 +315,5 @@ content:
 hidden:
   body: true
   excluded_dates: true
+  field_event_description: true
   included_dates: true

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventinstance.card
     - field.field.eventinstance.default.field_categories
+    - field.field.eventinstance.default.field_description
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -103,6 +104,7 @@ hidden:
   event_state: true
   event_ticket_categories: true
   field_categories: true
+  field_description: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.eventinstance.default.field_categories
+    - field.field.eventinstance.default.field_description
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -153,6 +154,13 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_description:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 14
     region: content
   title:
     type: string

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventinstance.list
     - field.field.eventinstance.default.field_categories
+    - field.field.eventinstance.default.field_description
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -24,7 +25,6 @@ dependencies:
     - datetime_range
     - entity_reference_revisions
     - link
-    - options
     - text
 _core:
   default_config_hash: ynM97GAGTtZBjg1uuiiRFaP8WTq766yoANHsZJ41__4
@@ -44,46 +44,45 @@ content:
     weight: 1
     region: content
   description:
-    type: text_trimmed
-    label: visually_hidden
-    settings:
-      trim_length: 200
+    type: text_default
+    label: hidden
+    settings: {  }
     third_party_settings: {  }
     weight: 2
     region: content
   event_address:
     type: address_default
-    label: visible
+    label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 51
+    weight: 4
     region: content
   event_categories:
     type: entity_reference_label
-    label: visible
+    label: above
     settings:
       link: true
     third_party_settings: {  }
-    weight: 52
+    weight: 5
     region: content
   event_description:
     type: text_default
-    label: visible
+    label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 52
+    weight: 6
     region: content
   event_image:
     type: entity_reference_label
-    label: visible
+    label: above
     settings:
       link: true
     third_party_settings: {  }
-    weight: 53
+    weight: 7
     region: content
   event_link:
     type: link
-    label: visible
+    label: above
     settings:
       trim_length: 80
       url_only: false
@@ -91,72 +90,72 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 54
+    weight: 8
     region: content
   event_paragraphs:
     type: entity_reference_revisions_entity_view
-    label: visible
+    label: above
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 55
+    weight: 9
     region: content
   event_partners:
     type: string
-    label: visible
+    label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 56
+    weight: 10
     region: content
   event_place:
     type: string
-    label: visible
+    label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 56
-    region: content
-  event_state:
-    type: list_default
-    label: visible
-    settings: {  }
-    third_party_settings: {  }
-    weight: 57
+    weight: 11
     region: content
   event_tags:
     type: entity_reference_label
-    label: visible
+    label: above
     settings:
       link: true
     third_party_settings: {  }
-    weight: 60
+    weight: 14
     region: content
   event_teaser_image:
     type: entity_reference_label
-    label: visible
+    label: above
     settings:
       link: true
     third_party_settings: {  }
-    weight: 59
+    weight: 13
     region: content
   event_teaser_text:
     type: string
-    label: visible
+    label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 60
+    weight: 15
     region: content
   event_ticket_categories:
     type: entity_reference_revisions_entity_view
-    label: visible
+    label: above
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 58
+    weight: 12
+    region: content
+  field_description:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
     region: content
   title:
     type: string
@@ -168,6 +167,7 @@ content:
     region: content
 hidden:
   body: true
+  event_state: true
   field_categories: true
   field_event_address: true
   field_event_description: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventinstance.list_teaser
     - field.field.eventinstance.default.field_categories
+    - field.field.eventinstance.default.field_description
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -66,14 +67,14 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 10
+    weight: 11
     region: content
   event_description:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   event_image:
     type: entity_reference_entity_view
@@ -82,7 +83,7 @@ content:
       view_mode: hero_wide
       link: false
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   event_link:
     type: link
@@ -94,7 +95,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   event_paragraphs:
     type: entity_reference_revisions_entity_view
@@ -103,7 +104,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 6
+    weight: 7
     region: content
   event_partners:
     type: string
@@ -111,7 +112,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 9
+    weight: 10
     region: content
   event_place:
     type: string
@@ -119,7 +120,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 7
+    weight: 8
     region: content
   event_tags:
     type: entity_reference_label
@@ -145,7 +146,14 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 8
+    weight: 9
+    region: content
+  field_description:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
     region: content
   field_event_image:
     type: entity_reference_entity_view

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventinstance.nav_spot
     - field.field.eventinstance.default.field_categories
+    - field.field.eventinstance.default.field_description
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -74,6 +75,7 @@ hidden:
   event_tags: true
   event_ticket_categories: true
   field_categories: true
+  field_description: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventinstance.nav_teaser
     - field.field.eventinstance.default.field_categories
+    - field.field.eventinstance.default.field_description
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -67,6 +68,7 @@ hidden:
   event_teaser_text: true
   event_ticket_categories: true
   field_categories: true
+  field_description: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventinstance.stacked_event
     - field.field.eventinstance.default.field_categories
+    - field.field.eventinstance.default.field_description
     - field.field.eventinstance.default.field_event_address
     - field.field.eventinstance.default.field_event_description
     - field.field.eventinstance.default.field_event_image
@@ -86,6 +87,7 @@ hidden:
   event_teaser_text: true
   event_ticket_categories: true
   field_categories: true
+  field_description: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventseries.default.card.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.card.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventseries.card
     - field.field.eventseries.default.field_categories
+    - field.field.eventseries.default.field_description
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -67,6 +68,7 @@ hidden:
   event_instances: true
   event_registration: true
   field_categories: true
+  field_description: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.eventseries.default.field_categories
+    - field.field.eventseries.default.field_description
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -37,6 +38,13 @@ content:
       link: false
     third_party_settings: {  }
     weight: 13
+    region: content
+  field_description:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 15
     region: content
   field_event_address:
     type: address_default

--- a/config/sync/core.entity_view_display.eventseries.default.list.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.list.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventseries.list
     - field.field.eventseries.default.field_categories
+    - field.field.eventseries.default.field_description
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -18,8 +19,6 @@ dependencies:
     - field.field.eventseries.default.field_teaser_text
     - field.field.eventseries.default.field_ticket_categories
     - recurring_events.eventseries_type.default
-  module:
-    - text
 _core:
   default_config_hash: SH4PVwBZQc690I-apt_nNKlkhxnZyFlf68d-7mxruF8
 id: eventseries.default.list
@@ -27,14 +26,6 @@ targetEntityType: eventseries
 bundle: default
 mode: list
 content:
-  body:
-    type: text_trimmed
-    label: hidden
-    settings:
-      trim_length: 200
-    third_party_settings: {  }
-    weight: 1
-    region: content
   title:
     type: string
     label: hidden
@@ -44,12 +35,14 @@ content:
     weight: 0
     region: content
 hidden:
+  body: true
   consecutive_recurring_date: true
   custom_date: true
   daily_recurring_date: true
   event_instances: true
   event_registration: true
   field_categories: true
+  field_description: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventseries.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.nav_spot.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventseries.nav_spot
     - field.field.eventseries.default.field_categories
+    - field.field.eventseries.default.field_description
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -58,6 +59,7 @@ hidden:
   event_instances: true
   event_registration: true
   field_categories: true
+  field_description: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/core.entity_view_display.eventseries.default.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.nav_teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.eventseries.nav_teaser
     - field.field.eventseries.default.field_categories
+    - field.field.eventseries.default.field_description
     - field.field.eventseries.default.field_event_address
     - field.field.eventseries.default.field_event_description
     - field.field.eventseries.default.field_event_image
@@ -49,6 +50,7 @@ hidden:
   event_instances: true
   event_registration: true
   field_categories: true
+  field_description: true
   field_event_address: true
   field_event_description: true
   field_event_image: true

--- a/config/sync/field.field.eventinstance.default.field_description.yml
+++ b/config/sync/field.field.eventinstance.default.field_description.yml
@@ -1,0 +1,19 @@
+uuid: 2181b43b-4386-46d3-8cc7-e5227940a73f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventinstance.field_description
+    - recurring_events.eventinstance_type.default
+id: eventinstance.default.field_description
+field_name: field_description
+entity_type: eventinstance
+bundle: default
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.eventinstance.default.field_event_description.yml
+++ b/config/sync/field.field.eventinstance.default.field_event_description.yml
@@ -11,8 +11,8 @@ id: eventinstance.default.field_event_description
 field_name: field_event_description
 entity_type: eventinstance
 bundle: default
-label: Description
-description: ''
+label: 'Description (DEPRECATED - WILL BE DELETED.)'
+description: 'This field will be deleted in the future. Please use the other description field.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.eventseries.default.field_description.yml
+++ b/config/sync/field.field.eventseries.default.field_description.yml
@@ -1,0 +1,19 @@
+uuid: 77d59c1c-0319-4996-99ff-c7ca8efe4482
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventseries.field_description
+    - recurring_events.eventseries_type.default
+id: eventseries.default.field_description
+field_name: field_description
+entity_type: eventseries
+bundle: default
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.eventseries.default.field_event_description.yml
+++ b/config/sync/field.field.eventseries.default.field_event_description.yml
@@ -12,8 +12,8 @@ id: eventseries.default.field_event_description
 field_name: field_event_description
 entity_type: eventseries
 bundle: default
-label: Description
-description: ''
+label: 'Description (DEPRECATED - WILL BE DELETED.)'
+description: 'This field will be deleted in the future. Please use the other description field.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.storage.eventinstance.field_description.yml
+++ b/config/sync/field.storage.eventinstance.field_description.yml
@@ -1,0 +1,19 @@
+uuid: 54d1b94e-8374-46ad-9d06-514fe7bac930
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+id: eventinstance.field_description
+field_name: field_description
+entity_type: eventinstance
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.eventseries.field_description.yml
+++ b/config/sync/field.storage.eventseries.field_description.yml
@@ -1,0 +1,19 @@
+uuid: 177295db-e6cb-404f-a24c-d26ce0a6640e
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+id: eventseries.field_description
+field_name: field_description
+entity_type: eventseries
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/dpl_event/dpl_event.deploy.php
+++ b/web/modules/custom/dpl_event/dpl_event.deploy.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Event deploy hooks.
+ *
+ * These get run AFTER config-import.
+ */
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+
+/**
+ * Pre-populate data to new non-WYSIWYG field field_description.
+ *
+ * We also empty out the old field. The field has been set to be hidden
+ * from the editors, and we'll delete it in a future deploy.
+ */
+function dpl_event_deploy_port_description_fields() : string {
+  $message = _dpl_event_port_wysiwyg('eventseries', 'field_event_description', 'field_description');
+  $message .= _dpl_event_port_wysiwyg('eventinstance', 'field_event_description', 'field_description');
+
+  return $message;
+}
+
+/**
+ * A helper function, for porting WYSIWYG fields to plain textareas.
+ */
+function _dpl_event_port_wysiwyg(string $entity_type, string $source_field, string $target_field): string {
+  $ids =
+    \Drupal::entityQuery($entity_type)
+      ->condition($source_field, '', '<>')
+      ->accessCheck(FALSE)
+      ->execute();
+
+  $entities =
+    \Drupal::entityTypeManager()->getStorage($entity_type)->loadMultiple($ids);
+
+  foreach ($entities as $entity) {
+    if (!($entity instanceof FieldableEntityInterface) || !$entity->hasField($target_field)) {
+      continue;
+    }
+
+    $value = $entity->get($source_field)->getValue();
+    $text = $value[0]['value'] ?? '';
+    $text = strip_tags($text);
+
+    $entity->set($target_field, $text);
+    $entity->set($source_field, NULL);
+    $entity->save();
+  }
+
+  return t("Updated @count description fields on @entity_type \r\n", [
+    "@count" => count($entities),
+    "@entity_type" => $entity_type,
+  ])->render();
+}

--- a/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
@@ -111,10 +111,9 @@ default:
       locality: Aarhus
       postal_code: '8000'
       address_line1: 'Kampmanns Plads 2'
-  field_event_description:
+  field_description:
     -
-      value: "<p>Tag med til en fortryllende oplevelse med 'Juleballet - Nøddeknækkeren', en tidløs balletklassiker der fortryller publikum af alle aldre. Nyd Tjajkovskijs betagende musik og enestående dans, som bringer julemagien til live. En ideel begivenhed for familier, par og balletentusiaster, der søger en unik kulturel oplevelse. Sikre dig din billet til denne uforglemmelige forestilling!</p>"
-      format: limited
+      value: "Tag med til en fortryllende oplevelse med 'Juleballet - Nøddeknækkeren', en tidløs balletklassiker der fortryller publikum af alle aldre. Nyd Tjajkovskijs betagende musik og enestående dans, som bringer julemagien til live. En ideel begivenhed for familier, par og balletentusiaster, der søger en unik kulturel oplevelse. Sikre dig din billet til denne uforglemmelige forestilling!"
   field_event_image:
     -
       entity: a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -119,10 +119,9 @@ default:
       locality: Aarhus
       postal_code: '8000'
       address_line1: 'Kampmanns Plads 2'
-  field_event_description:
+  field_description:
     -
-      value: '<p>Foreningen for Integreret Moderne Dans arbejder med at udvide normalitetsbegrebet i scenekunsten. For hvad er normalt? Rosenreglen og Mødrenes hus. I 2022 udgav hun også den stærkt politiske digtsamling Jeg vil have en statsminister.</p>'
-      format: limited
+      value: 'Foreningen for Integreret Moderne Dans arbejder med at udvide normalitetsbegrebet i scenekunsten. For hvad er normalt? Rosenreglen og Mødrenes hus. I 2022 udgav hun også den stærkt politiske digtsamling Jeg vil have en statsminister.'
   field_event_image:
     -
       entity: 618e176a-a45a-4c36-a197-664230aa0a34

--- a/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
@@ -183,10 +183,9 @@ default:
       locality: Aarhus
       postal_code: '8000'
       address_line1: 'Kampmanns Plads 2'
-  field_event_description:
+  field_description:
     -
-      value: '<p>Legestue for fædre og deres børn mellem 0 og 3 år.</p><p>Sving forbi Stadsbiblioteket til uforpligtende leg og hygge med junior (skærtorsdag og Kristi himmelfartsdag undtaget) finder babylegetøjet frem og inviterer til Fars legestue. Her kan du møde andre fædre og deres børn, ligesom I kan finde inspiration til leg og læsning.</p>'
-      format: limited
+      value: 'Legestue for fædre og deres børn mellem 0 og 3 år. Sving forbi Stadsbiblioteket til uforpligtende leg og hygge med junior (skærtorsdag og Kristi himmelfartsdag undtaget) finder babylegetøjet frem og inviterer til Fars legestue. Her kan du møde andre fædre og deres børn, ligesom I kan finde inspiration til leg og læsning.'
   field_event_image:
     -
       entity: ca329ad9-5a1c-4f55-b8a9-a60843b66466

--- a/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
@@ -112,10 +112,9 @@ default:
       locality: Aarhus
       postal_code: '8000'
       address_line1: 'Kampmanns Plads 2'
-  field_event_description:
+  field_description:
     -
-      value: "<p>Vær med til at gøre en forskel for miljøet ved at deltage i arrangementet 'Genbrugsstof fremfor plastik'. Denne begivenhed sætter fokus på bæredygtighed og vigtigheden af at vælge genbrugsmaterialer over plastik. Det er en fantastisk mulighed for at lære om miljøvenlige alternativer, deltage i inspirerende workshops og møde ligesindede, der deler en passion for bæredygtighed. Bliv inspireret til at gøre små ændringer i din hverdag, som kan have en stor indvirkning på vores planet</p>"
-      format: limited
+      value: "Vær med til at gøre en forskel for miljøet ved at deltage i arrangementet 'Genbrugsstof fremfor plastik'. Denne begivenhed sætter fokus på bæredygtighed og vigtigheden af at vælge genbrugsmaterialer over plastik. Det er en fantastisk mulighed for at lære om miljøvenlige alternativer, deltage i inspirerende workshops og møde ligesindede, der deler en passion for bæredygtighed. Bliv inspireret til at gøre små ændringer i din hverdag, som kan have en stor indvirkning på vores planet"
   field_event_image:
     -
       entity: d6d67fd2-775c-46e7-a1bf-6af46290a5c8

--- a/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
@@ -8,7 +8,7 @@
     "date": formatted_date,
     "event_address": content.field_event_address,
     "event_categories": content.field_categories,
-    "event_description": content.field_event_description,
+    "event_description": content.field_description,
     "event_image": content.field_event_image,
     "event_link": content.field_event_link,
     "event_paragraphs": content.field_event_paragraphs,


### PR DESCRIPTION
- Add warning on existing WYSIWYG field, and hide it from editors
- Setup basic field_description text area field
- Create deploy hook, moving data from WYSIWYG to textarea
- Delete existing data in WYSIWYG
- In a future deploy, we'll delete the WYSIWYG field.
