### PR TITLE
Add support for TwentyThree video platform

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -82,6 +82,7 @@ module:
   media: 0
   media_library: 0
   media_library_edit: 0
+  media_twentythree: 0
   menu_link_content: 0
   menu_ui: 0
   metatag: 0

--- a/web/modules/custom/media_twentythree/README.md
+++ b/web/modules/custom/media_twentythree/README.md
@@ -1,0 +1,30 @@
+# Media: TwentyThree
+
+[TwentyThree](https://www.twentythree.com/) is a video platform. [It supports oEmbed](https://www.twentythree.com/help/manage-oembed)
+which is also supported by Drupal Core.
+
+Integration between the two is somewhat tricky.
+
+TwentyThree is not listed on [the official list of oEmbed providers](https://www.twentythree.com/)
+In practice it is not possible to get the platform listed here either. It is a
+whitelabel software-as-a-service platform which can be exposed using custom
+domains. This makes it impossible to add a finite list of url schemes and
+endpoints supported by TwentyThree.
+
+The [oEmbed Providers Drupal module](https://www.drupal.org/project/oembed_providers)
+could be used to allow administrators to define their TwentyThree platform with
+its custom domain as an oEmbed Provider.
+
+This has two drawbacks:
+
+1. It is somewhat technical
+2. It does not integrate with the Core Media module in adding the new providers
+   to the list of supported oEmbed providers for remote video. Instead one has
+   to create a new media type for the provider.
+
+Instead this module integrates with TwentyThree in a way which should be easy
+for editors to use:
+
+1. It adds TwentyThree to the list of supported providers for remote video
+2. Through oEmbed discovery it allows editors to add videos from whatever
+   TwentyThree site using whatever domain.

--- a/web/modules/custom/media_twentythree/media_twentythree.info.yml
+++ b/web/modules/custom/media_twentythree/media_twentythree.info.yml
@@ -1,0 +1,8 @@
+name: "TwentyThree"
+type: module
+description: "Integrate the TwentyThree video platform into the Media module with oEmbed support"
+package: Media
+core_version_requirement: ^10
+
+dependencies:
+  - drupal:media

--- a/web/modules/custom/media_twentythree/media_twentythree.module
+++ b/web/modules/custom/media_twentythree/media_twentythree.module
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for TwentyThree module.
+ */
+
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\media\OEmbed\Provider;
+use Drupal\media_twentythree\ProviderRepositoryDecorator;
+
+/**
+ * Implements hook_media_source_info_alter().
+ *
+ * @param mixed[] $sources
+ *   Information about media sources.
+ */
+function media_twentythree_media_source_info_alter(array &$sources): void {
+  if (empty($sources["oembed:video"])) {
+    \Drupal::logger('media_twentythree')->warning('Unable to locate oEmbed video media source');
+  }
+
+  // Add TwentyThree to the list of supported providers for the native video
+  // media type alongside YouTube and Vimeo.
+  $sources["oembed:video"]["providers"][] = ProviderRepositoryDecorator::TWENTY_THREE_PROVIDER_NAME;
+}
+
+/**
+ * Implements hook_resource_url_alter().
+ *
+ * @param array{path: string, query: string[], fragment: string} $parsed_url
+ *   The resource url.
+ */
+function media_twentythree_oembed_resource_url_alter(array &$parsed_url, Provider $provider): void {
+  if ($provider->getName() != ProviderRepositoryDecorator::TWENTY_THREE_PROVIDER_NAME) {
+    return;
+  }
+
+  // Rewrite the resource url to use the path found with autodiscovery.
+  // As Twentythree is a whitelabel SaaS product which can be exposed on custom
+  // domains we do not have a fixed resource url for this provider. Instead use
+  // the one the resource defines in autodiscovery.
+  /** @var \Drupal\media_twentythree\DiscoveryUrlResolver $url_resolver */
+  $url_resolver = Drupal::service('media_twentythree.oembed.url_resolver');
+  $resource_url = $url_resolver->discoverResourceUrl($parsed_url['query']['url']);
+  if (!is_string($resource_url)) {
+    // If no resource url is discovered then do nothing.
+    return;
+  }
+
+  /** @var array{path: string, query: string[], fragment: string} $resource_url */
+  $resource_url = UrlHelper::parse($resource_url);
+
+  $parsed_url["path"] = $resource_url["path"];
+}

--- a/web/modules/custom/media_twentythree/media_twentythree.services.yml
+++ b/web/modules/custom/media_twentythree/media_twentythree.services.yml
@@ -1,0 +1,9 @@
+services:
+  media_twentythree.oembed.provider_repository:
+    decorates: media.oembed.provider_repository
+    class: Drupal\media_twentythree\ProviderRepositoryDecorator
+    public: false
+    arguments: ["@media_twentythree.oembed.provider_repository.inner"]
+  media_twentythree.oembed.url_resolver:
+    class: Drupal\media_twentythree\DiscoveryUrlResolver
+    parent: media.oembed.url_resolver

--- a/web/modules/custom/media_twentythree/src/DiscoveryUrlResolver.php
+++ b/web/modules/custom/media_twentythree/src/DiscoveryUrlResolver.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\media_twentythree;
+
+use Drupal\media\OEmbed\UrlResolver;
+
+/**
+ * Url resolver with support for public discovery of resource urls.
+ */
+class DiscoveryUrlResolver extends UrlResolver {
+
+  /**
+   * {@inheritDoc}
+   *
+   * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+   */
+  public function discoverResourceUrl($url) {
+    // For whatever reason this method is protected in the parent class.
+    return parent::discoverResourceUrl($url);
+  }
+
+}

--- a/web/modules/custom/media_twentythree/src/ProviderRepositoryDecorator.php
+++ b/web/modules/custom/media_twentythree/src/ProviderRepositoryDecorator.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\media_twentythree;
+
+use Drupal\media\OEmbed\Provider;
+use Drupal\media\OEmbed\ProviderRepositoryInterface;
+
+/**
+ * Drupal Core oEmbed provider repository decorator which adds TwentyThree.
+ */
+final class ProviderRepositoryDecorator implements ProviderRepositoryInterface {
+
+  // This name must match the value exposed from the TwentyThree oEmbed
+  // endpoint under "provider_name".
+  const TWENTY_THREE_PROVIDER_NAME = "TwentyThree";
+
+  /**
+   * Constructs a ProviderRepositoryDecorator object.
+   */
+  public function __construct(
+    private ProviderRepositoryInterface $mediaOembedProviderRepository,
+  ) {}
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getAll(): array {
+    $providers = $this->mediaOembedProviderRepository->getAll();
+    $providers[self::TWENTY_THREE_PROVIDER_NAME] = $this->getProvider();
+    return $providers;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function get($provider_name): Provider {
+    if ($provider_name == self::TWENTY_THREE_PROVIDER_NAME) {
+      return $this->getProvider();
+    }
+    return $this->mediaOembedProviderRepository->get($provider_name);
+  }
+
+  /**
+   * Build an oEmbed provider for TwentyThree.
+   */
+  private function getProvider(): Provider {
+    return new Provider(
+      self::TWENTY_THREE_PROVIDER_NAME,
+      "https://www.twentythree.com/",
+      [
+        [
+          // oEmbed providers require an endpoint to be defined. Here it is a
+          // dummy value as we cannot provide a fixed set of endpoints due to
+          // the nature of the TwentyThree product.
+          // @see media_twentythree_oembed_resource_url_alter()
+          'url' => "https://www.twentythree.com/oembed",
+        ],
+      ]
+    );
+  }
+
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-427

#### Description

Some public libraries use the TwentyThree video platform. This platform supports oEmbed which we currently use for using remote video.

However it is not supported out of the box - partly because it is not listed on the official list of oEmbed providers on https://oembed.com/providers.json. In practice it is not possible to get the platform listed here either. It is a whitelabel software-as-a-service platform which can be exposed using custom domains. This makes it impossible to add a finite list of url schemes and endpoints supported by TwentyThree.

We could in theory use the oEmvbed Providers Drupal module to allow libraries to define their TwentyThree platform with its custom domain as an oEmbed Provider.
https://www.drupal.org/project/oembed_providers

This has two drawbacks:

1. It is somewhat technical
2. It does not integrate with the Core Media module in adding the new providers to the list of supported oEmbed providers for remote video. Instead one has to create a new media type for the provider.

Instead we introduce a new module, media_twentythree which integrates with TwentyThree which should be easy for editors to handle:

1. It adds TwentyThree to the list of supported providers for remote video
2. Through oEmbed discovery it allows editors to add videos from whatever TwentyThree site using whatever url.

#### Screenshot of the result

Medie element fra TwentyThree
![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/4fed1dc3-cb99-4d16-abff-93297e2537d5)

Indsættelse af medie fra TwentyThree
![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/3ee85f5c-7f28-41d2-abfd-58d363c6f8cc)

Redigering af side med medie fra TwentyThree
![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/abf3e129-1342-4938-84fd-7e8b37408e19)

Visning af side med medie fra TwentyThree
![billede](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/fe665070-23ab-4252-8009-7697ff548653)
