### PR TITLE
Rework logic in user authentication handling

### DIFF
--- a/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
+++ b/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
@@ -16,6 +16,13 @@ use function Safe\preg_match as preg_match;
 class UserTokenAuthProvider implements AuthenticationProviderInterface {
 
   /**
+   * A map of known responses to authentication from token.
+   *
+   * @var array<string, ?AccountInterface>
+   */
+  private array $authMap = [];
+
+  /**
    * Constructor.
    */
   public function __construct(
@@ -60,9 +67,8 @@ class UserTokenAuthProvider implements AuthenticationProviderInterface {
     // Add static caching of user authentication. This method will be called
     // multiple times with the same request and retrieving user info and
     // loading the user may be expensive.
-    static $tokenMap = [];
-    if (array_key_exists($token, $tokenMap)) {
-      return $tokenMap[$token];
+    if (array_key_exists($token, $this->authMap)) {
+      return $this->authMap[$token];
     }
 
     $return = NULL;
@@ -89,7 +95,7 @@ class UserTokenAuthProvider implements AuthenticationProviderInterface {
       }
     }
 
-    $tokenMap[$token] = $return;
+    $this->authMap[$token] = $return;
     return $return;
   }
 

--- a/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
+++ b/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
@@ -41,10 +41,11 @@ class UserTokenAuthProvider implements AuthenticationProviderInterface {
    * {@inheritdoc}
    */
   public function applies(Request $request) : bool {
-    // If the request has a bearer token this provider applies. In general we
-    // might have tokens for different systems and we might not know if a
-    // specific token actually works with this setup but at least we can try.
-    return (bool) $this->getToken($request);
+    // We only know if this provider applies if we can actually resolve the
+    // request to a user. Clients may pass either user or library tokens.
+    // We cannot tell from the data alone which is which so we have to try
+    // to authenticate to see if it will resolve to a user to know.
+    return (bool) $this->authenticate($request);
   }
 
   /**
@@ -56,30 +57,40 @@ class UserTokenAuthProvider implements AuthenticationProviderInterface {
       return NULL;
     }
 
-    $user_info = $this->client->retrieveUserInfo($token);
-    if (!$user_info) {
-      // No need to log here. Error logging is already handled by the client.
-      return NULL;
-    }
-    // Allow modules to alter the user info.
-    // This allows this module to add a "sub" entry denoting the unique
-    // end-user (subject) identifier. This is needed for us to load the
-    // associated Drupal user from the OpenID Connect authmap.
-    $context = [];
-    try {
-      $this->moduleHandler->alter('openid_connect_userinfo', $user_info, $context);
-    } catch (\Exception $e) {
-      // Do nothing. If the token cannot resolve to a user then
-      // dpl_login_openid_connect_userinfo_alter() will throw an exception.
-      // However this is to be expected if this is a library token so in that
-      // case continue.
-    }
-    if (!isset($user_info['sub'])) {
-      return NULL;
+    // Add static caching of user authentication. This method will be called
+    // multiple times with the same request and retrieving user info and
+    // loading the user may be expensive.
+    static $tokenMap = [];
+    if (array_key_exists($token, $tokenMap)) {
+      return $tokenMap[$token];
     }
 
-    $user = $this->authmap->userLoadBySub($user_info['sub'], $this->client->getPluginId());
-    return ($user instanceof AccountInterface) ? $user : NULL;
+    $return = NULL;
+
+    $user_info = $this->client->retrieveUserInfo($token);
+    if ($user_info) {
+      // Allow modules to alter the user info.
+      // This allows this module to add a "sub" entry denoting the unique
+      // end-user (subject) identifier. This is needed for us to load the
+      // associated Drupal user from the OpenID Connect authmap.
+      $context = [];
+      try {
+        $this->moduleHandler->alter('openid_connect_userinfo', $user_info, $context);
+      }
+      catch (\Exception $e) {
+        // Do nothing. If the token cannot resolve to a user then
+        // dpl_login_openid_connect_userinfo_alter() will throw an exception.
+        // However this is to be expected if this is a library token so in that
+        // case continue.
+      }
+      if (isset($user_info['sub'])) {
+        $user = $this->authmap->userLoadBySub($user_info['sub'], $this->client->getPluginId());
+        $return = ($user instanceof AccountInterface) ? $user : NULL;
+      }
+    }
+
+    $tokenMap[$token] = $return;
+    return $return;
   }
 
 }

--- a/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
+++ b/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
@@ -66,7 +66,14 @@ class UserTokenAuthProvider implements AuthenticationProviderInterface {
     // end-user (subject) identifier. This is needed for us to load the
     // associated Drupal user from the OpenID Connect authmap.
     $context = [];
-    $this->moduleHandler->alter('openid_connect_userinfo', $user_info, $context);
+    try {
+      $this->moduleHandler->alter('openid_connect_userinfo', $user_info, $context);
+    } catch (\Exception $e) {
+      // Do nothing. If the token cannot resolve to a user then
+      // dpl_login_openid_connect_userinfo_alter() will throw an exception.
+      // However this is to be expected if this is a library token so in that
+      // case continue.
+    }
     if (!isset($user_info['sub'])) {
       return NULL;
     }

--- a/web/modules/custom/dpl_login/tests/src/Unit/UserTokenAuthProviderTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/UserTokenAuthProviderTest.php
@@ -59,18 +59,6 @@ class UserTokenAuthProviderTest extends UnitTestCase {
   }
 
   /**
-   * A request with a bearer token should be handled by the provider.
-   */
-  public function testRequestWithBearerTokenApplies(): void {
-    $provider = new UserTokenAuthProvider($this->openIdClient->reveal(), $this->moduleInvoker->reveal(), $this->authMap->reveal());
-
-    $request = new Request();
-    $request->headers->set('Authorization', 'Bearer abcd1234');
-
-    $this->assertTrue($provider->applies($request));
-  }
-
-  /**
    * A request with another type of authorization scheme should not be handled.
    */
   public function testRequestWithBasicAuthDoesNotApply(): void {
@@ -97,6 +85,8 @@ class UserTokenAuthProviderTest extends UnitTestCase {
 
     $request = new Request();
     $request->headers->set('Authorization', 'Bearer abcd1234');
+
+    $this->assertTrue($provider->applies($request));
 
     $authenticatedUser = $provider->authenticate($request);
     $this->assertEquals($user, $authenticatedUser);


### PR DESCRIPTION
#### Description

Currently we see requests failing when accessing the API with the error: "Unable to identify user. Both CPR and uniqueId are missing."

This occurs when the API is requested with a library bearer token as this cannot be related to a patron. The API is requested with a library token when is is accessed by a end user which is not authenticated through Adgangsplatformen  (e.g. the campaign endpoint) or by library staff (e.g. the opening hours).

This is unfortunate for multiple reasons:

1. It spams our error logs
2. It prevents other authentication providers from trying to authenticate the user as an exception is thrown

To address this this PR does two things:

1. To avoid hard errors in these cases the authentication provider swallows the exception so we can move along without authenticating the request. This should avoid most of the errors we are currently seeing.
2. When determining whether a request can be authenticated with a token we try resolve it to a user. If that is the case then we complete the authentication with the token. If not we allow other authentication providers to try to authenticate. This allows library staff to use the API when administering opening hours.

#### Additional comments or questions

I am not sure if it is a good idea to throw in this case or during a hook implementation in general. It will stop all execution. On the other hand I do not know what lead to this implementation so I created what I think it a suitable workaround in the authentication provider.

I have expecienced the problem in relation to loading opening hours for the administration interface through the CMS API. I expect the same problem will occur for loading search campaigns. It may also explain the large amount of logging errors related to this in Grafana.

For the record: The changes in this PR has already been included in our demo environment as they are needed to make the opening hours API work.

Another approach to this would be to [not include the library token in requests to the CMS](https://github.com/danskernesdigitalebibliotek/dpl-react/blob/develop/src/core/dpl-cms/mutator/fetcher.ts#L24). When I think about it I am not sure when that token is relevant.
