### PR TITLE
Add teaser text/image fields to page node. DDFFORM-428

### DIFF
--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -8,12 +8,37 @@ dependencies:
     - field.field.node.page.field_hero_title
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_teaser_image
+    - field.field.node.page.field_teaser_text
     - node.type.page
   module:
+    - field_group
+    - media_library
+    - media_library_edit
     - paragraphs
     - paragraphs_ee
     - paragraphs_features
+    - path
     - scheduler
+third_party_settings:
+  field_group:
+    group_teaser_card:
+      children:
+        - field_teaser_text
+        - field_teaser_image
+      label: 'Teaser card'
+      region: content
+      parent_name: ''
+      weight: 12
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -76,9 +101,26 @@ content:
       rows: 3
       placeholder: ''
     third_party_settings: {  }
+  field_teaser_image:
+    type: media_library_widget
+    weight: 10
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings:
+      media_library_edit:
+        show_edit: '1'
+  field_teaser_text:
+    type: string_textfield
+    weight: 9
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -110,7 +152,7 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.page.card.yml
+++ b/config/sync/core.entity_view_display.node.page.card.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.node.page.field_hero_title
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_teaser_image
+    - field.field.node.page.field_teaser_text
     - node.type.page
   module:
     - user
@@ -23,6 +25,23 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_teaser_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: hero_wide
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_teaser_text:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -8,6 +8,8 @@ dependencies:
     - field.field.node.page.field_hero_title
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_teaser_image
+    - field.field.node.page.field_teaser_text
     - node.type.page
   module:
     - user
@@ -23,6 +25,22 @@ content:
       link: true
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_teaser_image:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 109
+    region: content
+  field_teaser_text:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 108
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.page.full.yml
+++ b/config/sync/core.entity_view_display.node.page.full.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.node.page.field_hero_title
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_teaser_image
+    - field.field.node.page.field_teaser_text
     - node.type.page
   module:
     - entity_reference_revisions
@@ -56,5 +58,7 @@ content:
     region: content
 hidden:
   field_display_titles: true
+  field_teaser_image: true
+  field_teaser_text: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.list_teaser.yml
@@ -1,9 +1,9 @@
-uuid: c764f0cd-a350-4a01-945b-b39f319710ed
+uuid: 4c1253c3-0c9a-49fa-8870-745e7d39ba70
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.nav_teaser
+    - core.entity_view_mode.node.list_teaser
     - field.field.node.page.field_branch
     - field.field.node.page.field_display_titles
     - field.field.node.page.field_hero_title
@@ -14,17 +14,27 @@ dependencies:
     - node.type.page
   module:
     - user
-id: node.page.nav_teaser
+id: node.page.list_teaser
 targetEntityType: node
 bundle: page
-mode: nav_teaser
+mode: list_teaser
 content:
-  field_subtitle:
-    type: basic_string
+  field_teaser_image:
+    type: entity_reference_entity_view
     label: hidden
-    settings: {  }
+    settings:
+      view_mode: hero_wide
+      link: false
     third_party_settings: {  }
-    weight: 0
+    weight: 5
+    region: content
+  field_teaser_text:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
     region: content
   links:
     settings: {  }
@@ -36,7 +46,6 @@ hidden:
   field_display_titles: true
   field_hero_title: true
   field_paragraphs: true
-  field_teaser_image: true
-  field_teaser_text: true
+  field_subtitle: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.page.nav_spot.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.node.page.field_hero_title
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_teaser_image
+    - field.field.node.page.field_teaser_text
     - node.type.page
   module:
     - user
@@ -23,6 +25,23 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_teaser_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: hero_wide
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_teaser_text:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.node.page.field_hero_title
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_teaser_image
+    - field.field.node.page.field_teaser_text
     - node.type.page
   module:
     - user
@@ -28,5 +30,7 @@ hidden:
   field_hero_title: true
   field_paragraphs: true
   field_subtitle: true
+  field_teaser_image: true
+  field_teaser_text: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.page.field_teaser_image.yml
+++ b/config/sync/field.field.node.page.field_teaser_image.yml
@@ -1,0 +1,29 @@
+uuid: dc72221e-1f0a-43a2-a931-32e486cca2a9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_teaser_image
+    - media.type.image
+    - node.type.page
+id: node.page.field_teaser_image
+field_name: field_teaser_image
+entity_type: node
+bundle: page
+label: 'Teaser image'
+description: "The teaser fields are used for the card of display.\r\nIf no image has been selected, the text will be shown instead:\r\n\r\n<img src=\"/themes/custom/novel/images/teaser-text-image.jpg\" />\r\n\r\n<hr/>"
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: name
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.page.field_teaser_text.yml
+++ b/config/sync/field.field.node.page.field_teaser_text.yml
@@ -1,0 +1,19 @@
+uuid: c76802af-c217-4929-b4c8-be5260682e06
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_teaser_text
+    - node.type.page
+id: node.page.field_teaser_text
+field_name: field_teaser_text
+entity_type: node
+bundle: page
+label: 'Teaser text'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string


### PR DESCRIPTION
These fields, that already existed on articles, were missing on pages.

<img width="376" alt="Screenshot 2024-03-26 at 09 48 41" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/14d8a006-dd1d-4735-83b2-85880768f231">
