### PR TITLE
Ddfform 396 paragraph navigation grid ikke logisk visning af tre elementer

### DIFF
--- a/web/themes/custom/novel/templates/components/nav-grid.html.twig
+++ b/web/themes/custom/novel/templates/components/nav-grid.html.twig
@@ -5,7 +5,6 @@
 {%
   set classes = [
     'nav-grid',
-    'nav-grid--count-' ~ items|length,
     show_subtitles ? 'nav-grid--expanded' : 'nav-grid--simple',
     has_many ? 'nav-grid--has-many' : '',
     has_many ? 'nav-grid--folded' : '',
@@ -18,17 +17,16 @@
     <h2 class="nav-grid__title">{{ title }}</h2>
   {% endif %}
 </div>
-<div class="nav-grid__items">
+<ul class="nav-grid__items">
   {% for item in items %}
-    <div class="nav-grid__item">
+    <li class="nav-grid__item">
       {{- item.content|default(item) -}}
-    </div>
+    </li>
   {% endfor %}
-</div>
+</ul>
   {% if has_many %}
     <button class="nav-grid__controller btn-primary btn-outline btn-medium">
       {{ 'Show all'|trans }}
     </button>
   {% endif %}
-
 </div>

--- a/web/themes/custom/novel/templates/components/nav-grid.html.twig
+++ b/web/themes/custom/novel/templates/components/nav-grid.html.twig
@@ -12,21 +12,21 @@
 %}
 
 <div {{ attributes.addClass(classes) }}>
-<div class="nav-grid__header">
-  {% if title %}
-    <h2 class="nav-grid__title">{{ title }}</h2>
-  {% endif %}
-</div>
-<ul class="nav-grid__items">
-  {% for item in items %}
-    <li class="nav-grid__item">
-      {{- item.content|default(item) -}}
-    </li>
-  {% endfor %}
-</ul>
-  {% if has_many %}
-    <button class="nav-grid__controller btn-primary btn-outline btn-medium">
-      {{ 'Show all'|trans }}
-    </button>
-  {% endif %}
+    <div class="nav-grid__header">
+        {% if title %}
+            <h2 class="nav-grid__title">{{ title }}</h2>
+        {% endif %}
+    </div>
+    <ul class="nav-grid__items">
+        {% for item in items %}
+            <li class="nav-grid__item">
+                {{- item.content|default(item) -}}
+            </li>
+        {% endfor %}
+    </ul>
+    {% if has_many %}
+        <button class="nav-grid__controller btn-primary btn-outline btn-medium">
+            {{ 'Show all'|trans }}
+        </button>
+    {% endif %}
 </div>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-396

#### Description

This pull request removes the class `nav-grid--count-*` from the `nav-grid.html.twig` file in order to align with the changes in the DPL design system.
https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/549