### PR TITLE
Fix markup for `place` in Event page

### DIFF
--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-place.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-place.html.twig
@@ -1,1 +1,3 @@
-{% include '@novel/components/list-item-content-location.html.twig' %}
+{% for item in items %}
+    {{ item.content }}
+{% endfor %}


### PR DESCRIPTION
#### Link to issue


#### Description

This pull request fixes the markup for the `place` element in the Event page. 

#### Screenshot of the result
<img width="1250" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/dcdbddb8-ef79-4c06-bac4-79f0cd307d67">
