### PR TITLE
Styled error messages in Drupal

### DIFF
--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -125,6 +125,7 @@ function dpl_react_apps_texts(): array {
     'delete-reservation-modal-not-regrettable' => t('You cannot regret this action', [], ['context' => 'Global']),
     'digital-reservations-header' => t('Digital reservations', [], ['context' => 'Global']),
     'et-al' => t('et al.', [], ['context' => 'Global']),
+    'error-boundary-alert-body-button-aria' => t('Close error message', [], ['context' => 'React apps (Global error handling)']),
     'find-on-shelf-expand-button-explanation' => t('Find on shelf expand button explanation', [], ['context' => 'Global']),
     'find-on-shelf-table-description' => t('Find @work on shelf in the @branch branch', [], ['context' => 'Global']),
     'group-modal-button' => t('Renewable (@count)', [], ['context' => 'Global']),

--- a/web/themes/custom/novel/templates/error-message.html.twig
+++ b/web/themes/custom/novel/templates/error-message.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Theme override for status messages.
+ *
+ * Displays status, error, and warning messages, grouped by type.
+ *
+ * An invisible heading identifies the messages for assistive technology.
+ * Sighted users see a colored box. See http://www.w3.org/TR/WCAG-TECHS/H69.html
+ * for info.
+ *
+ * Add an ARIA label to the contentinfo area so that assistive technology
+ * user agents will better describe this landmark.
+ *
+ * Available variables:
+ * - message_list: List of messages to be displayed, grouped by type.
+ * - status_headings: List of all status types.
+ * - attributes: HTML attributes for the element, including:
+ *   - class: HTML classes.
+ */
+#}
+
+ <div class="error-message">
+  <div class="error-message__icon">
+    <img
+      src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-warning.svg"
+      alt="{{ 'Error warning icon'|t({}, {'context': 'Global error handling'}) }}"
+    />
+  </div>
+  <div class="error-message__description">
+    {{ message }}
+  </div>
+</div>

--- a/web/themes/custom/novel/templates/error-message.html.twig
+++ b/web/themes/custom/novel/templates/error-message.html.twig
@@ -1,22 +1,12 @@
 {#
 /**
  * @file
- * Theme override for status messages.
+ * Custom error message template
  *
- * Displays status, error, and warning messages, grouped by type.
- *
- * An invisible heading identifies the messages for assistive technology.
- * Sighted users see a colored box. See http://www.w3.org/TR/WCAG-TECHS/H69.html
- * for info.
- *
- * Add an ARIA label to the contentinfo area so that assistive technology
- * user agents will better describe this landmark.
+ * Used to display error messages.
  *
  * Available variables:
- * - message_list: List of messages to be displayed, grouped by type.
- * - status_headings: List of all status types.
- * - attributes: HTML attributes for the element, including:
- *   - class: HTML classes.
+ * - message: The error message to show.
  */
 #}
 

--- a/web/themes/custom/novel/templates/status-messages.html.twig
+++ b/web/themes/custom/novel/templates/status-messages.html.twig
@@ -1,0 +1,58 @@
+
+{#
+/**
+ * @file
+ * Theme override for status messages.
+ *
+ * Displays status, error, and warning messages, grouped by type.
+ *
+ * An invisible heading identifies the messages for assistive technology.
+ * Sighted users see a colored box. See http://www.w3.org/TR/WCAG-TECHS/H69.html
+ * for info.
+ *
+ * Add an ARIA label to the contentinfo area so that assistive technology
+ * user agents will better describe this landmark.
+ *
+ * Available variables:
+ * - message_list: List of messages to be displayed, grouped by type.
+ * - status_headings: List of all status types.
+ * - attributes: HTML attributes for the element, including:
+ *   - class: HTML classes.
+ */
+#}
+<div data-drupal-messages>
+{% for type, messages in message_list %}
+  <div role="contentinfo" aria-label="{{ status_headings[type] }}"{{ attributes|without('role', 'aria-label') }}>
+    {% if type == 'error' %}
+      <div role="alert">
+    {% endif %}
+    {% if status_headings[type] %}
+      <h2 class="visually-hidden">{{ status_headings[type] }}</h2>
+    {% endif %}
+    {% if messages|length > 1 %}
+      <ul>
+        {% for message in messages %}
+          <li>
+            {% if type != 'error' %}
+              {{ message }}
+            {% endif %}
+            {% if type == 'error' %}
+              {% include '@novel/error-message.html.twig' with {message: message} %}
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      {% if type != 'error' %}
+        {{ messages|first }}
+      {% endif %}
+      {% if type == 'error' %}
+        {% include '@novel/error-message.html.twig' with {message: messages|first} %}
+      {% endif %}
+    {% endif %}
+    {% if type == 'error' %}
+      </div>
+    {% endif %}
+  </div>
+{% endfor %}
+</div>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-488

#### Description

Apply styling to error messages

By adding template files that utilizes the markup/classes from the
design system

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/998889/bd2b073e-e033-439a-9326-82fe722233ec)

