### PR TITLE
Create more visible logout link for admins.

### DIFF
--- a/web/modules/custom/dpl_admin/dpl_admin.links.menu.yml
+++ b/web/modules/custom/dpl_admin/dpl_admin.links.menu.yml
@@ -3,3 +3,8 @@ dpl_admin.add_content:
   parent: system.admin_content
   route_name: dpl_admin.add_content
   weight: 5
+dpl_admin.logout:
+  title: "Logout"
+  route_name: user.logout
+  parent: system.admin
+  weight: 9999


### PR DESCRIPTION
<img width="484" alt="Screenshot 2024-04-05 at 11 36 37" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/a1214ecd-11b9-4f78-9cf2-180259fa8c48">

It's pretty hard to find the logout button as it is