### PR TITLE
Drop any existing database before restoring from dump

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -226,6 +226,7 @@ tasks:
   dev:restore:database:
     desc: 'Restore database from db dump file. Only one sql should be present the "{{ .DIR_RESTORE_DATABASE }}" directory.'
     cmds:
+      - task dev:cli -- drush sql:drop -y
       - docker-compose exec -T {{ .MYSQL_CONTAINER }} mysql < {{ .SQL_FILE }}
       - task dev:cache:clear:all
     preconditions:


### PR DESCRIPTION
#### Description

A database dump may not drop all existing tables if they were not known at the time of the backup. Consequently they will be left in the database after the restore.

This can cause problems if the tables are created by modules. (Re)installing these modules will fail after restoring as their table already exists.

Use Drush to drop the entire database before restoring to ensure we are in a clean state.