### PR TITLE
Make sure that editors and local administrators actually can edit menus.

### DIFF
--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -47,6 +47,7 @@ permissions:
   - 'add eventseries entity'
   - 'add new links to main menu'
   - 'administer dpl_footer settings'
+  - 'administer menu'
   - 'administer nodes'
   - 'administer paragraphs categories'
   - 'bypass node access'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -59,6 +59,7 @@ permissions:
   - 'administer dpl_footer settings'
   - 'administer instant loan configuration'
   - 'administer library agency configuration'
+  - 'administer menu'
   - 'administer nodes'
   - 'administer orphaned events entities'
   - 'administer paragraphs categories'


### PR DESCRIPTION
There is already a sub-permission that limits which menus they can edit - but this permission is apparantly also necessary to show the link of the overview page.
