### PR TITLE
WIP: Ddfform 465 billede kreditering viser ikke pa event instanser

### DIFF
--- a/config/sync/core.entity_view_display.media.image.hero_wide.yml
+++ b/config/sync/core.entity_view_display.media.image.hero_wide.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.hero_wide
+    - field.field.media.image.field_byline
     - field.field.media.image.field_media_image
     - image.style.hero_wide
     - media.type.image
@@ -14,6 +15,14 @@ targetEntityType: media
 bundle: image
 mode: hero_wide
 content:
+  field_byline:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_media_image:
     type: image
     label: hidden
@@ -27,7 +36,6 @@ content:
     region: content
 hidden:
   created: true
-  field_byline: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/config/sync/image.style.hero_wide_with_crediting.yml
+++ b/config/sync/image.style.hero_wide_with_crediting.yml
@@ -1,0 +1,17 @@
+uuid: f19a9b76-1c31-4351-bf0d-db79042103b8
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: hero_wide_with_crediting
+label: 'Hero wide (4/3) with crediting'
+effects:
+  646ca0bc-bead-4b5e-85d9-89319ffa5868:
+    uuid: 646ca0bc-bead-4b5e-85d9-89319ffa5868
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 800
+      height: 600
+      crop_type: focal_point

--- a/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    b62121d9-62ef-4645-80be-61bc2d3a595d: eventinstance
+    7ef4396c-5ce4-44ea-8dac-15df6bddab3e: eventinstance
     dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0: node
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f: media
@@ -101,7 +101,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: b62121d9-62ef-4645-80be-61bc2d3a595d
+      entity: 7ef4396c-5ce4-44ea-8dac-15df6bddab3e
   field_branch:
     -
       entity: dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    5698bb31-57b1-4abc-9b2d-de055a307ae2: eventinstance
+    980fa8a6-ab74-4dde-bfe7-5c30cf4e0edf: eventinstance
     852d781f-82c9-40ac-bc8d-d0cefe07706d: node
     f457c4c2-dc28-45cd-9b6e-fda4248d9d45: taxonomy_term
     618e176a-a45a-4c36-a197-664230aa0a34: media
@@ -109,7 +109,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: 5698bb31-57b1-4abc-9b2d-de055a307ae2
+      entity: 980fa8a6-ab74-4dde-bfe7-5c30cf4e0edf
   field_branch:
     -
       entity: 852d781f-82c9-40ac-bc8d-d0cefe07706d

