### PR TITLE
Make sure header doesnt break out zoom on mobile. DDFFORM-517

### DIFF
--- a/web/themes/custom/novel/templates/layout/page.html.twig
+++ b/web/themes/custom/novel/templates/layout/page.html.twig
@@ -43,7 +43,8 @@
  */
 #}
 
-<div>
+{# Overflow hidden is necessary, to avoid the header breaking out on mobile. #}
+<div class="overflow-hidden">
   {% include '@novel/layout/header.html.twig'
     with {
     'header': page.header,


### PR DESCRIPTION
We cant really reflect this in the design system, as we have no story that combines the header, page etc.

This relies on https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/574 being merged first.


<img width="490" alt="Screenshot 2024-04-08 at 15 16 51" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/12376583/b7b7872c-5806-41e4-a38c-6732b9fa876f">
