### PR TITLE
Make paragraphs cloneable. DDFFORM-398

### DIFF
--- a/config/sync/entity_clone.cloneable_entities.yml
+++ b/config/sync/entity_clone.cloneable_entities.yml
@@ -1,3 +1,5 @@
 cloneable_entities:
   - node
+  - path_alias
   - eventseries
+  - paragraph


### PR DESCRIPTION
This is to not "re-use" paragraphs when using templates. If this is not done, you might make a template clone, and edit paragraphs and see that it does the changes on both the child, and the parent.
