### PR TITLE
DDFFORM 432

### DIFF
--- a/config/sync/content_lock.settings.yml
+++ b/config/sync/content_lock.settings.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: 6Ka3T1c-CIjEUO1Q64NXKksLthkMhj53a6zy4RJBtkc
-verbose: 1
+verbose: 0
 types:
   crop: {  }
   file: {  }
@@ -40,7 +40,7 @@ form_op_lock:
     mode: 0
     values: {  }
   path_alias:
-    mode: null
+    mode: 0
     values: {  }
   eventseries:
     mode: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -43,7 +43,6 @@ dependencies:
     - taxonomy
     - theme_permission
     - toolbar
-    - update
     - view_unpublished
 id: administrator
 label: Administrator
@@ -196,6 +195,5 @@ permissions:
   - 'view unpublished eventinstance entity'
   - 'view unpublished eventseries entity'
   - 'view unpublished paragraphs'
-  - 'view update notifications'
   - 'view user email addresses'
   - 'view users by role'


### PR DESCRIPTION
- **Toggle off verbose contect_lock messages.**
- **Do not display available updates in status messages of any kind, to the role administrator.**

#### Link to issue

[Ticket: DDFFORM-432](https://reload.atlassian.net/browse/DDFFORM-432)

#### Description

This PR does two things:
- Removes the verbose status messaging related to the content_lock module. 
- Disables the display of all update messages to the role of administrator. 
-- Notice: The administrator role was the only one able to see this, now no other role that 'admin' will see these messages. 


For testing: 
- Test that for any other role than 'admin', no update messages will be displayed. 
- Test that for admin, these update messages are still displayed. 
- Test that when editing content that was unlocked before accessing, you are _not_ shown a status message anymore. 
- Test that when editing content, that is locked by another user, you are still shown the warning message allowing you to break the lock of that content. 

#### Screenshot of the result

The permission that was changed: 

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/a2672a3b-752d-4002-9a16-1e248db383fd)

