### PR TITLE
Update permission required to view event settings

### DIFF
--- a/web/modules/custom/dpl_event/dpl_event.routing.yml
+++ b/web/modules/custom/dpl_event/dpl_event.routing.yml
@@ -4,4 +4,4 @@ dpl_event.settings:
     _title: "Event settings"
     _form: 'Drupal\dpl_event\Form\SettingsForm'
   requirements:
-    _permission: "administer event configuration"
+    _permission: "administer library agency configuration"


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-240

#### Description

Currently only user 1 can access the event settings. The current permission is not defined elsewhere and consequently cannot be enabled for roles.

Use the somewhat generic administer library agency configuration permission for now. It seems to be what we are using elsewhere for configuration of similar library specific information.
