### PR TITLE
Make sure that contrib modules translations are being scanned as well

### DIFF
--- a/task/Taskfile.translations.yml
+++ b/task/Taskfile.translations.yml
@@ -14,6 +14,8 @@ tasks:
     cmds:
       # Make sure that the potion module is active
       - task dev:cli -- drush en -y potion
+      # Generate translations for contrib modules
+      - task dev:cli -- drush potion:generate {{ .LANGUAGE }} modules/contrib/ {{ .PO_DIR }} --recursive --default-write-mode=override
       # Generate translations for custom modules
       - task dev:cli -- drush potion:generate {{ .LANGUAGE }} modules/custom/ {{ .PO_DIR }} --recursive --default-write-mode=override
       # Generate translations for custom themes


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-514

#### Description

Labels and descriptions are exposed to library admins from contrib modules so the need to be translated as well.
