### PR TITLE
Patch Twig Tweak to ensure cache is purged when adding first menu item

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -307,6 +307,9 @@
             },
             "drupal/theme_permission": {
                 "3105637: Edit, install and uninstall permission": "https://www.drupal.org/files/issues/2024-02-01/theme-permission-edit-install-uninstall-3105637-7.patch"
+            },
+            "drupal/twig_tweak": {
+                "3428226: Clear menu cache when adding first item": "https://git.drupalcode.org/project/twig_tweak/-/merge_requests/47.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "13e26ab1e5e74543b9f19ebc1c34984f",
+    "content-hash": "0b5cd7488c1f668ec3f5f2f5c57fde54",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-424

#### Description

Patch Twig Tweak to ensure cache is purged when adding first menu item. Otherwise users will have to clear the cache themselves.

[Read the corresponding issue for more information](https://www.drupal.org/project/twig_tweak/issues/3428226).