### PR TITLE
Fix Lagoon integration for database and file synchronization

### DIFF
--- a/assets/lagoon.site.yml
+++ b/assets/lagoon.site.yml
@@ -1,0 +1,8 @@
+'*':
+  host: 20.238.147.183
+  paths:
+    files: /app/web/sites/default/files
+  user: ${env-name}
+  ssh:
+    options: '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=FATAL -p 22'
+    tty: false

--- a/composer.json
+++ b/composer.json
@@ -237,6 +237,7 @@
                 "[web-root]/sites/default/development.settings.php": "assets/development.settings.php",
                 "[web-root]/sites/default/local.services.yml": "assets/local.services.yml",
                 "[web-root]/sites/default/local.settings.php": "assets/local.settings.php",
+                "[project-root]/drush/sites/lagoon.site.yml": "assets/lagoon.site.yml",
                 "[web-root]/.eslintrc.json": false,
                 "[project-root]/.gitattributes": {
                     "append": "assets/.gitattributes"

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
         }
     ],
     "require": {
-        "amazeeio/drupal_integrations": "0.3.7",
+        "amazeeio/drupal_integrations": "^0.4",
         "brick/math": "^0.12.1",
         "composer/installers": "1.12.0",
         "cweagans/composer-patches": "1.7.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,34 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d42b61b0cba10495f9bb667664999be",
+    "content-hash": "361b3a686e1bef2df99ee2533df47682",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
-            "version": "0.3.7",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/drupal-integrations.git",
-                "reference": "f5d4ddd9fbdb0e1ec4b7ab4c110189b6ddd6538d"
+                "reference": "4166cbcce9429e7e1cfaa9ffba4d44c1c267f083"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/drupal-integrations/zipball/f5d4ddd9fbdb0e1ec4b7ab4c110189b6ddd6538d",
-                "reference": "f5d4ddd9fbdb0e1ec4b7ab4c110189b6ddd6538d",
+                "url": "https://api.github.com/repos/amazeeio/drupal-integrations/zipball/4166cbcce9429e7e1cfaa9ffba4d44c1c267f083",
+                "reference": "4166cbcce9429e7e1cfaa9ffba4d44c1c267f083",
                 "shasum": ""
             },
             "require": {
                 "drupal/core-composer-scaffold": "*"
             },
             "conflict": {
-                "drupal/core": "<8.5"
+                "drupal/core": "<9.0"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
                 "drupal/coder": "^8.3"
             },
             "suggest": {
-                "drupal/lagoon_logs": "Zero configuration logging system for Drupal 7 and 8 sites running on amazee.io Lagoon"
+                "drupal/lagoon_logs": "Zero configuration logging system for Drupal sites running on Lagoon"
             },
             "type": "drupal-drush",
             "extra": {
@@ -53,12 +53,12 @@
             "license": [
                 "MIT"
             ],
-            "description": "Add this project to any Drupal distribution based on drupal/core-composer-scaffold to enable it for use on Lagoon.",
+            "description": "Add this project to any Drupal 9+ distribution based on drupal/core-composer-scaffold to enable it for use on Lagoon.",
             "support": {
                 "issues": "https://github.com/amazeeio/drupal-integrations/issues",
-                "source": "https://github.com/amazeeio/drupal-integrations/tree/0.3.7"
+                "source": "https://github.com/amazeeio/drupal-integrations/tree/0.4.0"
             },
-            "time": "2022-03-03T01:57:35+00:00"
+            "time": "2023-11-13T00:29:04+00:00"
         },
         {
             "name": "asm89/stack-cors",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "361b3a686e1bef2df99ee2533df47682",
+    "content-hash": "1a889c9fcc4585ec2179d1c470fb140c",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
#### Link to issue

[DDFDRIFT-36](https://reload.atlassian.net/browse/DDFDRIFT-36?atlOrigin=eyJpIjoiOTI2M2E2ZDhkZDEwNGM2ZmIyYThjOTRiYWU5YzM5ZGMiLCJwIjoiaiJ9)

#### Description

When doing work with Lagoon we have encountered several problems which are related to how Drush is used and more specifically site aliases.

Our work boils down to two problems:

1. Lagoon uses the `lagoon:aliases` Drush command exposed by the https://packagist.org/packages/amazeeio/drupal_integrations package. The current version of this command fails due to compatibility problems with the currently used version `symfony/process` which has moved when upgrading Drupal Core.
2. Lagoon references `lagoon.sites.yml` when running Drush commands. This references the Lagoon Cloud hostname and IP by default. To avoid this we provide our own `lagoon.sites.yml` which has `host: 20.238.147.183` and SSH port `22` customized to our own platform.


[DDFDRIFT-36]: https://reload.atlassian.net/browse/DDFDRIFT-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