### PR TITLE
Remove field-ticket-categories.html.twig template.

### DIFF
--- a/web/themes/custom/novel/templates/fields/field--field-ticket-categories.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-ticket-categories.html.twig
@@ -1,8 +1,0 @@
-{% if items|length == 1 %}
-  {# Events with a single ticket category should only show the price. #}
-  <span>{{ items.0.content['#paragraph'].field_ticket_category_price|view }}</span>
-{% else %}
-  {% for item in items %}
-    {{ item.content }}
-  {% endfor %}
-{% endif %}


### PR DESCRIPTION

#### Link to issue

[DDFFORM-366](https://reload.atlassian.net/browse/DDFFORM-366)

#### Description

This PR ensures that ticket categories will always be shown on event series. 

Before, we only wanted to show the price, if there were multiple ticket categories with different prices. This is no longer the case. 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/a54649e6-1bd1-46dc-9a19-a5bdcb82d413)
#### Additional comments or questions

