### PR TITLE
Tweak preview of media paragraphs.

### DIFF
--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -7,6 +7,18 @@
   padding: calc(var(--gin-spacing-m) - 2px) calc(var(--gin-spacing-l) - 2px);
 }
 
+/* Display medias more compact in paragraph preview. */
+.paragraph--view-mode--preview .field--name-field-medias {
+  .field__items {
+    display: flex;
+    gap: 20px;
+  }
+
+  .field__item {
+    max-width: 220px;
+  }
+}
+
 /* Displaying the byline on the media-library preview. */
 .media-library-item__preview {
   position: relative;
@@ -24,6 +36,7 @@
   font-size: 13px;
   color: white;
   background-color: rgba(0, 0, 0, 0.5);
+  overflow: auto;
 }
 
 /* Make the inner dialog widget take more space of the screen. */

--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -14,6 +14,9 @@
 
 .media-library-item__preview-wrapper .field--name-field-byline {
   position: absolute;
+  max-height: 125px;
+  left: 0;
+  right: 0;
   bottom: 0;
   padding: 5px;
   z-index: 2;


### PR DESCRIPTION
- Admin: Dont place byline above buttons. DDFFORM-469
- Preview of multiple medias in paragraph more compact. DDFFORM-469

-----


Before:

<img width="621" alt="Screenshot 2024-04-02 at 14 37 55" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/09841263-fe39-4868-90da-902367358b17">
<img width="241" alt="Screenshot 2024-04-02 at 14 38 02" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/579089c5-991a-4da8-a40a-f5ff2a4679a8">


After:

<img width="504" alt="Screenshot 2024-04-02 at 14 38 22" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/dd636756-dce7-4c2b-965d-e9e5dbb7c820">
<img width="533" alt="Screenshot 2024-04-02 at 14 38 18" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/1f61f5fe-4c8a-4974-b2ca-c22bb1f01497">
