### PR TITLE
Do not clone branches when cloning content

### DIFF
--- a/config/sync/entity_clone.settings.yml
+++ b/config/sync/entity_clone.settings.yml
@@ -8,7 +8,7 @@ form_settings:
     disable: true
     hidden: true
   node:
-    default_value: true
+    default_value: false
     disable: true
     hidden: true
   user:


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-402

#### Description

Currently a branch will be cloned if an entity referencing the branch is cloned. This is a result of the configuration that:

1. Cloning is enabled for content (nodes)
2. Cloning of (related) nodes are enabled by default
3. Cloning of (related) nodes is hidden on the clone form making both the problem and the solution harder to figure out.

We cannot configure cloning per bundle/content type so instead we change the configuration so that cloning of related nodes is disabled by default.

This could potentially cause us not to clone other nodes that we want to clone but we will have to cross that bridge if/when we get to it.

We do not change any other setting in this context. The current configuration that the only clonable entities are nodes, event series and paragraphs ensures that whatever related cloning settings are set for other entity types should not matter for us currently.

#### Additional comments or questions

Reviewing this is hard. I suggest that you test it through the following steps

1. Attach a branch to an article or page
2. Clone the article or page
3. See that the branch is not cloned also