### PR TITLE
Increase time for Lagoon environments to become available to 15 mins

### DIFF
--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -52,7 +52,7 @@ jobs:
           resource: ${{ steps.environment.outputs.url }}
           # Time in ms. Wait for 15 mins for deployment to complete. We have
           # seen deployments taking up to 12 mins.
-          timeout: 600000
+          timeout: 900000
           # Poll every 10 seconds. For whatever reason Lagoon environments may
           # return 200 during the deployment process even though the deployment
           # is not complete. Reduce polling interval to the risk of this


### PR DESCRIPTION
#### Description

According to the preceeding comment this was actually as intended. The current value of 600000ms is 10mins and gets it wrong.

In practice 10mins is still not long enough for environments to become available.

900000ms is the correct value.