### PR TITLE
DDFLSBP-465 - Add custom template for user creation page

### DIFF
--- a/web/themes/custom/novel/templates/layout/page--user--registration--create.html.twig
+++ b/web/themes/custom/novel/templates/layout/page--user--registration--create.html.twig
@@ -1,0 +1,52 @@
+{#
+/**
+ * @file
+ * Theme override to display a user/registration/create page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+<div>
+  {{ drupal_block('system_messages_block') }}
+
+  <main id="main-content" role="main">
+    {{ page.content }}
+  </main>
+</div>

--- a/web/themes/custom/novel/templates/layout/page--user--registration--create.html.twig
+++ b/web/themes/custom/novel/templates/layout/page--user--registration--create.html.twig
@@ -3,8 +3,10 @@
  * @file
  * Theme override to display a user/registration/create page.
  *
- * The doctype, html, head and body tags are not in this template. Instead they
- * can be found in the html.html.twig template in this directory.
+ * This template is a variant of the page.html.twig template used for rendering
+ * the user registration page. As we don't want the user accessing things outside
+ * of the registration form, we have removed the header and footer regions for this
+ * page.
  *
  * Available variables:
  *


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-465

#### Description

This PR adds a new custom template for the user registration page (`user/registration/create`)
The template is a stripped down version of the normal page template. It removes the header and footer sections of the page.

This PR also has a sister PR: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1019

#### Screenshot of the result

![Screenshot 2024-03-11 at 12 10 59](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/6142323/15fd4deb-f16a-4b10-b821-039598a19d83)


#### Additional comments or questions

This PR has a sister PR in dpl-react: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1019
