### PR TITLE
Ddflsbp 419 fix yamldiscovery warning

### DIFF
--- a/web/modules/custom/dpl_recommender/dpl_recommender.links.menu.yml
+++ b/web/modules/custom/dpl_recommender/dpl_recommender.links.menu.yml
@@ -1,8 +1,0 @@
-/* eslint-disable yml/no-empty-document */
-# This route is commented out for the time being due to this task: https://reload.atlassian.net/browse/DDFLSBP-419
-
-# dpl_recommender.settings_form:
-#   title: "Recommender settings"
-#   route_name: dpl_recommender.settings
-#   description: "Change recommender settings"
-#   parent: dpl_library_agency.settings


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-419

#### Description

The previous fix for this task, was to comment out the links.menu.yml file content, but this solution was presenting us with warnings when clearing Drupal cache. Sometimes this would also show on admin UI pages. 
This PR instead removes the links.menu.yml file completely. We can add it again when needed.

#### Additional comments or questions

The issues has been discussed here: https://reload.zulipchat.com/#narrow/stream/240325-DDF/topic/Cache.20clear.20warning/near/431508624 