--- a/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
@@ -5,30 +5,30 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    625690c1-6e55-4719-8c75-07437ec86118: eventinstance
-    042db348-60e5-44e2-b6a5-5261da40edc8: eventinstance
-    24b13761-c0d4-46e9-94f1-7fd13b20b61f: eventinstance
-    ff913c85-3ee8-48ea-8c18-cc61071e3504: eventinstance
-    a1588050-c22a-4d56-8f03-e40b27fc916f: eventinstance
-    e3444214-4f71-45ee-b151-a920f3d6bea2: eventinstance
-    e1913e78-705b-42a3-924f-7d68c23c1c35: eventinstance
-    38229603-41fb-433a-b174-cbb703a12193: eventinstance
-    3c3790d8-7956-4a8c-84f2-0f9d08369424: eventinstance
-    e4a7581c-2d3c-4b49-a3c4-31ba2bdb1597: eventinstance
-    acc79028-ded5-46ec-a0e8-6f4268697fad: eventinstance
-    b7ffa140-69c4-40bb-b81c-1982aa927648: eventinstance
-    ea9538b3-1d7a-4676-8f1e-64f9dde7bd84: eventinstance
-    66d85eae-f8f9-449f-9915-419cef7f2792: eventinstance
-    d84ae03e-e7a0-461f-82a3-2478a6e41323: eventinstance
-    e383ff8f-f6b8-4c22-bb9c-583a2481d9b3: eventinstance
-    9a831f70-2273-471f-a57f-effc4ed55c21: eventinstance
-    90e7e9c0-46ed-4474-b950-1d4a2db2ebe3: eventinstance
-    80e3abdd-d716-4abe-9e57-2d535e9708c2: eventinstance
-    a8b93a6d-b435-4c76-bbe1-eb7a427e369f: eventinstance
-    3850e557-90e4-4a89-8255-67aac951bd20: eventinstance
-    7eb34eb0-6a2b-4aec-ab7c-a9a26f8b6ae0: eventinstance
-    c101962d-7e35-4d74-abb3-825c8f87f795: eventinstance
-    9f243ad0-a379-4df0-8ca3-85b0e33bc223: eventinstance
+    3c496dee-8db4-4e92-b746-8d70c157e470: eventinstance
+    043be87d-ac07-43e3-81aa-4b477e773dde: eventinstance
+    e267b1b2-d607-40ab-b2be-4092f53aee03: eventinstance
+    24d2b4aa-7541-417c-9f97-5dd5a64aa259: eventinstance
+    25374f4e-e77e-4429-975c-79a925e20e4f: eventinstance
+    86eb1d35-3a2c-45a5-b5be-035a933c893a: eventinstance
+    a7a3b0b8-8c69-4e4b-971e-ba0d6d7af054: eventinstance
+    38a34183-48b9-4208-84ea-8ebc045159e9: eventinstance
+    9cdbcc5c-5070-4db2-bca3-7f91a019b240: eventinstance
+    49059fe5-2010-44a2-945e-20239a49717c: eventinstance
+    930c2084-84dc-4688-9fb8-b159b0bf215d: eventinstance
+    20f4f078-7a8a-4606-af9d-a96edfc167ed: eventinstance
+    5efbbe9d-08f7-4e3b-9145-79e34cdd48fb: eventinstance
+    69c61cc0-d105-4dc2-aeb6-f643c2a499f8: eventinstance
+    fb878907-a9dd-492f-a5b9-56eaaafbac6c: eventinstance
+    16be32df-d220-4461-84e9-fb4269820dba: eventinstance
+    4c177d8e-a92d-40f6-b1ae-c924d273da50: eventinstance
+    a0424e5c-f3ce-4bcc-bfcd-d2555659593a: eventinstance
+    c7f41f1f-df53-4ef9-b646-18f9f65a2dcd: eventinstance
+    328b512d-3d1b-4cbb-92eb-a284de1ada69: eventinstance
+    331d9091-e464-4c8b-a136-587f47bdbfbf: eventinstance
+    248b6116-0aff-4eb6-8f90-aef97dc0b182: eventinstance
+    c3f9a7e0-d7d8-4b02-8992-2c7af6f78b94: eventinstance
+    4c643164-a2bb-4786-98e0-f3c34331e658: eventinstance
     dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0: node
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     ca329ad9-5a1c-4f55-b8a9-a60843b66466: media
@@ -127,53 +127,53 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: 625690c1-6e55-4719-8c75-07437ec86118
+      entity: 3c496dee-8db4-4e92-b746-8d70c157e470
     -
-      entity: 042db348-60e5-44e2-b6a5-5261da40edc8
+      entity: 043be87d-ac07-43e3-81aa-4b477e773dde
     -
-      entity: 24b13761-c0d4-46e9-94f1-7fd13b20b61f
+      entity: e267b1b2-d607-40ab-b2be-4092f53aee03
     -
-      entity: ff913c85-3ee8-48ea-8c18-cc61071e3504
+      entity: 24d2b4aa-7541-417c-9f97-5dd5a64aa259
     -
-      entity: a1588050-c22a-4d56-8f03-e40b27fc916f
+      entity: 25374f4e-e77e-4429-975c-79a925e20e4f
     -
-      entity: e3444214-4f71-45ee-b151-a920f3d6bea2
+      entity: 86eb1d35-3a2c-45a5-b5be-035a933c893a
     -
-      entity: e1913e78-705b-42a3-924f-7d68c23c1c35
+      entity: a7a3b0b8-8c69-4e4b-971e-ba0d6d7af054
     -
-      entity: 38229603-41fb-433a-b174-cbb703a12193
+      entity: 38a34183-48b9-4208-84ea-8ebc045159e9
     -
-      entity: 3c3790d8-7956-4a8c-84f2-0f9d08369424
+      entity: 9cdbcc5c-5070-4db2-bca3-7f91a019b240
     -
-      entity: e4a7581c-2d3c-4b49-a3c4-31ba2bdb1597
+      entity: 49059fe5-2010-44a2-945e-20239a49717c
     -
