### PR TITLE
Decrease minimal react app container height to be same as screen height

### DIFF
--- a/web/themes/custom/novel/css/novel.css
+++ b/web/themes/custom/novel/css/novel.css
@@ -1,4 +1,4 @@
 .dpl-react-app-container--page {
-  min-height: 200vh;
+  min-height: 100vh;
   background-color: #f6f5f0;
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-532

#### Description
The containers for React apps' min-height was set to double the size of screen height, which creates a lot of unnecessary whitespace on short pages. 

#### Screenshot of the result
-

#### Additional comments or questions
-
