### PR TITLE
Set permissions for opening-hours

### DIFF
--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -15,8 +15,9 @@ dependencies:
     - rest.resource.dpl_opening_hours_create
     - rest.resource.dpl_opening_hours_delete
     - rest.resource.dpl_opening_hours_update
-    - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.breadcrumb_structure
+    - taxonomy.vocabulary.categories
+    - taxonomy.vocabulary.opening_hours_categories
     - taxonomy.vocabulary.tags
   module:
     - administerusersbyrole
@@ -105,6 +106,7 @@ permissions:
   - 'create page content'
   - 'create terms in breadcrumb_structure'
   - 'create terms in categories'
+  - 'create terms in opening_hours_categories'
   - 'create terms in tags'
   - 'create users'
   - 'create video media'
@@ -166,6 +168,7 @@ permissions:
   - 'edit own video media'
   - 'edit terms in breadcrumb_structure'
   - 'edit terms in categories'
+  - 'edit terms in opening_hours_categories'
   - 'edit terms in tags'
   - 'edit themes novel'
   - 'edit users by role'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -15,8 +15,9 @@ dependencies:
     - rest.resource.dpl_opening_hours_create
     - rest.resource.dpl_opening_hours_delete
     - rest.resource.dpl_opening_hours_update
-    - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.breadcrumb_structure
+    - taxonomy.vocabulary.categories
+    - taxonomy.vocabulary.opening_hours_categories
     - taxonomy.vocabulary.tags
   module:
     - administerusersbyrole
@@ -95,6 +96,7 @@ permissions:
   - 'create page content'
   - 'create terms in breadcrumb_structure'
   - 'create terms in categories'
+  - 'create terms in opening_hours_categories'
   - 'create terms in tags'
   - 'create users'
   - 'create video media'
@@ -155,6 +157,7 @@ permissions:
   - 'edit own video media'
   - 'edit terms in breadcrumb_structure'
   - 'edit terms in categories'
+  - 'edit terms in opening_hours_categories'
   - 'edit terms in tags'
   - 'edit themes novel'
   - 'edit users by role'


### PR DESCRIPTION
#### Link to issue


#### Description
Enable `Administrator` and `Local administrator` to manage (add, edit) opening hours taxonomy terms.

#### Screenshot of the result