-      entity: acc79028-ded5-46ec-a0e8-6f4268697fad
+      entity: 930c2084-84dc-4688-9fb8-b159b0bf215d
     -
-      entity: b7ffa140-69c4-40bb-b81c-1982aa927648
+      entity: 20f4f078-7a8a-4606-af9d-a96edfc167ed
     -
-      entity: ea9538b3-1d7a-4676-8f1e-64f9dde7bd84
+      entity: 5efbbe9d-08f7-4e3b-9145-79e34cdd48fb
     -
-      entity: 66d85eae-f8f9-449f-9915-419cef7f2792
+      entity: 69c61cc0-d105-4dc2-aeb6-f643c2a499f8
     -
-      entity: d84ae03e-e7a0-461f-82a3-2478a6e41323
+      entity: fb878907-a9dd-492f-a5b9-56eaaafbac6c
     -
-      entity: e383ff8f-f6b8-4c22-bb9c-583a2481d9b3
+      entity: 16be32df-d220-4461-84e9-fb4269820dba
     -
-      entity: 9a831f70-2273-471f-a57f-effc4ed55c21
+      entity: 4c177d8e-a92d-40f6-b1ae-c924d273da50
     -
-      entity: 90e7e9c0-46ed-4474-b950-1d4a2db2ebe3
+      entity: a0424e5c-f3ce-4bcc-bfcd-d2555659593a
     -
-      entity: 80e3abdd-d716-4abe-9e57-2d535e9708c2
+      entity: c7f41f1f-df53-4ef9-b646-18f9f65a2dcd
     -
-      entity: a8b93a6d-b435-4c76-bbe1-eb7a427e369f
+      entity: 328b512d-3d1b-4cbb-92eb-a284de1ada69
     -
-      entity: 3850e557-90e4-4a89-8255-67aac951bd20
+      entity: 331d9091-e464-4c8b-a136-587f47bdbfbf
     -
-      entity: 7eb34eb0-6a2b-4aec-ab7c-a9a26f8b6ae0
+      entity: 248b6116-0aff-4eb6-8f90-aef97dc0b182
     -
-      entity: c101962d-7e35-4d74-abb3-825c8f87f795
+      entity: c3f9a7e0-d7d8-4b02-8992-2c7af6f78b94
     -
-      entity: 9f243ad0-a379-4df0-8ca3-85b0e33bc223
+      entity: 4c643164-a2bb-4786-98e0-f3c34331e658
   field_branch:
     -
       entity: dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0

--- a/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    c153863e-b8a3-4eb8-be1d-5666d1712ea3: eventinstance
+    214019e7-80af-4d11-9686-bf80db7867cd: eventinstance
     e539b26b-2992-406b-accf-03e549522c0d: taxonomy_term
     d6d67fd2-775c-46e7-a1bf-6af46290a5c8: media
     4704c566-afc2-4131-ab81-3d636f2451bf: taxonomy_term
@@ -101,7 +101,7 @@ default:
         href: '/user/login'
   event_instances:
     -
-      entity: c153863e-b8a3-4eb8-be1d-5666d1712ea3
+      entity: 214019e7-80af-4d11-9686-bf80db7867cd
   field_categories:
     -
       entity: e539b26b-2992-406b-accf-03e549522c0d

--- a/web/modules/custom/dpl_example_content/content/media/618e176a-a45a-4c36-a197-664230aa0a34.yml
+++ b/web/modules/custom/dpl_example_content/content/media/618e176a-a45a-4c36-a197-664230aa0a34.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Ahmad Odeh / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/65432ee1-43f1-4130-9565-5683467d4b5a.yml
+++ b/web/modules/custom/dpl_example_content/content/media/65432ee1-43f1-4130-9565-5683467d4b5a.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Admad Odeh / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/7b9d1894-7f9a-4f96-a7dc-efa3af5fc902.yml
+++ b/web/modules/custom/dpl_example_content/content/media/7b9d1894-7f9a-4f96-a7dc-efa3af5fc902.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 50b4d50b-9c75-4698-b803-a125b46daaac

--- a/web/modules/custom/dpl_example_content/content/media/a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f.yml
+++ b/web/modules/custom/dpl_example_content/content/media/a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 24244298-ff4d-4662-bc7f-5b9aa529f89e

