### PR TITLE
Add skeleton template for Fee list [DDFLSBP-485]

### DIFF
--- a/web/themes/custom/novel/templates/dpl-react-app--fee-list.html.twig
+++ b/web/themes/custom/novel/templates/dpl-react-app--fee-list.html.twig
@@ -1,0 +1,127 @@
+<div class="dpl-react-app-container--page">
+    <div {{ attributes }}>
+        <div class="fee-list-page" data-cy="fee-list-page">
+            <h1 data-cy="fee-list-headline" class="text-header-h1 my-32">
+                {{ attributes['data-fee-list-headline-text']|raw }}
+            </h1>
+            <div>
+                <div data-cy="fee-list-body">
+                    <div class="fee-list-body__text">
+                        {{ attributes['data-fee-list-body-text']|raw }}
+                    </div>
+                    <div class="fee-list-body__payment-info-link">
+                        <a
+                            href=""
+                            rel="noreferrer"
+                            class="link-tag"
+                            >
+                        {{ attributes['data-view-fees-and-compensation-rates-text']|raw }}
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <section class="ssc fee-list">
+                <h2 class="dpl-list-buttons__header" aria-label="Fee payment info">
+                    <div class="ssc-head-line w-20 mt-10"></div>
+                </h2>
+                <button type="button" class="list-reservation my-32" aria-label="Fee card">
+                    <div class="list-reservation__material">
+                        <div>
+                            <div class="ssc-square cover--size-small"></div>
+                        </div>
+                        <div class="list-reservation__information">
+                            <div class="ssc-head-line w-30 mb-24"></div>
+                            <div class="ssc-head-line w-100 mb-4"></div>
+                            <div class="ssc-line w-70 mb-4"></div>
+                            <div class="ssc-line w-60 mb-4"></div>
+                        </div>
+                    </div>
+                    <div class="list-reservation__status">
+                        <div>
+                            <div class="list-reservation__deadline">
+                                <div class="ssc-head-line w-30"></div>
+                                <div class="ssc-line w-80 mb-4"></div>
+                            </div>
+                        </div>
+                        <div class="list-reservation__fee flex justify-end">
+                            <div class="ssc-head-line w-30"></div>
+                        </div>
+                    </div>
+                </button>
+                <button type="button" class="list-reservation my-32" aria-label="Fee card">
+                    <div class="list-reservation__material">
+                        <div>
+                            <div class="ssc-square cover--size-small"></div>
+                        </div>
+                        <div class="list-reservation__information">
+                            <div class="ssc-head-line w-30 mb-24"></div>
+                            <div class="ssc-head-line w-100 mb-4"></div>
+                            <div class="ssc-line w-70 mb-4"></div>
+                            <div class="ssc-line w-60 mb-4"></div>
+                        </div>
+                    </div>
+                    <div class="list-reservation__status">
+                        <div>
+                            <div class="list-reservation__deadline">
+                                <div class="ssc-head-line w-30"></div>
+                                <div class="ssc-line w-80 mb-4"></div>
+                            </div>
+                        </div>
+                        <div class="list-reservation__fee flex justify-end">
+                            <div class="ssc-head-line w-30"></div>
+                        </div>
+                    </div>
+                </button>
+                <div class="ssc-head-line w-20 mt-48"></div>
+                <button type="button" class="list-reservation my-32" aria-label="Fee card">
+                    <div class="list-reservation__material">
+                        <div>
+                            <div class="ssc-square cover--size-small"></div>
+                        </div>
+                        <div class="list-reservation__information">
+                            <div class="ssc-head-line w-30 mb-24"></div>
+                            <div class="ssc-head-line w-100 mb-4"></div>
+                            <div class="ssc-line w-70 mb-4"></div>
+                            <div class="ssc-line w-60 mb-4"></div>
+                        </div>
+                    </div>
+                    <div class="list-reservation__status">
+                        <div>
+                            <div class="list-reservation__deadline">
+                                <div class="ssc-head-line w-30"></div>
+                                <div class="ssc-line w-80 mb-4"></div>
+                            </div>
+                        </div>
+                        <div class="list-reservation__fee flex justify-end">
+                            <div class="ssc-head-line w-30"></div>
+                        </div>
+                    </div>
+                </button>
+                <button type="button" class="list-reservation my-32" aria-label="Fee card">
+                    <div class="list-reservation__material">
+                        <div>
+                            <div class="ssc-square cover--size-small"></div>
+                        </div>
+                        <div class="list-reservation__information">
+                            <div class="ssc-head-line w-30 mb-24"></div>
+                            <div class="ssc-head-line w-100 mb-4"></div>
+                            <div class="ssc-line w-70 mb-4"></div>
+                            <div class="ssc-line w-60 mb-4"></div>
+                        </div>
+                    </div>
+                    <div class="list-reservation__status">
+                        <div>
+                            <div class="list-reservation__deadline">
+                                <div class="ssc-head-line w-30"></div>
+                                <div class="ssc-line w-80 mb-4"></div>
+                            </div>
+                        </div>
+                        <div class="list-reservation__fee flex justify-end">
+                            <div class="ssc-head-line w-30"></div>
+                        </div>
+                    </div>
+                </button>
+            </section>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-485

#### Description

Adds a Twig template for displaying a skeleton screen until the React component is initialized.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/105956/45b5d30a-cad5-4ffa-a935-a9e30fab1ea2

#### Additional comments or questions

*