### PR TITLE
Lower Lighthouse performance targets

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -42,7 +42,8 @@ module.exports = {
         // Our quality standard requires all categories to be green. Green
         // translates to a score between 90 and 100 - or 0.9-1.
         // TODO: Implement inline critial CSS to raise score above 0.9
-        "categories:performance": ["error", { minScore: 0.85 }],
+        // TODO: Implement depedency splitting to raise score above 0.75
+        "categories:performance": ["error", { minScore: 0.75 }],
         "categories:accessibility": ["error", { minScore: 0.9 }],
         "categories:best-practices": ["error", { minScore: 0.9 }],
         "categories:seo": ["error", { minScore: 0.9 }],


### PR DESCRIPTION
#### Description

To implement business functionality we have lately been adding a couple of heavy third party JavaScript libraries: fullcalendar and flatpickr. Due to our Webpack setup these libraries are added to the global bundle.js file and thus the increase in size affect all applications even if they are not using said dependencies.

This takes our very close to or over the limits set by Lighthouse. However due to variance between runs in GitHub Actions tests sometime pass and sometime fail. This cause us to having to rerun Actions until we get a test pass.

This is annoying but we currently cannot prioritize implementing a change which addressees this.

Consequently we choose to reduce the required performance score.

Samples from recent test failures show that we score a minimum of 78. Set the limit to 75 (or 0.75) to ensure that we get a pass in most circumstances but serious problems will still cause a failure.

#### Additional comments or questions

This PR is intentionally against `develop` to release branches can include it when they wish.