--- a/web/modules/custom/dpl_example_content/content/media/a6a77786-07db-48d8-98ff-3bda54f231bf.yml
+++ b/web/modules/custom/dpl_example_content/content/media/a6a77786-07db-48d8-98ff-3bda54f231bf.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 7fb4d332-81ef-4dc0-af9a-dfcd29ecf367

--- a/web/modules/custom/dpl_example_content/content/media/aba3cea8-cee5-42c1-a152-e30c2ab135e2.yml
+++ b/web/modules/custom/dpl_example_content/content/media/aba3cea8-cee5-42c1-a152-e30c2ab135e2.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Jilbert Ebrahimi / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/ca329ad9-5a1c-4f55-b8a9-a60843b66466.yml
+++ b/web/modules/custom/dpl_example_content/content/media/ca329ad9-5a1c-4f55-b8a9-a60843b66466.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 4400c2b6-2158-4ddb-aa87-9279dcf77fb7

--- a/web/modules/custom/dpl_example_content/content/media/d6d67fd2-775c-46e7-a1bf-6af46290a5c8.yml
+++ b/web/modules/custom/dpl_example_content/content/media/d6d67fd2-775c-46e7-a1bf-6af46290a5c8.yml
@@ -33,6 +33,13 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
+  field_byline:
+    -
+      value: 'Photo by Unsplash'
   field_media_image:
     -
       entity: ed301960-e40f-42b5-9229-4ac20fd07a7e

--- a/web/modules/custom/dpl_example_content/content/media/d97a25fd-a6ae-48b9-9a1a-7aec5372688e.yml
+++ b/web/modules/custom/dpl_example_content/content/media/d97a25fd-a6ae-48b9-9a1a-7aec5372688e.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Becca Tapert / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/dc33677f-8894-4717-b34b-d985f6ad875f.yml
+++ b/web/modules/custom/dpl_example_content/content/media/dc33677f-8894-4717-b34b-d985f6ad875f.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_file:
     -
       entity: 3403d0ba-cbdc-425d-93f4-6cdabb5378b1

--- a/web/modules/custom/dpl_example_content/content/media/e4ce7616-976d-43fc-aed2-a01c42b67db9.yml
+++ b/web/modules/custom/dpl_example_content/content/media/e4ce7616-976d-43fc-aed2-a01c42b67db9.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: 231326de-6d73-42c6-8ec3-5d2bbae9cb91

--- a/web/modules/custom/dpl_example_content/content/media/e8283d3c-968a-4e74-ae02-9f02b76bb839.yml
+++ b/web/modules/custom/dpl_example_content/content/media/e8283d3c-968a-4e74-ae02-9f02b76bb839.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_media_image:
     -
       entity: e00e1460-169e-468d-9835-d664f06d0969

--- a/web/modules/custom/dpl_example_content/content/media/eef50571-39dc-461a-96ff-b6b7180ade61.yml
+++ b/web/modules/custom/dpl_example_content/content/media/eef50571-39dc-461a-96ff-b6b7180ade61.yml
@@ -33,6 +33,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_byline:
     -
       value: 'Af Jon Tyson / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/f0204f0b-1f63-4c76-bb67-e3f7489ee392.yml
+++ b/web/modules/custom/dpl_example_content/content/media/f0204f0b-1f63-4c76-bb67-e3f7489ee392.yml
@@ -31,6 +31,10 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: ''
+      langcode: en
   field_media_oembed_video:
     -
       value: 'https://www.youtube.com/watch?v=CmzKQ3PSrow'

--- a/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
+++ b/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
@@ -59,6 +59,10 @@ default:
       attributes:
         name: title
         content: 'Jesper Stein vinder Læsernes Bogpris for Rampen | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_categories:
     -
       entity: 92033694-15ac-4d9e-b275-ddfd18e48d9f

--- a/web/modules/custom/dpl_example_content/content/node/480a6997-4ca2-4cc6-a8f2-61254401d044.yml
+++ b/web/modules/custom/dpl_example_content/content/node/480a6997-4ca2-4cc6-a8f2-61254401d044.yml
@@ -47,6 +47,10 @@ default:
       attributes:
         name: title
         content: 'Det virtuelle bibliotek | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_address:
     -
       langcode: en

