### PR TITLE
Automatic unpublishing of events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -272,6 +272,9 @@
             "drupal/focal_point": {
                 "3162210: Preview link accidentally closes the media library": "https://www.drupal.org/files/issues/2020-10-11/preview_link_accidentally_closes_the_media_library-3162210-19.patch"
             },
+            "drupal/job_scheduler": {
+                "3426366: Callables as worker callbacks": "https://git.drupalcode.org/project/job_scheduler/-/merge_requests/7.patch"
+            },
             "drupal/jsonlog": {
                 "3251587: Change logging from stdout to stderr": "https://www.drupal.org/files/issues/2021-11-29/jsonlog-change-stdout-to-stderr-3251587-3.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -273,7 +273,8 @@
                 "3162210: Preview link accidentally closes the media library": "https://www.drupal.org/files/issues/2020-10-11/preview_link_accidentally_closes_the_media_library-3162210-19.patch"
             },
             "drupal/job_scheduler": {
-                "3426366: Callables as worker callbacks": "https://git.drupalcode.org/project/job_scheduler/-/merge_requests/7.patch"
+                "3426366: Callables as worker callbacks": "https://git.drupalcode.org/project/job_scheduler/-/merge_requests/7.patch",
+                "3426378: Views support": "https://git.drupalcode.org/project/job_scheduler/-/merge_requests/8.patch"
             },
             "drupal/jsonlog": {
                 "3251587: Change logging from stdout to stderr": "https://www.drupal.org/files/issues/2021-11-29/jsonlog-change-stdout-to-stderr-3251587-3.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "166418197daad83bd59d6f061887a584",
+    "content-hash": "440aa9608771f5cb0c9b82f84a7306e1",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eee45e7403e9a4be7382971376d15f08",
+    "content-hash": "166418197daad83bd59d6f061887a584",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -2,6 +2,7 @@ _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
 ignored_config_entities:
   - dpl_dashboard.settings
+  - dpl_event.settings
   - dpl_favorites_list.settings
   - dpl_fbs.settings
   - dpl_fees.settings

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -51,6 +51,7 @@ module:
   dpl_something_similar: 0
   dpl_static_content: 0
   dpl_url_proxy: 0
+  drupal_typed: 0
   dynamic_entity_reference: 0
   dynamic_page_cache: 0
   editor: 0

--- a/config/sync/dpl_event.settings.yml
+++ b/config/sync/dpl_event.settings.yml
@@ -1,0 +1,1 @@
+unpublish_schedule: 0

--- a/config/sync/views.view.scheduled_jobs.yml
+++ b/config/sync/views.view.scheduled_jobs.yml
@@ -1,0 +1,594 @@
+uuid: e002a8e2-974f-4513-af91-8fa3ec3baf9f
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.admin
+  module:
+    - job_scheduler
+    - user
+id: scheduled_jobs
+label: 'Scheduled jobs'
+module: views
+description: ''
+tag: ''
+base_table: job_schedule
+base_field: jid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Scheduled jobs'
+      fields:
+        jid:
+          id: jid
+          table: job_schedule
+          field: jid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: job_schedule
+          entity_field: jid
+          plugin_id: field
+          label: ID
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: job_schedule
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: job_schedule
+          entity_field: name
+          plugin_id: field
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: job_schedule
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: job_schedule
+          entity_field: type
+          plugin_id: field
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        id:
+          id: id
+          table: job_schedule
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: job_schedule
+          entity_field: id
+          plugin_id: field
+          label: 'Job ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        next:
+          id: next
+          table: job_schedule
+          field: next
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: job_schedule
+          entity_field: next
+          plugin_id: field
+          label: 'Next execution'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer site configuration'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters:
+        name:
+          id: name
+          table: job_schedule
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: job_schedule
+          entity_field: name
+          plugin_id: string
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        id:
+          id: id
+          table: job_schedule
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: job_schedule
+          entity_field: id
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: id_op
+            label: 'Job ID'
+            description: ''
+            use_operator: false
+            operator: id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            jid: jid
+            name: name
+            next: next
+          default: next
+          info:
+            jid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            next:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/system/job-scheduler/scheduled-jobs
+      menu:
+        type: normal
+        title: 'Scheduled jobs'
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: admin
+        parent: job_scheduler.admin_settings
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/web/modules/custom/dpl_event/dpl_event.info.yml
+++ b/web/modules/custom/dpl_event/dpl_event.info.yml
@@ -7,3 +7,4 @@ core_version_requirement: ^10
 dependencies:
   - drupal:enum_field
   - drupal:job_scheduler
+  - drupal:drupal_typed

--- a/web/modules/custom/dpl_event/dpl_event.links.menu.yml
+++ b/web/modules/custom/dpl_event/dpl_event.links.menu.yml
@@ -1,0 +1,6 @@
+dpl_event.settings:
+  title: Event settings
+  description: Configure handling of events.
+  parent: dpl_library_agency.settings
+  route_name: dpl_event.settings
+  weight: 10

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -12,6 +12,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\dpl_event\EventState;
 use Drupal\dpl_event\Workflows\OccurredSchedule;
+use Drupal\dpl_event\Workflows\UnpublishSchedule;
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\recurring_events\Entity\EventInstance;
 use Drupal\recurring_events\Entity\EventSeries;
@@ -24,7 +25,11 @@ use Drupal\recurring_events\Entity\EventSeries;
  */
 function dpl_event_cron_job_scheduler_info(): array {
   $occurred_schedule = DrupalTyped::service(OccurredSchedule::class, 'dpl_event.occurred_schedule');
-  return $occurred_schedule->getSchedule();
+  $unpublish_schedule = DrupalTyped::service(UnpublishSchedule::class, 'dpl_event.unpublish_schedule');
+  return array_merge(
+    $occurred_schedule->getSchedule(),
+    $unpublish_schedule->getSchedule()
+  );
 }
 
 /**
@@ -32,9 +37,13 @@ function dpl_event_cron_job_scheduler_info(): array {
  */
 function dpl_event_eventinstance_insert(EntityInterface $entity): void {
   $occurred_schedule = DrupalTyped::service(OccurredSchedule::class, 'dpl_event.occurred_schedule');
-  if ($entity instanceof EventInstance && $occurred_schedule->isActive($entity)) {
-    $occurred_schedule->scheduleOccurred($entity);
+  $unpublish_schedule = DrupalTyped::service(UnpublishSchedule::class, 'dpl_event.unpublish_schedule');
+  if (!$entity instanceof EventInstance) {
+    return;
   }
+
+  $occurred_schedule->isActive($entity) && $occurred_schedule->scheduleOccurred($entity);
+  $unpublish_schedule->scheduleUnpublication($entity);
 }
 
 /**
@@ -42,9 +51,13 @@ function dpl_event_eventinstance_insert(EntityInterface $entity): void {
  */
 function dpl_event_eventinstance_update(EntityInterface $entity): void {
   $occurred_schedule = DrupalTyped::service(OccurredSchedule::class, 'dpl_event.occurred_schedule');
-  if ($entity instanceof EventInstance && $occurred_schedule->isActive($entity)) {
-    $occurred_schedule->scheduleOccurred($entity);
+  $unpublish_schedule = DrupalTyped::service(UnpublishSchedule::class, 'dpl_event.unpublish_schedule');
+  if (!$entity instanceof EventInstance) {
+    return;
   }
+
+  $occurred_schedule->isActive($entity) && $occurred_schedule->scheduleOccurred($entity);
+  $unpublish_schedule->scheduleUnpublication($entity);
 }
 
 /**

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\dpl_event\EventState;
+use Drupal\dpl_event\EventWrapper;
 use Drupal\dpl_event\Workflows\OccurredSchedule;
 use Drupal\dpl_event\Workflows\UnpublishSchedule;
 use Drupal\drupal_typed\DrupalTyped;
@@ -42,7 +43,7 @@ function dpl_event_eventinstance_insert(EntityInterface $entity): void {
     return;
   }
 
-  $occurred_schedule->isActive($entity) && $occurred_schedule->scheduleOccurred($entity);
+  (new EventWrapper($entity))->isActive() && $occurred_schedule->scheduleOccurred($entity);
   $unpublish_schedule->scheduleUnpublication($entity);
 }
 
@@ -56,7 +57,7 @@ function dpl_event_eventinstance_update(EntityInterface $entity): void {
     return;
   }
 
-  $occurred_schedule->isActive($entity) && $occurred_schedule->scheduleOccurred($entity);
+  (new EventWrapper($entity))->isActive() && $occurred_schedule->scheduleOccurred($entity);
   $unpublish_schedule->scheduleUnpublication($entity);
 }
 

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -56,8 +56,15 @@ function dpl_event_eventinstance_update(EntityInterface $entity): void {
   if (!$entity instanceof EventInstance) {
     return;
   }
+  $updatedEvent = new EventWrapper($entity);
+  if (isset($entity->original) && $entity->original instanceof EventInstance) {
+    // If there are no changes to the date then skip updating schedules.
+    if ($updatedEvent->hasSameDate($entity->original)) {
+      return;
+    }
+  }
 
-  (new EventWrapper($entity))->isActive() && $occurred_schedule->scheduleOccurred($entity);
+  $updatedEvent->isActive() && $occurred_schedule->scheduleOccurred($entity);
   $unpublish_schedule->scheduleUnpublication($entity);
 }
 

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -11,31 +11,29 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\dpl_event\EventState;
-use Drupal\job_scheduler\Entity\JobSchedule;
+use Drupal\dpl_event\Workflows\OccurredSchedule;
+use Drupal\drupal_typed\DrupalTyped;
 use Drupal\recurring_events\Entity\EventInstance;
 use Drupal\recurring_events\Entity\EventSeries;
-use Safe\DateTimeImmutable;
 
 /**
  * Implements hook_cron_job_scheduler_info().
  *
- * @return non-empty-array<string, array{'worker callback': string}>
+ * @return non-empty-array<string, array{'worker callback': callable}>
  *   Job scheduler information.
  */
 function dpl_event_cron_job_scheduler_info(): array {
-  return [
-    "dpl_event_set_occurred" => [
-      "worker callback" => 'dpl_event_set_occurred_callback',
-    ],
-  ];
+  $occurred_schedule = DrupalTyped::service(OccurredSchedule::class, 'dpl_event.occurred_schedule');
+  return $occurred_schedule->getSchedule();
 }
 
 /**
  * Implements hook_node_insert().
  */
 function dpl_event_eventinstance_insert(EntityInterface $entity): void {
-  if ($entity instanceof EventInstance && dpl_event_eventinstance_is_active($entity)) {
-    dpl_event_schedule_set_occurred($entity);
+  $occurred_schedule = DrupalTyped::service(OccurredSchedule::class, 'dpl_event.occurred_schedule');
+  if ($entity instanceof EventInstance && $occurred_schedule->isActive($entity)) {
+    $occurred_schedule->scheduleOccurred($entity);
   }
 }
 
@@ -43,79 +41,9 @@ function dpl_event_eventinstance_insert(EntityInterface $entity): void {
  * Implements hook_node_update().
  */
 function dpl_event_eventinstance_update(EntityInterface $entity): void {
-  if ($entity instanceof EventInstance && dpl_event_eventinstance_is_active($entity)) {
-    dpl_event_schedule_set_occurred($entity);
-  }
-}
-
-/**
- * Determine if an event is considered active.
- *
- * An event is considered active if it has not occurred or been cancelled.
- */
-function dpl_event_eventinstance_is_active(EventInstance $event): bool {
-  $event_states = array_map(function (array $sfield_value): EventState {
-    return EventState::from($sfield_value['value']);
-  }, $event->get("event_state")->getValue());
-
-  return !(in_array(EventState::Cancelled, $event_states)
-    || in_array(EventState::Occurred, $event_states));
-}
-
-/**
- * Schedule setting an event to occurred in the future.
- */
-function dpl_event_schedule_set_occurred(EventInstance $event): void {
-  $now_timestamp = \Drupal::time()->getCurrentTime();
-
-  $event_date = $event->get('date')->get(0);
-  if (!$event_date) {
-    return;
-  }
-  $event_date_values = $event_date->getValue();
-  if (!$event_date_values || empty($event_date_values["end_value"])) {
-    return;
-  }
-  $event_end_date = new DateTimeImmutable($event_date_values["end_value"]);
-  $event_end_timestamp = $event_end_date->getTimestamp();
-
-  $job = [
-    'name' => 'dpl_event_set_occurred',
-    'type' => 'event',
-    'id' => $event->id(),
-    // The period is the number of seconds to wait between job executions. A
-    // negative period means that the job will be executed as soon as
-    // possible. By setting periodic false the job is only executed once.
-    'period' => $event_end_timestamp - $now_timestamp,
-    'periodic' => FALSE,
-  ];
-
-  /** @var \Drupal\job_scheduler\JobSchedulerInterface $scheduler */
-  $scheduler = \Drupal::service('job_scheduler.manager');
-  // Remove any preexisting job with the same name, type and id.
-  $scheduler->remove($job);
-  // Schedule the new update.
-  $scheduler->set($job);
-
-  \Drupal::logger('dpl_event')->debug(
-    'Scheduled "occurred" update for event %event_id at %end_time',
-    ['%event_id' => $event->id(), '%end_time' => $event_end_date->format('c')]
-  );
-}
-
-/**
- * Callback to be executed for scheduled jobs.
- */
-function dpl_event_set_occurred_callback(JobSchedule $job): void {
-  $event = \Drupal::entityTypeManager()->getStorage('eventinstance')->load($job->getId());
-  if (!$event || !$event instanceof EventInstance) {
-    return;
-  }
-
-  // Set state to occurred for events we consider active.
-  if (dpl_event_eventinstance_is_active($event)) {
-    $event->set("field_event_state", EventState::Occurred);
-    $event->save();
+  $occurred_schedule = DrupalTyped::service(OccurredSchedule::class, 'dpl_event.occurred_schedule');
+  if ($entity instanceof EventInstance && $occurred_schedule->isActive($entity)) {
+    $occurred_schedule->scheduleOccurred($entity);
   }
 }
 

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -56,15 +56,15 @@ function dpl_event_eventinstance_update(EntityInterface $entity): void {
   if (!$entity instanceof EventInstance) {
     return;
   }
-  $updatedEvent = new EventWrapper($entity);
+  $updated_event = new EventWrapper($entity);
   if (isset($entity->original) && $entity->original instanceof EventInstance) {
     // If there are no changes to the date then skip updating schedules.
-    if ($updatedEvent->hasSameDate($entity->original)) {
+    if ($updated_event->hasSameDate($entity->original)) {
       return;
     }
   }
 
-  $updatedEvent->isActive() && $occurred_schedule->scheduleOccurred($entity);
+  $updated_event->isActive() && $occurred_schedule->scheduleOccurred($entity);
   $unpublish_schedule->scheduleUnpublication($entity);
 }
 

--- a/web/modules/custom/dpl_event/dpl_event.routing.yml
+++ b/web/modules/custom/dpl_event/dpl_event.routing.yml
@@ -1,0 +1,7 @@
+dpl_event.settings:
+  path: "/admin/config/dpl-event/settings"
+  defaults:
+    _title: "Event settings"
+    _form: 'Drupal\dpl_event\Form\SettingsForm'
+  requirements:
+    _permission: "administer event configuration"

--- a/web/modules/custom/dpl_event/dpl_event.services.yml
+++ b/web/modules/custom/dpl_event/dpl_event.services.yml
@@ -1,4 +1,11 @@
 services:
+  dpl_event.logger:
+    parent: logger.channel_base
+    arguments: ["dpl_event"]
+  dpl_event.event_instance_storage:
+    class: \Drupal\recurring_events\EventInstanceStorage
+    factory: ["@entity_type.manager", "getStorage"]
+    arguments: ["eventinstance"]
   dpl_event.price_formatter:
     class: Drupal\dpl_event\PriceFormatter
     arguments: ["@string_translation"]
@@ -6,3 +13,10 @@ services:
     class: Drupal\dpl_event\ReoccurringDateFormatter
     arguments:
       ["@string_translation", "@entity_type.manager", "@date.formatter"]
+  dpl_event.occurred_schedule:
+    class: Drupal\dpl_event\Workflows\OccurredSchedule
+    arguments:
+      - "@dpl_event.logger"
+      - "@datetime.time"
+      - "@job_scheduler.manager"
+      - "@dpl_event.event_instance_storage"

--- a/web/modules/custom/dpl_event/dpl_event.services.yml
+++ b/web/modules/custom/dpl_event/dpl_event.services.yml
@@ -20,3 +20,11 @@ services:
       - "@datetime.time"
       - "@job_scheduler.manager"
       - "@dpl_event.event_instance_storage"
+  dpl_event.unpublish_schedule:
+    class: Drupal\dpl_event\Workflows\UnpublishSchedule
+    arguments:
+      - "@dpl_event.logger"
+      - "@datetime.time"
+      - "@job_scheduler.manager"
+      - "@dpl_event.event_instance_storage"
+      - "@config.factory"

--- a/web/modules/custom/dpl_event/src/EventWrapper.php
+++ b/web/modules/custom/dpl_event/src/EventWrapper.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\dpl_event;
+
+use Drupal\recurring_events\Entity\EventInstance;
+use Safe\DateTimeImmutable;
+
+/**
+ * Wrapper to ease access to certain data structures on events.
+ *
+ * There are multiple situations where this can be relevant:
+ *
+ * - Embedded business logic within values
+ * - Making access easier
+ * - Converting values to usable types
+ */
+class EventWrapper {
+
+  /**
+   * Constuctor.
+   */
+  public function __construct(
+    private EventInstance $event
+  ) {}
+
+  /**
+   * Determine if an event is considered active.
+   *
+   * An event is considered active if it has not occurred or been cancelled.
+   */
+  public function isActive() : bool {
+    $event_states = array_map(function (array $sfield_value): EventState {
+      return EventState::from($sfield_value['value']);
+    }, $this->event->get("event_state")->getValue());
+
+    return !(in_array(EventState::Cancelled, $event_states)
+      || in_array(EventState::Occurred, $event_states));
+  }
+
+  /**
+   * When the event starts.
+   */
+  public function getStartDate(): \DateTimeInterface {
+    return $this->getDate("value");
+  }
+
+  /**
+   * When the event ends.
+   */
+  public function getEndDate(): \DateTimeInterface {
+    return $this->getDate("end_value");
+  }
+
+  /**
+   * Determine if two events occur on the exact same date.
+   */
+  public function hasSameDate(EventInstance $otherEvent): bool {
+    $otherWrapper = new static($otherEvent);
+    return $this->getStartDate() == $otherWrapper->getStartDate() &&
+      $this->getEndDate() == $otherWrapper->getEndDate();
+  }
+
+  /**
+   * Get a date for the event.
+   *
+   * @param "value"|"end_value" $value
+   *   The part of the date to get.
+   */
+  private function getDate(string $value): \DateTimeInterface {
+    $event_date = $this->event->get('date')->get(0);
+    if (!$event_date) {
+      throw new \LogicException("Unable to retrieve date from event instance");
+    }
+
+    $event_date_values = $event_date->getValue();
+    if (!$event_date_values || empty($event_date_values[$value])) {
+      throw new \LogicException("Unable to retrieve date from event instance");
+    }
+    // Drupal stores dates in UTC by default but if no timezone is specified
+    // then the default timezone will be assumed.
+    return new DateTimeImmutable($event_date_values[$value], new \DateTimeZone('UTC'));
+  }
+
+}

--- a/web/modules/custom/dpl_event/src/Form/SettingsForm.php
+++ b/web/modules/custom/dpl_event/src/Form/SettingsForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\dpl_event\Workflows\UnpublishSchedule;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use function Safe\array_combine as array_combine;
 
@@ -23,7 +24,8 @@ final class SettingsForm extends ConfigFormBase {
    */
   public function __construct(
       ConfigFactoryInterface $config_factory,
-      private DateFormatterInterface $dateFormatter
+      private DateFormatterInterface $dateFormatter,
+      private UnpublishSchedule $unpublishSchedule
   ) {
     parent::__construct($config_factory);
   }
@@ -34,7 +36,8 @@ final class SettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container): static {
     return new static(
           $container->get('config.factory'),
-          $container->get('date.formatter')
+          $container->get('date.formatter'),
+          $container->get('dpl_event.unpublish_schedule')
       );
   }
 
@@ -105,6 +108,8 @@ final class SettingsForm extends ConfigFormBase {
       ->set('unpublish_schedule', $form_state->getValue('unpublish_schedule'))
       ->save();
     parent::submitForm($form, $form_state);
+
+    $this->unpublishSchedule->rescheduleAll();
   }
 
 }

--- a/web/modules/custom/dpl_event/src/Form/SettingsForm.php
+++ b/web/modules/custom/dpl_event/src/Form/SettingsForm.php
@@ -16,6 +16,8 @@ use function Safe\array_combine as array_combine;
  */
 final class SettingsForm extends ConfigFormBase {
 
+  const CONFIG_NAME = 'dpl_event.settings';
+
   /**
    * Constructor for the settings form.
    */
@@ -40,21 +42,21 @@ final class SettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function getFormId(): string {
-    return 'dpl_event_settings';
+    return self::CONFIG_NAME;
   }
 
   /**
    * {@inheritdoc}
    */
   protected function getEditableConfigNames(): array {
-    return ['dpl_event.settings'];
+    return [self::CONFIG_NAME];
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
-    $config = $this->config('dpl_event.settings');
+    $config = $this->config(self::CONFIG_NAME);
 
     $form['unpublish'] = [
       '#type' => 'fieldset',
@@ -99,7 +101,7 @@ final class SettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
-    $this->config('dpl_event.settings')
+    $this->config(self::CONFIG_NAME)
       ->set('unpublish_schedule', $form_state->getValue('unpublish_schedule'))
       ->save();
     parent::submitForm($form, $form_state);

--- a/web/modules/custom/dpl_event/src/Form/SettingsForm.php
+++ b/web/modules/custom/dpl_event/src/Form/SettingsForm.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\dpl_event\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use function Safe\array_combine as array_combine;
+
+/**
+ * Configure Event settings for this site.
+ */
+final class SettingsForm extends ConfigFormBase {
+
+  /**
+   * Constructor for the settings form.
+   */
+  public function __construct(
+      ConfigFactoryInterface $config_factory,
+      private DateFormatterInterface $dateFormatter
+  ) {
+    parent::__construct($config_factory);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+          $container->get('config.factory'),
+          $container->get('date.formatter')
+      );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'dpl_event_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return ['dpl_event.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('dpl_event.settings');
+
+    $form['unpublish'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Automatic unpublication', [], ['context' => 'DPL event']),
+    ];
+
+    $period = [
+    // 6 hours
+      21600,
+    // 12 hours
+      43200,
+    // 1 day
+      86400,
+    // 3 days
+      259200,
+    // 1 week
+      604800,
+    // 2 weeks
+      1209600,
+    // 1 month
+      2592000,
+    // 3 months
+      7776000,
+    // 6 months
+      15552000,
+    ];
+    $period = array_map([$this->dateFormatter, 'formatInterval'], array_combine($period, $period));
+    $form['unpublish']['unpublish_schedule'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Schedule', [], ['context' => "DPL event"]),
+      '#default_value' => $config->get('unpublish_schedule'),
+      '#options' => $period,
+      '#empty_option' => $this->t('Automatic unpublication disabled', [], ['context' => "DPL event"]),
+      '#empty_value' => 0,
+      '#description' => $this->t('How much time should pass after an event has occurred before it should be unpublished automatically.', [], ['context' => "DPL event"]),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $this->config('dpl_event.settings')
+      ->set('unpublish_schedule', $form_state->getValue('unpublish_schedule'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/web/modules/custom/dpl_event/src/Workflows/OccurredSchedule.php
+++ b/web/modules/custom/dpl_event/src/Workflows/OccurredSchedule.php
@@ -15,6 +15,8 @@ use Psr\Log\LoggerInterface;
  * Schedule for marking events that are no longer active as occurred.
  */
 class OccurredSchedule {
+  const JOB_SCHEDULE_NAME = 'dpl_event_set_occurred';
+  const JOB_SCHEDULE_TYPE = 'event';
 
   /**
    * Constructor.
@@ -34,7 +36,7 @@ class OccurredSchedule {
    */
   public function getSchedule(): array {
     return [
-      "dpl_event_set_occurred" => [
+      self::JOB_SCHEDULE_NAME => [
         "worker callback" => [$this, 'callback'],
       ],
     ];
@@ -62,8 +64,8 @@ class OccurredSchedule {
     $eventEndDate = (new EventWrapper($event))->getEndDate();
 
     $job = [
-      'name' => 'dpl_event_set_occurred',
-      'type' => 'event',
+      'name' => self::JOB_SCHEDULE_NAME,
+      'type' => self::JOB_SCHEDULE_TYPE,
       'id' => $event->id(),
       // The period is the number of seconds to wait between job executions. A
       // negative period means that the job will be executed as soon as

--- a/web/modules/custom/dpl_event/src/Workflows/OccurredSchedule.php
+++ b/web/modules/custom/dpl_event/src/Workflows/OccurredSchedule.php
@@ -69,7 +69,9 @@ class OccurredSchedule {
     if (!$event_date_values || empty($event_date_values["end_value"])) {
       return;
     }
-    $event_end_date = new DateTimeImmutable($event_date_values["end_value"]);
+    // Drupal stores dates in UTC by default but if no timezone is specified
+    // then the default timezone will be assumed.
+    $event_end_date = new DateTimeImmutable($event_date_values["end_value"], new \DateTimeZone('UTC'));
     $event_end_timestamp = $event_end_date->getTimestamp();
 
     $job = [

--- a/web/modules/custom/dpl_event/src/Workflows/OccurredSchedule.php
+++ b/web/modules/custom/dpl_event/src/Workflows/OccurredSchedule.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\dpl_event\Workflows;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\dpl_event\EventState;
+use Drupal\job_scheduler\Entity\JobSchedule;
+use Drupal\job_scheduler\JobSchedulerInterface;
+use Drupal\recurring_events\Entity\EventInstance;
+use Drupal\recurring_events\EventInstanceStorageInterface;
+use Psr\Log\LoggerInterface;
+use Safe\DateTimeImmutable;
+
+/**
+ * Schedule for marking events that are no longer active as occurred.
+ */
+class OccurredSchedule {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    private LoggerInterface $logger,
+    private TimeInterface $time,
+    private JobSchedulerInterface $jobScheduler,
+    private EventInstanceStorageInterface $eventInstanceStorage,
+  ) {}
+
+  /**
+   * Schedule for hook_cron_job_scheduler_info().
+   *
+   * @return non-empty-array<string, array{'worker callback': callable}>
+   *   Job scheduler information.
+   */
+  public function getSchedule(): array {
+    return [
+      "dpl_event_set_occurred" => [
+        "worker callback" => [$this, 'callback'],
+      ],
+    ];
+  }
+
+  /**
+   * The callback which will be triggered when the scheduled event occurs.
+   */
+  public function callback(JobSchedule $job): void {
+    $event = $this->eventInstanceStorage->load($job->getId());
+    if (!$event || !$event instanceof EventInstance) {
+      return;
+    }
+
+    if ($this->isActive($event)) {
+      $event->set("field_event_state", EventState::Occurred);
+      $event->save();
+    }
+  }
+
+  /**
+   * Schedule setting an event to occurred in the future.
+   */
+  public function scheduleOccurred(EventInstance $event): void {
+    $now_timestamp = $this->time->getCurrentTime();
+
+    $event_date = $event->get('date')->get(0);
+    if (!$event_date) {
+      return;
+    }
+    $event_date_values = $event_date->getValue();
+    if (!$event_date_values || empty($event_date_values["end_value"])) {
+      return;
+    }
+    $event_end_date = new DateTimeImmutable($event_date_values["end_value"]);
+    $event_end_timestamp = $event_end_date->getTimestamp();
+
+    $job = [
+      'name' => 'dpl_event_set_occurred',
+      'type' => 'event',
+      'id' => $event->id(),
+      // The period is the number of seconds to wait between job executions. A
+      // negative period means that the job will be executed as soon as
+      // possible. By setting periodic false the job is only executed once.
+      'period' => $event_end_timestamp - $now_timestamp,
+      'periodic' => FALSE,
+    ];
+
+    // Remove any preexisting job with the same name, type and id.
+    $this->jobScheduler->remove($job);
+    // Schedule the new update.
+    $this->jobScheduler->set($job);
+
+    $this->logger->debug(
+      'Scheduled "occurred" update for event %event_id at %end_time',
+      ['%event_id' => $event->id(), '%end_time' => $event_end_date->format('c')]
+    );
+  }
+
+  /**
+   * Determine if an event is considered active.
+   *
+   * An event is considered active if it has not occurred or been cancelled.
+   */
+  public function isActive(EventInstance $event): bool {
+    $event_states = array_map(function (array $sfield_value): EventState {
+      return EventState::from($sfield_value['value']);
+    }, $event->get("event_state")->getValue());
+
+    return !(in_array(EventState::Cancelled, $event_states)
+      || in_array(EventState::Occurred, $event_states));
+  }
+
+}

--- a/web/modules/custom/dpl_event/src/Workflows/UnpublishSchedule.php
+++ b/web/modules/custom/dpl_event/src/Workflows/UnpublishSchedule.php
@@ -18,6 +18,8 @@ use Drupal\recurring_events\EventInstanceStorageInterface;
  * Schedule for automatically marking events.
  */
 final class UnpublishSchedule {
+  const JOB_SCHEDULE_NAME = 'dpl_event_unpublish';
+  const JOB_SCHEDULE_TYPE = 'eventinstance';
 
   /**
    * Constructor.
@@ -38,7 +40,7 @@ final class UnpublishSchedule {
    */
   public function getSchedule(): array {
     return [
-      'dpl_event_unpublish' => [
+      self::JOB_SCHEDULE_NAME => [
         'worker callback' => [$this, 'callback'],
       ],
     ];
@@ -80,8 +82,8 @@ final class UnpublishSchedule {
     $unpublication_timestamp = $unpublication_date->getTimestamp();
 
     $job = [
-      'name' => 'dpl_event_unpublish',
-      'type' => 'eventinstance',
+      'name' => self::JOB_SCHEDULE_NAME,
+      'type' => self::JOB_SCHEDULE_TYPE,
       'id' => $event->id(),
       // The period is the number of seconds to wait between job executions. A
       // negative period means that the job will be executed as soon as
@@ -111,7 +113,7 @@ final class UnpublishSchedule {
    * scheduled in the past.
    */
   public function rescheduleAll(): void {
-    $this->jobScheduler->removeAll('dpl_event_unpublish', 'eventinstance');
+    $this->jobScheduler->removeAll(self::JOB_SCHEDULE_NAME, self::JOB_SCHEDULE_TYPE);
 
     $publishedEventInstanceIds = ($this->eventInstanceStorage->getQuery())
       ->accessCheck(FALSE)

--- a/web/modules/custom/dpl_event/src/Workflows/UnpublishSchedule.php
+++ b/web/modules/custom/dpl_event/src/Workflows/UnpublishSchedule.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\dpl_event\Workflows;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\dpl_event\Form\SettingsForm;
+use Drupal\job_scheduler\Entity\JobSchedule;
+use Drupal\job_scheduler\JobSchedulerInterface;
+use Drupal\recurring_events\Entity\EventInstance;
+use Drupal\recurring_events\EventInstanceStorageInterface;
+use Safe\DateTimeImmutable;
+
+/**
+ * Schedule for automatically marking events.
+ */
+final class UnpublishSchedule {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    private LoggerChannelInterface $logger,
+    private TimeInterface $time,
+    private JobSchedulerInterface $jobScheduler,
+    private EventInstanceStorageInterface $eventInstanceStorage,
+    private ConfigFactoryInterface $configFactory
+  ) {}
+
+  /**
+   * Schedule for hook_cron_job_scheduler_info().
+   *
+   * @return non-empty-array<string, array{'worker callback': callable}>
+   *   Job scheduler information.
+   */
+  public function getSchedule(): array {
+    return [
+      'dpl_event_unpublish' => [
+        'worker callback' => [$this, 'callback'],
+      ],
+    ];
+  }
+
+  /**
+   * Callback to execute scheduled unpublication.
+   */
+  public function callback(JobSchedule $job): void {
+    $event = $this->eventInstanceStorage->load($job->getId());
+    if (!$event || !$event instanceof EventInstance) {
+      throw new \UnexpectedValueException("Unable to load event instance {$job->getId()} for automatic unpublication");
+    }
+
+    $event->setUnpublished()->save();
+
+    // If all instances in the series are unpublished then also unpublish the
+    // series.
+    $eventSeries = $event->getEventSeries();
+    $allEventInstances = $eventSeries->get('event_instances')->referencedEntities();
+    $publishedInstances = array_filter($allEventInstances, function (EventInstance $event) {
+      return $event->isPublished();
+    });
+    if (empty($publishedInstances)) {
+      $eventSeries->setUnpublished()->save();
+    }
+  }
+
+  /**
+   * Schedule unpublication of an event instance.
+   */
+  public function scheduleUnpublication(EventInstance $event): void {
+    $config = $this->configFactory->get(SettingsForm::CONFIG_NAME);
+    $schedule = (int) $config->get('unpublish_schedule');
+    $now_timestamp = $this->time->getCurrentTime();
+
+    $event_date = $event->get('date')->get(0);
+    if (!$event_date) {
+      return;
+    }
+    $event_date_values = $event_date->getValue();
+    if (!$event_date_values || empty($event_date_values["end_value"])) {
+      return;
+    }
+    // Drupal stores dates in UTC by default but if no timezone is specified
+    // then the default timezone will be assumed.
+    $event_end_date = new DateTimeImmutable($event_date_values["end_value"], new \DateTimeZone('UTC'));
+    $unpublication_date = $event_end_date->modify("+{$schedule} seconds");
+    $unpublication_timestamp = $unpublication_date->getTimestamp();
+
+    $job = [
+      'name' => 'dpl_event_unpublish',
+      'type' => 'eventinstance',
+      'id' => $event->id(),
+      // The period is the number of seconds to wait between job executions. A
+      // negative period means that the job will be executed as soon as
+      // possible. By setting periodic false the job is only executed once.
+      'period' => $unpublication_timestamp - $now_timestamp,
+      'periodic' => FALSE,
+    ];
+
+    // Remove any preexisting job with the same name, type and id.
+    $this->jobScheduler->remove($job);
+    // If automatic unpublication is enabled and needed then schedule a new
+    // unpublication.
+    if ($schedule > 0 && $event->isPublished()) {
+      $this->jobScheduler->set($job);
+
+      $this->logger->debug(
+        'Scheduled unpublication for event %event_id at %end_time',
+        ['%event_id' => $event->id(), '%end_time' => $unpublication_date->format('c')]
+      );
+    }
+  }
+
+  /**
+   * Reschedule all event instances for unpublication.
+   *
+   * This will update schedules for all events even those that where not
+   * scheduled in the past.
+   */
+  public function rescheduleAll(): void {
+    $this->jobScheduler->removeAll('dpl_event_unpublish', 'eventinstance');
+
+    $publishedEventInstanceIds = ($this->eventInstanceStorage->getQuery())
+      ->accessCheck(FALSE)
+      ->condition('status', 1)
+      ->execute();
+    /** @var \Drupal\recurring_events\Entity\EventInstance[] $publishedEventInstances */
+    $publishedEventInstances = $this->eventInstanceStorage->loadMultiple($publishedEventInstanceIds);
+
+    array_walk($publishedEventInstances, function (EventInstance $event) {
+      $this->scheduleUnpublication($event);
+    });
+  }
+
+}

--- a/web/modules/custom/drupal_typed/drupal_typed.info.yml
+++ b/web/modules/custom/drupal_typed/drupal_typed.info.yml
@@ -1,0 +1,5 @@
+name: "DrupalTyped"
+type: module
+description: "Better, faster, stronger types"
+package: Development
+core_version_requirement: ^10

--- a/web/modules/custom/drupal_typed/src/DrupalTyped.php
+++ b/web/modules/custom/drupal_typed/src/DrupalTyped.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\drupal_typed;
+
+/**
+ * Static Service Container wrapper with improved handling types.
+ *
+ * This is basically a wrapper around \Drupal with methods for ensuring and
+ * communicating types to the surrounding codebase.
+ */
+class DrupalTyped {
+
+  /**
+   * Retrieves a service from the container.
+   *
+   * @param class-string<T> $className
+   *   The required class name of the service to retrieve.
+   * @param string $serviceName
+   *   The ID of the service to retrieve.
+   *
+   * @template T of object
+   *
+   * @return T
+   *   The specified service.
+   */
+  public static function service(string $className, string $serviceName): object {
+    $service = \Drupal::service($serviceName);
+    if (!$service instanceof $className) {
+      $actualClass = get_class($service);
+      throw new \LogicException("Service {$serviceName} of class {$actualClass} is not of class {$className}");
+    }
+    return $service;
+  }
+
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-240

#### Description

This PR adds support for automatic unpublishing of events a configurable time period after they have occured.

At the high level this consists of:

1. A new configuration form for handling this is added
2. A new job schedule for unpublishing events is implemented

In the process of implementing this some things were refactored along the way. I recommend reading the commits one by one reading the additional commentary there.

#### Additional comments or questions

Since Benjamin is on vacation I have also requested a review from @spaceo and @Dresse. If one of you can take a look today I would appreciate it. If this is accepted by @LasseStaus or @kasperbirch1 before then I will merge it at the end of the day.
