### PR TITLE
Footer update

### DIFF
--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -2,6 +2,11 @@
  * This file is loaded into admin pages.
  */
 
+/* Overriding wrong styling from reset.scss */
+.button:focus {
+  padding: calc(var(--gin-spacing-m) - 2px) calc(var(--gin-spacing-l) - 2px);
+}
+
 /* Displaying the byline on the media-library preview. */
 .media-library-item__preview {
   position: relative;

--- a/web/modules/custom/dpl_footer/dpl_footer.module
+++ b/web/modules/custom/dpl_footer/dpl_footer.module
@@ -18,12 +18,5 @@ function dpl_footer_preprocess_page(array &$variables): void {
   // Setting a cache tag so we can clear caches when the footer is updated.
   $variables['#cache']['tags'][] = 'dpl_footer';
 
-  // Preparing the footer variables.
-  $footer_values = \Drupal::state()->get('dpl_footer_values');
-
-  // Directly assigning footer variables without checking for
-  // a specific language.
-  if (!empty($footer_values)) {
-    $variables['footer_items'] = $footer_values['footer_items'];
-  }
+  $variables['footer_settings'] = \Drupal::state()->get('dpl_footer_values');
 }

--- a/web/modules/custom/dpl_footer/src/Form/FooterForm.php
+++ b/web/modules/custom/dpl_footer/src/Form/FooterForm.php
@@ -64,20 +64,61 @@ class FooterForm extends FormBase {
 
     $form['footer_items'] = [
       '#type' => 'multivalue',
-      '#title' => $this->t('Footer item'),
+      '#title' => $this->t('Footer columns', [], ['context' => 'DPL admin UX']),
       '#cardinality' => MultiValue::CARDINALITY_UNLIMITED,
       '#default_value' => $default_values['footer_items'] ?? [],
       'name' => [
         '#type' => 'textfield',
-        '#title' => $this->t('Name'),
+        '#title' => $this->t('Name', [], ['context' => 'DPL admin UX']),
       ],
       'content' => [
         '#type' => 'text_format',
-        '#title' => $this->t('content'),
-        '#description' => $this->t('If there is no content the item will be removed.'),
+        '#title' => $this->t('Content', [], ['context' => 'DPL admin UX']),
+        '#description' => $this->t('If there is no content the item will be removed.', [], ['context' => 'DPL admin UX']),
         '#allowed_formats' => ['basic'],
       ],
     ];
+
+    $form['secondary_links'] = [
+      '#type' => 'multivalue',
+      '#title' => $this->t('Secondary links'),
+      '#cardinality' => MultiValue::CARDINALITY_UNLIMITED,
+      '#default_value' => $default_values['secondary_links'] ?? [],
+      'name' => [
+        '#type' => 'textfield',
+        '#title' => $this->t('Link title', [], ['context' => 'DPL admin UX']),
+      ],
+      'content' => [
+        '#type' => 'linkit',
+        '#autocomplete_route_name' => 'linkit.autocomplete',
+        '#autocomplete_route_parameters' => [
+          'linkit_profile_id' => 'default',
+        ],
+        '#title' => $this->t('Link'),
+        '#description' => $this->t('If there is no content the item will be removed.', [], ['context' => 'DPL admin UX']),
+      ],
+    ];
+
+    $social_medias = [
+      'facebook' => $this->t('Facebook'),
+      'instagram' => $this->t('Instagram'),
+      'youtube' => $this->t('Youtube'),
+      'spotify' => $this->t('Spotify'),
+    ];
+
+    $form['socials'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t("Social media URLs", [], ['context' => 'DPL admin UX']),
+      '#description' => $this->t('The link will only be displayed if there is content.', [], ['context' => 'DPL admin UX']),
+    ];
+
+    foreach ($social_medias as $key => $name) {
+      $form['socials'][$key] = [
+        '#type' => 'url',
+        '#title' => $name,
+        '#default_value' => $default_values[$key] ?? [],
+      ];
+    }
 
     // Add a submit button that handles the submission of the form.
     $form['actions']['submit'] = [
@@ -97,7 +138,14 @@ class FooterForm extends FormBase {
     // Filter out footer items where 'content' value is an empty string.
     if (isset($values['footer_items']) && is_array($values['footer_items'])) {
       $values['footer_items'] = array_filter($values['footer_items'], function ($item) {
-        return isset($item['content']) && isset($item['content']['value']) && $item['content']['value'] !== '';
+        return !empty($item['content']['value']);
+      });
+    }
+
+    // Filter out secondary links where 'content' value is an empty string.
+    if (isset($values['secondary_links']) && is_array($values['secondary_links'])) {
+      $values['secondary_links'] = array_filter($values['secondary_links'], function ($item) {
+        return !empty($item['content']);
       });
     }
 

--- a/web/themes/custom/novel/templates/components/footer-columns.html.twig
+++ b/web/themes/custom/novel/templates/components/footer-columns.html.twig
@@ -1,5 +1,5 @@
 <ul class="footer-columns">
-    {% for item in footer %}
+    {% for item in settings.footer_items %}
         <li class="footer-column">
             <h3 class="footer__title">{{ item.name }}</h3>
             <div class="footer__content">

--- a/web/themes/custom/novel/templates/components/footer-info-icons.html.twig
+++ b/web/themes/custom/novel/templates/components/footer-info-icons.html.twig
@@ -1,22 +1,11 @@
 <ul class="footer-info__icons">
-    <li>
-        <a href="/" class="footer-info__icon">
-            <img width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/social/icon-social-facebook.svg" alt="Facebook link" loading="lazy"/>
+  {% for key in ['facebook', 'instagram', 'youtube', 'spotify'] %}
+    {% if settings[key] is not empty %}
+      <li>
+        <a href="{{ settings[key] }}" class="footer-info__icon" target="_blank">
+          <img width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/social/icon-social-{{ key }}.svg" alt="{{ key }} link" loading="lazy"/>
         </a>
-    </li>
-    <li>
-        <a href="/" class="footer-info__icon">
-            <img width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/social/icon-social-instagram.svg" alt="Instagram link" loading="lazy"/>
-        </a>
-    </li>
-    <li>
-        <a href="/" class="footer-info__icon">
-            <img width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/social/icon-social-youtube.svg" alt="Youtube link" loading="lazy"/>
-        </a>
-    </li>
-    <li>
-        <a href="/" class="footer-info__icon">
-            <img width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/social/icon-social-spotify.svg" alt="Spotify link" loading="lazy"/>
-        </a>
-    </li>
+      </li>
+    {% endif %}
+  {% endfor %}
 </ul>

--- a/web/themes/custom/novel/templates/components/footer-info-links.html.twig
+++ b/web/themes/custom/novel/templates/components/footer-info-links.html.twig
@@ -1,11 +1,9 @@
 <ul class="footer-info__links">
-    <li>
-        <a href="/" class="footer-info__link">Behandling af persondata</a>
-    </li>
-    <li>
-        <a href="/" class="footer-info__link">Servicedeklaration</a>
-    </li>
-    <li>
-        <a href="/" class="footer-info__link">Tilgængelighed</a>
-    </li>
+  {% for link in settings.secondary_links %}
+    {% if link.name and link.content %}
+      <li>
+        <a href="{{ link.content }}" class="footer-info__link">{{ link.name }}</a>
+      </li>
+    {% endif %}
+  {% endfor %}
 </ul>

--- a/web/themes/custom/novel/templates/layout/footer.html.twig
+++ b/web/themes/custom/novel/templates/layout/footer.html.twig
@@ -1,5 +1,4 @@
 <footer class="footer">
-    <h2 class="hide-visually">Globale links</h2>
     {# mobile footer #}
     <div class="pagefold-parent--small internal-pagefold-parent footer__mobile">
         <div class="pagefold-triangle--small pagefold-inherit-parent"></div>

--- a/web/themes/custom/novel/templates/layout/page.html.twig
+++ b/web/themes/custom/novel/templates/layout/page.html.twig
@@ -61,7 +61,7 @@
 
   {% include '@novel/layout/footer.html.twig'
     with {
-    'footer': footer_items,
+    'settings': footer_settings,
     'logo': logo,
   } only %}
 </div>


### PR DESCRIPTION
- Override faulty button styling from reset.scss. DDFFORM-487
- Expand footer settings, to include secondary footer. DDFFORM-406

------

Test it by going here: https://varnish.pr-935.dpl-cms.dplplat01.dpl.reload.dk/admin/structure/footer

And yeah, the form is getting a bit bloated. I think we should take this discussion with DDF/in the demo.