--- a/web/modules/custom/dpl_example_content/content/node/852d781f-82c9-40ac-bc8d-d0cefe07706d.yml
+++ b/web/modules/custom/dpl_example_content/content/node/852d781f-82c9-40ac-bc8d-d0cefe07706d.yml
@@ -47,6 +47,10 @@ default:
       attributes:
         name: title
         content: 'Brønshøj Bibliotek | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_address:
     -
       langcode: da

--- a/web/modules/custom/dpl_example_content/content/node/982e0d87-f6b8-4b84-8de8-c8c8bcfef557.yml
+++ b/web/modules/custom/dpl_example_content/content/node/982e0d87-f6b8-4b84-8de8-c8c8bcfef557.yml
@@ -52,6 +52,10 @@ default:
       attributes:
         name: title
         content: 'Bibliotekarerne anbefaler læsning til den mørke tid | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_override_author:
     -
       value: 'Det Digitale Folkebibliotek'

--- a/web/modules/custom/dpl_example_content/content/node/9cfd15df-32b4-4af9-b2da-56b039b5bf6b.yml
+++ b/web/modules/custom/dpl_example_content/content/node/9cfd15df-32b4-4af9-b2da-56b039b5bf6b.yml
@@ -47,6 +47,10 @@ default:
       attributes:
         name: title
         content: '3 gode til godnat 3-6 år | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_paragraphs:
     -
       entity:
@@ -125,6 +129,7 @@ default:
           field_recommendation_work_id:
             -
               value: 'work-of:870970-basis:51869168'
+              material_type: ''
     -
       entity:
         _meta:
@@ -177,6 +182,7 @@ default:
           field_recommendation_work_id:
             -
               value: 'work-of:870970-basis:51143574'
+              material_type: ''
     -
       entity:
         _meta:
@@ -229,6 +235,7 @@ default:
           field_recommendation_work_id:
             -
               value: 'work-of:870970-basis:53642101'
+              material_type: ''
   field_show_override_author:
     -
       value: false

--- a/web/modules/custom/dpl_example_content/content/node/dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0.yml
+++ b/web/modules/custom/dpl_example_content/content/node/dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0.yml
@@ -48,6 +48,10 @@ default:
       attributes:
         name: title
         content: 'Hovedbiblioteket | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_address:
     -
       langcode: da

--- a/web/modules/custom/dpl_example_content/content/node/fd774222-4b22-4803-ae45-2d4e80d84fac.yml
+++ b/web/modules/custom/dpl_example_content/content/node/fd774222-4b22-4803-ae45-2d4e80d84fac.yml
@@ -56,6 +56,10 @@ default:
       attributes:
         name: title
         content: 'Frontpage | DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
   field_paragraphs:
     -
       entity:
@@ -340,9 +344,6 @@ default:
           revision_translation_affected:
             -
               value: true
-          field_filter_content_types:
-            -
-              target_id: article
           field_title:
             -
               value: 'Nye artikler'

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/8'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/11'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/3'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/5'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/4704c566-afc2-4131-ab81-3d636f2451bf.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/4704c566-afc2-4131-ab81-3d636f2451bf.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/10'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/4'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/6'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/1'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/2'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/e539b26b-2992-406b-accf-03e549522c0d.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/e539b26b-2992-406b-accf-03e549522c0d.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/9'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/7'
+  path:
+    -
+      alias: ''
+      langcode: da

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
@@ -31,3 +31,7 @@ default:
       attributes:
         rel: canonical
         href: '/taxonomy/term/12'
+  path:
+    -
+      alias: ''
+      langcode: da


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-465

#### Description
This pull request should be put on hold until we can collectively decide on a strategy for managing different image formats. 

The problem with the hero image not showing credits is that the byline field is not showing. We need to consider that applying hero_wide across different sections, such as list teasers and the map grid, leads to design inconsistencies, and we should also review its impact in other areas.

My idea is to add a new image format `hero_wide_with_crediting` to handle how we can get credit on some images and not others. This needs to be decided together if this is the right way to handle it.


#### Screenshot of the result
<img width="1571" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/cad8c708-0cc7-4f95-bd26-f65759fd0624">

<img width="1571" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/fe24611d-c95b-4ce9-a9b9-0b6378803dfb">

<img width="1571" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/c4a7fddb-6451-406b-854b-06f234664ccd">
