### PR TITLE
Prevent warning when displaying period for past event

### DIFF
--- a/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
+++ b/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
@@ -116,6 +116,10 @@ class ReoccurringDateFormatter {
       ->sort('date.value', 'ASC')
       ->execute();
 
+    if (empty($upcoming_ids)) {
+      return NULL;
+    }
+
     // Load the first event instance - the remaining IDs are useful later on,
     // when we want to check if it is alone or not.
     $upcoming_event_id = reset($upcoming_ids);


### PR DESCRIPTION
#### Description

Do not try to load event instances if no ids for future events can be found.

This will cause an empty value to be passed to `EventInstance::load()` which in turn will issue a PHP warning.

#### Screenshot of the result

Before this change the following error was raised:

![Monosnap | DPL CMS 2024-03-11 20-47-19](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/fb47b77f-2257-4372-b345-beb8fdd4bb10)
