### PR TITLE
Add Opening Hours Taxonomy and Color Field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
         "drupal/address": "^1.0",
         "drupal/admin_toolbar": "^3.4",
         "drupal/administerusersbyrole": "^3.4",
+        "drupal/color_field": "^3.0",
         "drupal/config_ignore": "^2.4",
         "drupal/content_lock": "^2.3",
         "drupal/core-composer-scaffold": "~10.1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f55d3da64ec2d881b96c8707c530d719",
+    "content-hash": "39624974e770ccc9d22894fc3cad895d",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2214,6 +2214,58 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/better_exposed_filters",
                 "issues": "https://www.drupal.org/project/issues/better_exposed_filters"
+            }
+        },
+        {
+            "name": "drupal/color_field",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/color_field.git",
+                "reference": "3.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/color_field-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "7a72fde925bc777b292aef7afa4ceb98d46cc0b5"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "require-dev": {
+                "drupal/token": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.0.0",
+                    "datestamp": "1671324231",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "NickDickinsonWilde",
+                    "homepage": "https://www.drupal.org/user/3094661"
+                },
+                {
+                    "name": "targoo",
+                    "homepage": "https://www.drupal.org/user/431910"
+                }
+            ],
+            "description": "Provides a color field type to store the color value and opacity.",
+            "homepage": "https://www.drupal.org/project/color_field",
+            "support": {
+                "source": "https://git.drupalcode.org/project/color_field",
+                "error": "require-dev.drupal/feeds : invalid version constraint (Could not parse version constraint : Invalid version string \"\")"
             }
         },
         {

--- a/config/sync/core.entity_form_display.taxonomy_term.opening_hours_categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.opening_hours_categories.default.yml
@@ -13,10 +13,11 @@ bundle: opening_hours_categories
 mode: default
 content:
   field_opening_hours_color:
-    type: color_field_widget_html5
+    type: color_field_widget_box
     weight: 1
     region: content
-    settings: {  }
+    settings:
+      default_colors: '#ac725e,#d06b64,#f83a22,#fa573c,#ff7537,#ffad46,#42d692,#16a765,#7bd148,#b3dc6c,#fbe983,#92e1c0,#9fe1e7,#9fc6e7,#4986e7,#9a9cff,#b99aff,#c2c2c2,#cabdbf,#cca6ac,#f691b2,#cd74e6,#a47ae2'
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/config/sync/core.entity_form_display.taxonomy_term.opening_hours_categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.opening_hours_categories.default.yml
@@ -7,23 +7,14 @@ dependencies:
     - taxonomy.vocabulary.opening_hours_categories
   module:
     - color_field
-    - text
 id: taxonomy_term.opening_hours_categories.default
 targetEntityType: taxonomy_term
 bundle: opening_hours_categories
 mode: default
 content:
-  description:
-    type: text_textarea
-    weight: 1
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
   field_opening_hours_color:
     type: color_field_widget_html5
-    weight: 2
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -36,6 +27,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
+  description: true
   langcode: true
   path: true
   publish_on: true

--- a/config/sync/core.entity_form_display.taxonomy_term.opening_hours_categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.opening_hours_categories.default.yml
@@ -1,0 +1,43 @@
+uuid: 57ccbff2-eb5b-43ac-9cb2-f66a131b311f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.opening_hours_categories.field_opening_hours_color
+    - taxonomy.vocabulary.opening_hours_categories
+  module:
+    - color_field
+    - text
+id: taxonomy_term.opening_hours_categories.default
+targetEntityType: taxonomy_term
+bundle: opening_hours_categories
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_opening_hours_color:
+    type: color_field_widget_html5
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  publish_on: true
+  status: true
+  unpublish_on: true

--- a/config/sync/core.entity_view_display.taxonomy_term.opening_hours_categories.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.opening_hours_categories.default.yml
@@ -1,0 +1,34 @@
+uuid: 4cd8ca49-2dd0-4b24-b5c9-42701f87ed29
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.opening_hours_categories.field_opening_hours_color
+    - taxonomy.vocabulary.opening_hours_categories
+  module:
+    - color_field
+    - text
+id: taxonomy_term.opening_hours_categories.default
+targetEntityType: taxonomy_term
+bundle: opening_hours_categories
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_opening_hours_color:
+    type: color_field_formatter_text
+    label: above
+    settings:
+      format: hex
+      opacity: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -9,6 +9,7 @@ module:
   block: 0
   breakpoint: 0
   ckeditor5: 0
+  color_field: 0
   config_filter: 0
   config_ignore: 0
   content_lock: 0

--- a/config/sync/field.field.taxonomy_term.opening_hours_categories.field_opening_hours_color.yml
+++ b/config/sync/field.field.taxonomy_term.opening_hours_categories.field_opening_hours_color.yml
@@ -1,0 +1,25 @@
+uuid: d50021f5-af80-417c-912c-01cc41f037d0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_opening_hours_color
+    - taxonomy.vocabulary.opening_hours_categories
+  module:
+    - color_field
+id: taxonomy_term.opening_hours_categories.field_opening_hours_color
+field_name: field_opening_hours_color
+entity_type: taxonomy_term
+bundle: opening_hours_categories
+label: 'Opening hours color'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    color: '#999999'
+    opacity: 0.8
+default_value_callback: ''
+settings:
+  opacity: 1
+field_type: color_field_type

--- a/config/sync/field.field.taxonomy_term.opening_hours_categories.field_opening_hours_color.yml
+++ b/config/sync/field.field.taxonomy_term.opening_hours_categories.field_opening_hours_color.yml
@@ -17,7 +17,7 @@ required: false
 translatable: false
 default_value:
   -
-    color: '#999999'
+    color: '#4986e7'
     opacity: 0.8
 default_value_callback: ''
 settings:

--- a/config/sync/field.storage.taxonomy_term.field_opening_hours_color.yml
+++ b/config/sync/field.storage.taxonomy_term.field_opening_hours_color.yml
@@ -1,0 +1,20 @@
+uuid: c465e6f3-cdbb-47ed-85ac-8f8d2812cf67
+langcode: en
+status: true
+dependencies:
+  module:
+    - color_field
+    - taxonomy
+id: taxonomy_term.field_opening_hours_color
+field_name: field_opening_hours_color
+entity_type: taxonomy_term
+type: color_field_type
+settings:
+  format: '#HEXHEX'
+module: color_field
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.taxonomy_term.opening_hours_categories.yml
+++ b/config/sync/language.content_settings.taxonomy_term.opening_hours_categories.yml
@@ -1,0 +1,11 @@
+uuid: f1955f14-2e16-49f8-bd72-e2acb64b32e9
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.opening_hours_categories
+id: taxonomy_term.opening_hours_categories
+target_entity_type_id: taxonomy_term
+target_bundle: opening_hours_categories
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language/da/core.date_format.short.yml
+++ b/config/sync/language/da/core.date_format.short.yml
@@ -1,1 +1,2 @@
 label: 'Standard kort dato'
+pattern: 'm/d/Y - H:i'

--- a/config/sync/taxonomy.vocabulary.opening_hours_categories.yml
+++ b/config/sync/taxonomy.vocabulary.opening_hours_categories.yml
@@ -1,0 +1,24 @@
+uuid: d3f84ae0-e7e3-4832-b10a-49450ad5bca1
+langcode: en
+status: true
+dependencies:
+  module:
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+name: 'Opening hours categories'
+vid: opening_hours_categories
+description: 'This is for adding types of opening hours, e.g. "open" or "Telephone time"'
+weight: 0

--- a/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    b62121d9-62ef-4645-80be-61bc2d3a595d: eventinstance
+    8e3d2c4b-2208-4679-ae5f-74731a767214: eventinstance
     dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0: node
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f: media
@@ -101,7 +101,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: b62121d9-62ef-4645-80be-61bc2d3a595d
+      entity: 8e3d2c4b-2208-4679-ae5f-74731a767214
   field_branch:
     -
       entity: dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0

--- a/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    8e3d2c4b-2208-4679-ae5f-74731a767214: eventinstance
+    28602a8e-98eb-4905-9e13-a58782c2894d: eventinstance
     dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0: node
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f: media
@@ -101,7 +101,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: 8e3d2c4b-2208-4679-ae5f-74731a767214
+      entity: 28602a8e-98eb-4905-9e13-a58782c2894d
   field_branch:
     -
       entity: dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    5698bb31-57b1-4abc-9b2d-de055a307ae2: eventinstance
+    cab5787f-de4f-4a2a-96f6-eb0e96724af3: eventinstance
     852d781f-82c9-40ac-bc8d-d0cefe07706d: node
     f457c4c2-dc28-45cd-9b6e-fda4248d9d45: taxonomy_term
     618e176a-a45a-4c36-a197-664230aa0a34: media
@@ -109,7 +109,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: 5698bb31-57b1-4abc-9b2d-de055a307ae2
+      entity: cab5787f-de4f-4a2a-96f6-eb0e96724af3
   field_branch:
     -
       entity: 852d781f-82c9-40ac-bc8d-d0cefe07706d

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    cab5787f-de4f-4a2a-96f6-eb0e96724af3: eventinstance
+    e424f47d-6b01-443e-8a03-0d3b436e20d3: eventinstance
     852d781f-82c9-40ac-bc8d-d0cefe07706d: node
     f457c4c2-dc28-45cd-9b6e-fda4248d9d45: taxonomy_term
     618e176a-a45a-4c36-a197-664230aa0a34: media
@@ -109,7 +109,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: cab5787f-de4f-4a2a-96f6-eb0e96724af3
+      entity: e424f47d-6b01-443e-8a03-0d3b436e20d3
   field_branch:
     -
       entity: 852d781f-82c9-40ac-bc8d-d0cefe07706d

--- a/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
@@ -5,30 +5,30 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    13a34a1f-dfd4-44c7-b5eb-2df27dff918a: eventinstance
-    98f33e63-cf35-4973-9679-47c3c4cbae08: eventinstance
-    d0326768-c789-40a8-b240-f2092e67dd69: eventinstance
-    e44df3bd-478f-4a63-a92f-b9aa7bfac1cb: eventinstance
-    02860e69-5d1f-450a-91c6-da2d0e460006: eventinstance
-    8f72c5ca-bd0a-4b09-96b7-632f50c50c1f: eventinstance
-    b6706003-cafd-4941-b93d-b21c2f70bd64: eventinstance
-    51c1dda9-6134-44e2-8551-94233710a7e1: eventinstance
-    27dae2f6-4348-4ad8-97d9-07ba8bf19c55: eventinstance
-    53ed575e-9213-438c-8b0f-5365e2a23ded: eventinstance
-    774207a6-8aca-4417-8158-04a2a9a821e3: eventinstance
-    561282f5-918d-4f8c-9467-ff4bd5ce31c1: eventinstance
-    d85af39e-30c3-479a-8618-7314bffdba02: eventinstance
-    7d940a5a-9840-4428-bf3b-140e2e431435: eventinstance
-    ae332e35-be5f-4740-981d-7be19e9312c6: eventinstance
-    f6a5417d-6495-475e-bb4f-5e0db8490f04: eventinstance
-    b0ee1b84-2fe1-458f-9fab-9b50cd2b12ed: eventinstance
-    171e6345-3b37-4b5d-9952-156a3124893f: eventinstance
-    4827e838-7821-4dcc-9953-00e8a0c5e5d8: eventinstance
-    8a79e7bf-1c61-4b20-a4da-acb653719342: eventinstance
-    3fcd360f-20ae-428f-baf5-37bede1ba839: eventinstance
-    16b515b9-0a5c-469d-8d29-c63b60c85e67: eventinstance
-    bcd58b68-0ee1-484d-af3f-f066239f1a8e: eventinstance
-    41377cf1-c5af-483b-ba5e-45cd90624110: eventinstance
+    7188667e-7497-409d-abf9-e82d816c9076: eventinstance
+    c1294fb3-f662-4129-a8b9-a5660b48453f: eventinstance
+    b2be22d3-7757-4af5-ac0f-a1a525a3500b: eventinstance
+    60733077-2d35-4e85-a39b-6a2d5d6e7ead: eventinstance
+    762e792d-9aa7-4452-8481-ece67ce6be1a: eventinstance
+    c6810c6b-3fc9-45c3-af3b-6ae6f3d502ca: eventinstance
+    43ef335d-b3c7-4fe8-8ae0-597dfa04ad22: eventinstance
+    027f8b61-714d-4759-aa1a-0d6913b4e341: eventinstance
+    3abed85c-054a-4377-96e6-74f577ebe111: eventinstance
+    f6169b2d-31b7-458f-89ee-a71e0bd7093b: eventinstance
+    1d4ef0e6-5e48-47ed-b7ed-9beaaf40064b: eventinstance
+    9e98fbf1-8ef5-43e6-9fe7-c66f81f1cc87: eventinstance
+    4582ccc8-ae38-4d8b-937e-53a387eb8916: eventinstance
+    ee78427d-cc6b-4246-8e0e-47e3c7c58b0b: eventinstance
+    367ba067-e53c-4ae1-8b30-f829dfb94743: eventinstance
+    07edc291-5bb9-48e0-9a38-4df1ef284e67: eventinstance
+    7e010c14-6497-4b03-96d4-ae649de1c0fe: eventinstance
+    f35b1d12-9e12-4b15-a356-979485256141: eventinstance
+    28d04879-c8f8-49c1-8550-11e975a9284a: eventinstance
+    e4810e2b-69c4-4766-bebd-096d03544564: eventinstance
+    3c0e7d70-7735-47f1-a614-1e14bb099c8c: eventinstance
+    d2b924c4-77e9-4384-ac41-add5183c4bd3: eventinstance
+    d6ffefcc-90d8-486d-9af0-c4a7c8fbb144: eventinstance
+    12c564b3-f67f-4610-82d7-c4b65b882c16: eventinstance
     dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0: node
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     ca329ad9-5a1c-4f55-b8a9-a60843b66466: media
@@ -127,53 +127,53 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: 13a34a1f-dfd4-44c7-b5eb-2df27dff918a
+      entity: 7188667e-7497-409d-abf9-e82d816c9076
     -
-      entity: 98f33e63-cf35-4973-9679-47c3c4cbae08
+      entity: c1294fb3-f662-4129-a8b9-a5660b48453f
     -
-      entity: d0326768-c789-40a8-b240-f2092e67dd69
+      entity: b2be22d3-7757-4af5-ac0f-a1a525a3500b
     -
-      entity: e44df3bd-478f-4a63-a92f-b9aa7bfac1cb
+      entity: 60733077-2d35-4e85-a39b-6a2d5d6e7ead
     -
-      entity: 02860e69-5d1f-450a-91c6-da2d0e460006
+      entity: 762e792d-9aa7-4452-8481-ece67ce6be1a
     -
-      entity: 8f72c5ca-bd0a-4b09-96b7-632f50c50c1f
+      entity: c6810c6b-3fc9-45c3-af3b-6ae6f3d502ca
     -
-      entity: b6706003-cafd-4941-b93d-b21c2f70bd64
+      entity: 43ef335d-b3c7-4fe8-8ae0-597dfa04ad22
     -
-      entity: 51c1dda9-6134-44e2-8551-94233710a7e1
+      entity: 027f8b61-714d-4759-aa1a-0d6913b4e341
     -
-      entity: 27dae2f6-4348-4ad8-97d9-07ba8bf19c55
+      entity: 3abed85c-054a-4377-96e6-74f577ebe111
     -
-      entity: 53ed575e-9213-438c-8b0f-5365e2a23ded
+      entity: f6169b2d-31b7-458f-89ee-a71e0bd7093b
     -
-      entity: 774207a6-8aca-4417-8158-04a2a9a821e3
+      entity: 1d4ef0e6-5e48-47ed-b7ed-9beaaf40064b
     -
-      entity: 561282f5-918d-4f8c-9467-ff4bd5ce31c1
+      entity: 9e98fbf1-8ef5-43e6-9fe7-c66f81f1cc87
     -
-      entity: d85af39e-30c3-479a-8618-7314bffdba02
+      entity: 4582ccc8-ae38-4d8b-937e-53a387eb8916
     -
-      entity: 7d940a5a-9840-4428-bf3b-140e2e431435
+      entity: ee78427d-cc6b-4246-8e0e-47e3c7c58b0b
     -
-      entity: ae332e35-be5f-4740-981d-7be19e9312c6
+      entity: 367ba067-e53c-4ae1-8b30-f829dfb94743
     -
-      entity: f6a5417d-6495-475e-bb4f-5e0db8490f04
+      entity: 07edc291-5bb9-48e0-9a38-4df1ef284e67
     -
-      entity: b0ee1b84-2fe1-458f-9fab-9b50cd2b12ed
+      entity: 7e010c14-6497-4b03-96d4-ae649de1c0fe
     -
-      entity: 171e6345-3b37-4b5d-9952-156a3124893f
+      entity: f35b1d12-9e12-4b15-a356-979485256141
     -
-      entity: 4827e838-7821-4dcc-9953-00e8a0c5e5d8
+      entity: 28d04879-c8f8-49c1-8550-11e975a9284a
     -
-      entity: 8a79e7bf-1c61-4b20-a4da-acb653719342
+      entity: e4810e2b-69c4-4766-bebd-096d03544564
     -
-      entity: 3fcd360f-20ae-428f-baf5-37bede1ba839
+      entity: 3c0e7d70-7735-47f1-a614-1e14bb099c8c
     -
-      entity: 16b515b9-0a5c-469d-8d29-c63b60c85e67
+      entity: d2b924c4-77e9-4384-ac41-add5183c4bd3
     -
-      entity: bcd58b68-0ee1-484d-af3f-f066239f1a8e
+      entity: d6ffefcc-90d8-486d-9af0-c4a7c8fbb144
     -
-      entity: 41377cf1-c5af-483b-ba5e-45cd90624110
+      entity: 12c564b3-f67f-4610-82d7-c4b65b882c16
   field_branch:
     -
       entity: dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0

--- a/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
@@ -5,30 +5,30 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    625690c1-6e55-4719-8c75-07437ec86118: eventinstance
-    042db348-60e5-44e2-b6a5-5261da40edc8: eventinstance
-    24b13761-c0d4-46e9-94f1-7fd13b20b61f: eventinstance
-    ff913c85-3ee8-48ea-8c18-cc61071e3504: eventinstance
-    a1588050-c22a-4d56-8f03-e40b27fc916f: eventinstance
-    e3444214-4f71-45ee-b151-a920f3d6bea2: eventinstance
-    e1913e78-705b-42a3-924f-7d68c23c1c35: eventinstance
-    38229603-41fb-433a-b174-cbb703a12193: eventinstance
-    3c3790d8-7956-4a8c-84f2-0f9d08369424: eventinstance
-    e4a7581c-2d3c-4b49-a3c4-31ba2bdb1597: eventinstance
-    acc79028-ded5-46ec-a0e8-6f4268697fad: eventinstance
-    b7ffa140-69c4-40bb-b81c-1982aa927648: eventinstance
-    ea9538b3-1d7a-4676-8f1e-64f9dde7bd84: eventinstance
-    66d85eae-f8f9-449f-9915-419cef7f2792: eventinstance
-    d84ae03e-e7a0-461f-82a3-2478a6e41323: eventinstance
-    e383ff8f-f6b8-4c22-bb9c-583a2481d9b3: eventinstance
-    9a831f70-2273-471f-a57f-effc4ed55c21: eventinstance
-    90e7e9c0-46ed-4474-b950-1d4a2db2ebe3: eventinstance
-    80e3abdd-d716-4abe-9e57-2d535e9708c2: eventinstance
-    a8b93a6d-b435-4c76-bbe1-eb7a427e369f: eventinstance
-    3850e557-90e4-4a89-8255-67aac951bd20: eventinstance
-    7eb34eb0-6a2b-4aec-ab7c-a9a26f8b6ae0: eventinstance
-    c101962d-7e35-4d74-abb3-825c8f87f795: eventinstance
-    9f243ad0-a379-4df0-8ca3-85b0e33bc223: eventinstance
+    13a34a1f-dfd4-44c7-b5eb-2df27dff918a: eventinstance
+    98f33e63-cf35-4973-9679-47c3c4cbae08: eventinstance
+    d0326768-c789-40a8-b240-f2092e67dd69: eventinstance
+    e44df3bd-478f-4a63-a92f-b9aa7bfac1cb: eventinstance
+    02860e69-5d1f-450a-91c6-da2d0e460006: eventinstance
+    8f72c5ca-bd0a-4b09-96b7-632f50c50c1f: eventinstance
+    b6706003-cafd-4941-b93d-b21c2f70bd64: eventinstance
+    51c1dda9-6134-44e2-8551-94233710a7e1: eventinstance
+    27dae2f6-4348-4ad8-97d9-07ba8bf19c55: eventinstance
+    53ed575e-9213-438c-8b0f-5365e2a23ded: eventinstance
+    774207a6-8aca-4417-8158-04a2a9a821e3: eventinstance
+    561282f5-918d-4f8c-9467-ff4bd5ce31c1: eventinstance
+    d85af39e-30c3-479a-8618-7314bffdba02: eventinstance
+    7d940a5a-9840-4428-bf3b-140e2e431435: eventinstance
+    ae332e35-be5f-4740-981d-7be19e9312c6: eventinstance
+    f6a5417d-6495-475e-bb4f-5e0db8490f04: eventinstance
+    b0ee1b84-2fe1-458f-9fab-9b50cd2b12ed: eventinstance
+    171e6345-3b37-4b5d-9952-156a3124893f: eventinstance
+    4827e838-7821-4dcc-9953-00e8a0c5e5d8: eventinstance
+    8a79e7bf-1c61-4b20-a4da-acb653719342: eventinstance
+    3fcd360f-20ae-428f-baf5-37bede1ba839: eventinstance
+    16b515b9-0a5c-469d-8d29-c63b60c85e67: eventinstance
+    bcd58b68-0ee1-484d-af3f-f066239f1a8e: eventinstance
+    41377cf1-c5af-483b-ba5e-45cd90624110: eventinstance
     dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0: node
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     ca329ad9-5a1c-4f55-b8a9-a60843b66466: media
@@ -127,53 +127,53 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: 625690c1-6e55-4719-8c75-07437ec86118
+      entity: 13a34a1f-dfd4-44c7-b5eb-2df27dff918a
     -
-      entity: 042db348-60e5-44e2-b6a5-5261da40edc8
+      entity: 98f33e63-cf35-4973-9679-47c3c4cbae08
     -
-      entity: 24b13761-c0d4-46e9-94f1-7fd13b20b61f
+      entity: d0326768-c789-40a8-b240-f2092e67dd69
     -
-      entity: ff913c85-3ee8-48ea-8c18-cc61071e3504
+      entity: e44df3bd-478f-4a63-a92f-b9aa7bfac1cb
     -
-      entity: a1588050-c22a-4d56-8f03-e40b27fc916f
+      entity: 02860e69-5d1f-450a-91c6-da2d0e460006
     -
-      entity: e3444214-4f71-45ee-b151-a920f3d6bea2
+      entity: 8f72c5ca-bd0a-4b09-96b7-632f50c50c1f
     -
-      entity: e1913e78-705b-42a3-924f-7d68c23c1c35
+      entity: b6706003-cafd-4941-b93d-b21c2f70bd64
     -
-      entity: 38229603-41fb-433a-b174-cbb703a12193
+      entity: 51c1dda9-6134-44e2-8551-94233710a7e1
     -
-      entity: 3c3790d8-7956-4a8c-84f2-0f9d08369424
+      entity: 27dae2f6-4348-4ad8-97d9-07ba8bf19c55
     -
-      entity: e4a7581c-2d3c-4b49-a3c4-31ba2bdb1597
+      entity: 53ed575e-9213-438c-8b0f-5365e2a23ded
     -
-      entity: acc79028-ded5-46ec-a0e8-6f4268697fad
+      entity: 774207a6-8aca-4417-8158-04a2a9a821e3
     -
-      entity: b7ffa140-69c4-40bb-b81c-1982aa927648
+      entity: 561282f5-918d-4f8c-9467-ff4bd5ce31c1
     -
-      entity: ea9538b3-1d7a-4676-8f1e-64f9dde7bd84
+      entity: d85af39e-30c3-479a-8618-7314bffdba02
     -
-      entity: 66d85eae-f8f9-449f-9915-419cef7f2792
+      entity: 7d940a5a-9840-4428-bf3b-140e2e431435
     -
-      entity: d84ae03e-e7a0-461f-82a3-2478a6e41323
+      entity: ae332e35-be5f-4740-981d-7be19e9312c6
     -
-      entity: e383ff8f-f6b8-4c22-bb9c-583a2481d9b3
+      entity: f6a5417d-6495-475e-bb4f-5e0db8490f04
     -
-      entity: 9a831f70-2273-471f-a57f-effc4ed55c21
+      entity: b0ee1b84-2fe1-458f-9fab-9b50cd2b12ed
     -
-      entity: 90e7e9c0-46ed-4474-b950-1d4a2db2ebe3
+      entity: 171e6345-3b37-4b5d-9952-156a3124893f
     -
-      entity: 80e3abdd-d716-4abe-9e57-2d535e9708c2
+      entity: 4827e838-7821-4dcc-9953-00e8a0c5e5d8
     -
-      entity: a8b93a6d-b435-4c76-bbe1-eb7a427e369f
+      entity: 8a79e7bf-1c61-4b20-a4da-acb653719342
     -
-      entity: 3850e557-90e4-4a89-8255-67aac951bd20
+      entity: 3fcd360f-20ae-428f-baf5-37bede1ba839
     -
-      entity: 7eb34eb0-6a2b-4aec-ab7c-a9a26f8b6ae0
+      entity: 16b515b9-0a5c-469d-8d29-c63b60c85e67
     -
-      entity: c101962d-7e35-4d74-abb3-825c8f87f795
+      entity: bcd58b68-0ee1-484d-af3f-f066239f1a8e
     -
-      entity: 9f243ad0-a379-4df0-8ca3-85b0e33bc223
+      entity: 41377cf1-c5af-483b-ba5e-45cd90624110
   field_branch:
     -
       entity: dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0

--- a/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    c153863e-b8a3-4eb8-be1d-5666d1712ea3: eventinstance
+    8881d2bb-2928-4c78-a104-6cb09079a95e: eventinstance
     e539b26b-2992-406b-accf-03e549522c0d: taxonomy_term
     d6d67fd2-775c-46e7-a1bf-6af46290a5c8: media
     4704c566-afc2-4131-ab81-3d636f2451bf: taxonomy_term
@@ -101,7 +101,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: c153863e-b8a3-4eb8-be1d-5666d1712ea3
+      entity: 8881d2bb-2928-4c78-a104-6cb09079a95e
   field_categories:
     -
       entity: e539b26b-2992-406b-accf-03e549522c0d

--- a/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    8881d2bb-2928-4c78-a104-6cb09079a95e: eventinstance
+    fde19c73-3a38-4788-aa84-a376d3ee6cf6: eventinstance
     e539b26b-2992-406b-accf-03e549522c0d: taxonomy_term
     d6d67fd2-775c-46e7-a1bf-6af46290a5c8: media
     4704c566-afc2-4131-ab81-3d636f2451bf: taxonomy_term
@@ -101,7 +101,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: 8881d2bb-2928-4c78-a104-6cb09079a95e
+      entity: fde19c73-3a38-4788-aa84-a376d3ee6cf6
   field_categories:
     -
       entity: e539b26b-2992-406b-accf-03e549522c0d

--- a/web/modules/custom/dpl_example_content/content/media/618e176a-a45a-4c36-a197-664230aa0a34.yml
+++ b/web/modules/custom/dpl_example_content/content/media/618e176a-a45a-4c36-a197-664230aa0a34.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Ahmad Odeh / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/65432ee1-43f1-4130-9565-5683467d4b5a.yml
+++ b/web/modules/custom/dpl_example_content/content/media/65432ee1-43f1-4130-9565-5683467d4b5a.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Admad Odeh / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/7b9d1894-7f9a-4f96-a7dc-efa3af5fc902.yml
+++ b/web/modules/custom/dpl_example_content/content/media/7b9d1894-7f9a-4f96-a7dc-efa3af5fc902.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 50b4d50b-9c75-4698-b803-a125b46daaac

--- a/web/modules/custom/dpl_example_content/content/media/a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f.yml
+++ b/web/modules/custom/dpl_example_content/content/media/a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 24244298-ff4d-4662-bc7f-5b9aa529f89e

--- a/web/modules/custom/dpl_example_content/content/media/a6a77786-07db-48d8-98ff-3bda54f231bf.yml
+++ b/web/modules/custom/dpl_example_content/content/media/a6a77786-07db-48d8-98ff-3bda54f231bf.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 7fb4d332-81ef-4dc0-af9a-dfcd29ecf367

--- a/web/modules/custom/dpl_example_content/content/media/aba3cea8-cee5-42c1-a152-e30c2ab135e2.yml
+++ b/web/modules/custom/dpl_example_content/content/media/aba3cea8-cee5-42c1-a152-e30c2ab135e2.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Jilbert Ebrahimi / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/ca329ad9-5a1c-4f55-b8a9-a60843b66466.yml
+++ b/web/modules/custom/dpl_example_content/content/media/ca329ad9-5a1c-4f55-b8a9-a60843b66466.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 4400c2b6-2158-4ddb-aa87-9279dcf77fb7

--- a/web/modules/custom/dpl_example_content/content/media/d6d67fd2-775c-46e7-a1bf-6af46290a5c8.yml
+++ b/web/modules/custom/dpl_example_content/content/media/d6d67fd2-775c-46e7-a1bf-6af46290a5c8.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: ed301960-e40f-42b5-9229-4ac20fd07a7e

--- a/web/modules/custom/dpl_example_content/content/media/d97a25fd-a6ae-48b9-9a1a-7aec5372688e.yml
+++ b/web/modules/custom/dpl_example_content/content/media/d97a25fd-a6ae-48b9-9a1a-7aec5372688e.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Becca Tapert / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/dc33677f-8894-4717-b34b-d985f6ad875f.yml
+++ b/web/modules/custom/dpl_example_content/content/media/dc33677f-8894-4717-b34b-d985f6ad875f.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_file:
     -
       entity: 3403d0ba-cbdc-425d-93f4-6cdabb5378b1

--- a/web/modules/custom/dpl_example_content/content/media/e4ce7616-976d-43fc-aed2-a01c42b67db9.yml
+++ b/web/modules/custom/dpl_example_content/content/media/e4ce7616-976d-43fc-aed2-a01c42b67db9.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 231326de-6d73-42c6-8ec3-5d2bbae9cb91

--- a/web/modules/custom/dpl_example_content/content/media/e8283d3c-968a-4e74-ae02-9f02b76bb839.yml
+++ b/web/modules/custom/dpl_example_content/content/media/e8283d3c-968a-4e74-ae02-9f02b76bb839.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: e00e1460-169e-468d-9835-d664f06d0969

--- a/web/modules/custom/dpl_example_content/content/media/eef50571-39dc-461a-96ff-b6b7180ade61.yml
+++ b/web/modules/custom/dpl_example_content/content/media/eef50571-39dc-461a-96ff-b6b7180ade61.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Jon Tyson / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/f0204f0b-1f63-4c76-bb67-e3f7489ee392.yml
+++ b/web/modules/custom/dpl_example_content/content/media/f0204f0b-1f63-4c76-bb67-e3f7489ee392.yml
@@ -31,6 +31,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: en
   field_media_oembed_video:
     -
       value: 'https://www.youtube.com/watch?v=CmzKQ3PSrow'

--- a/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
+++ b/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
@@ -59,6 +59,10 @@ default:
       attributes:
         name: title
         content: 'Jesper Stein vinder Læsernes Bogpris for Rampen | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_categories:
     -
       entity: 92033694-15ac-4d9e-b275-ddfd18e48d9f

--- a/web/modules/custom/dpl_example_content/content/node/480a6997-4ca2-4cc6-a8f2-61254401d044.yml
+++ b/web/modules/custom/dpl_example_content/content/node/480a6997-4ca2-4cc6-a8f2-61254401d044.yml
@@ -47,6 +47,10 @@ default:
       attributes:
         name: title
         content: 'Det virtuelle bibliotek | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_address:
     -
       langcode: en

--- a/web/modules/custom/dpl_example_content/content/node/852d781f-82c9-40ac-bc8d-d0cefe07706d.yml
+++ b/web/modules/custom/dpl_example_content/content/node/852d781f-82c9-40ac-bc8d-d0cefe07706d.yml
@@ -47,6 +47,10 @@ default:
       attributes:
         name: title
         content: 'Brønshøj Bibliotek | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_address:
     -
       langcode: da

--- a/web/modules/custom/dpl_example_content/content/node/982e0d87-f6b8-4b84-8de8-c8c8bcfef557.yml
+++ b/web/modules/custom/dpl_example_content/content/node/982e0d87-f6b8-4b84-8de8-c8c8bcfef557.yml
@@ -52,6 +52,10 @@ default:
       attributes:
         name: title
         content: 'Bibliotekarerne anbefaler læsning til den mørke tid | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_override_author:
     -
       value: 'Det Digitale Folkebibliotek'

--- a/web/modules/custom/dpl_example_content/content/node/9cfd15df-32b4-4af9-b2da-56b039b5bf6b.yml
+++ b/web/modules/custom/dpl_example_content/content/node/9cfd15df-32b4-4af9-b2da-56b039b5bf6b.yml
@@ -47,6 +47,10 @@ default:
       attributes:
         name: title
         content: '3 gode til godnat 3-6 år | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_paragraphs:
     -
       entity:
@@ -125,6 +129,7 @@ default:
           field_recommendation_work_id:
             -
               value: 'work-of:870970-basis:51869168'
+              material_type: ''
     -
       entity:
         _meta:
@@ -177,6 +182,7 @@ default:
           field_recommendation_work_id:
             -
               value: 'work-of:870970-basis:51143574'
+              material_type: ''
     -
       entity:
         _meta:
@@ -229,6 +235,7 @@ default:
           field_recommendation_work_id:
             -
               value: 'work-of:870970-basis:53642101'
+              material_type: ''
   field_show_override_author:
     -
       value: false

--- a/web/modules/custom/dpl_example_content/content/node/dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0.yml
+++ b/web/modules/custom/dpl_example_content/content/node/dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0.yml
@@ -48,6 +48,10 @@ default:
       attributes:
         name: title
         content: 'Hovedbiblioteket | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_address:
     -
       langcode: da

--- a/web/modules/custom/dpl_example_content/content/node/fd774222-4b22-4803-ae45-2d4e80d84fac.yml
+++ b/web/modules/custom/dpl_example_content/content/node/fd774222-4b22-4803-ae45-2d4e80d84fac.yml
@@ -56,6 +56,10 @@ default:
       attributes:
         name: title
         content: 'Frontpage | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_paragraphs:
     -
       entity:
@@ -340,9 +344,6 @@ default:
           revision_translation_affected:
             -
               value: true
-          field_filter_content_types:
-            -
-              target_id: article
           field_title:
             -
               value: 'Nye artikler'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/8'
+        href: '/taxonomy/term/10'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/8'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/11'
+        href: '/taxonomy/term/13'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/11'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/3'
+        href: '/taxonomy/term/5'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/5'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/5'
+        href: '/taxonomy/term/7'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/370b0de6-dc86-4f22-b088-4ae54d70dd2a.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/370b0de6-dc86-4f22-b088-4ae54d70dd2a.yml
@@ -1,16 +1,16 @@
 _meta:
   version: '1.0'
   entity_type: taxonomy_term
-  uuid: 1006441f-bb39-43b5-8c08-1a79344abf8b
-  bundle: tags
-  default_langcode: da
+  uuid: 370b0de6-dc86-4f22-b088-4ae54d70dd2a
+  bundle: opening_hours_categories
+  default_langcode: en
 default:
   status:
     -
       value: true
   name:
     -
-      value: dans
+      value: Åbent
   weight:
     -
       value: 0
@@ -25,13 +25,17 @@ default:
       tag: meta
       attributes:
         name: title
-        content: 'dans | DPL CMS'
+        content: 'Åbent | DPL CMS'
     -
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/3'
+        href: '/taxonomy/term/13'
   path:
     -
       alias: ''
-      langcode: da
+      langcode: en
+  field_opening_hours_color:
+    -
+      color: '#42B234'
+      opacity: 0.8

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/370b0de6-dc86-4f22-b088-4ae54d70dd2a.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/370b0de6-dc86-4f22-b088-4ae54d70dd2a.yml
@@ -30,12 +30,12 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/13'
+        href: '/taxonomy/term/1'
   path:
     -
       alias: ''
       langcode: en
   field_opening_hours_color:
     -
-      color: '#42B234'
+      color: '#F83A22'
       opacity: 0.8

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/4704c566-afc2-4131-ab81-3d636f2451bf.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/4704c566-afc2-4131-ab81-3d636f2451bf.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/10'
+        href: '/taxonomy/term/12'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/4704c566-afc2-4131-ab81-3d636f2451bf.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/4704c566-afc2-4131-ab81-3d636f2451bf.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/10'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/4'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/4'
+        href: '/taxonomy/term/6'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/55c98729-b664-43d4-9612-42fd9505b5d6.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/55c98729-b664-43d4-9612-42fd9505b5d6.yml
@@ -1,16 +1,16 @@
 _meta:
   version: '1.0'
   entity_type: taxonomy_term
-  uuid: 1006441f-bb39-43b5-8c08-1a79344abf8b
-  bundle: tags
-  default_langcode: da
+  uuid: 55c98729-b664-43d4-9612-42fd9505b5d6
+  bundle: opening_hours_categories
+  default_langcode: en
 default:
   status:
     -
       value: true
   name:
     -
-      value: dans
+      value: Telefontid
   weight:
     -
       value: 0
@@ -25,13 +25,17 @@ default:
       tag: meta
       attributes:
         name: title
-        content: 'dans | DPL CMS'
+        content: 'Telefontid | DPL CMS'
     -
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/3'
+        href: '/taxonomy/term/14'
   path:
     -
       alias: ''
-      langcode: da
+      langcode: en
+  field_opening_hours_color:
+    -
+      color: '#EEFF00'
+      opacity: 0.8

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/55c98729-b664-43d4-9612-42fd9505b5d6.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/55c98729-b664-43d4-9612-42fd9505b5d6.yml
@@ -13,7 +13,7 @@ default:
       value: Telefontid
   weight:
     -
-      value: 0
+      value: 1
   parent:
     -
       target_id: 0
@@ -30,12 +30,12 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/14'
+        href: '/taxonomy/term/2'
   path:
     -
       alias: ''
       langcode: en
   field_opening_hours_color:
     -
-      color: '#EEFF00'
+      color: '#FBE983'
       opacity: 0.8

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/6'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/6'
+        href: '/taxonomy/term/8'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/1'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/1'
+        href: '/taxonomy/term/3'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/2'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/2'
+        href: '/taxonomy/term/4'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/e539b26b-2992-406b-accf-03e549522c0d.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/e539b26b-2992-406b-accf-03e549522c0d.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/9'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/e539b26b-2992-406b-accf-03e549522c0d.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/e539b26b-2992-406b-accf-03e549522c0d.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/9'
+        href: '/taxonomy/term/11'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/7'
+        href: '/taxonomy/term/9'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/7'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
@@ -30,7 +30,7 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/12'
+        href: '/taxonomy/term/14'
   path:
     -
       alias: ''

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/12'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
@@ -68,6 +68,8 @@ default_content:
     - 807e6053-86ed-4dce-b6a9-a48b566b5910
     - 4704c566-afc2-4131-ab81-3d636f2451bf
     - e539b26b-2992-406b-accf-03e549522c0d
+    - 370b0de6-dc86-4f22-b088-4ae54d70dd2a
+    - 55c98729-b664-43d4-9612-42fd9505b5d6
   menu_link_content:
     - ff6db3ce-49e0-4107-b283-3403e22c5e6d
     - c391079e-a4f5-4d29-992f-92ed1a2dd96c


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-408


#### Description
This pull request introduces a taxonomy for various types of Opening Hours, such as 'Åbent' and 'Telefontid.' 
These terms are intended for future use in the API from `dpl_opening_hours` module.

Additionally, I have added a color field to the 'Opening Hours Categories' terms. This enhancement allows users to select a color that will be visible in the event display within the full calendar view.

#### Screenshot of the result
<img width="1711" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/f26d3545-43d7-48a1-b43f-da403b337284">

<img width="1711" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/608e7503-d328-4617-9d41-238eda32bbf1">

<img width="1711" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/6cb4304b-4cee-4bc0-a9ca-af71fdfd6dc0">

Added color palette
<img width="708" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/4ec2c2d9-460e-45d5-9eeb-6b03ea29f5f6">
