### PR TITLE
Add cypress test for 'Opening Hours' - DDFFORM-559 

### DIFF
--- a/cypress/e2e/opening-hours-editor.cy.ts
+++ b/cypress/e2e/opening-hours-editor.cy.ts
@@ -1,13 +1,7 @@
 const selectionOption = "Telefontid";
 
-const loginAndVisit = (url: string) => {
-  cy.clearCookies();
-  cy.drupalLogin();
-  cy.visit(url);
-};
-
 const createBranchAndVisitOpeningHoursAdmin = () => {
-  loginAndVisit("/node/add/branch");
+  cy.drupalLoginAndVisit("/node/add/branch");
   cy.get("#edit-title-0-value").type("Test branch");
   cy.get('button[title="Show all Paragraphs"]').click();
   cy.get('button[value="Opening Hours"]').click({
@@ -52,7 +46,7 @@ const visitOpeningHoursPage = () => {
 const visitOpeningHoursPageAdmin = () => {
   const adminUrl = Cypress.env("adminUrl");
   if (adminUrl) {
-    loginAndVisit(adminUrl);
+    cy.drupalLoginAndVisit(adminUrl);
   }
 };
 

--- a/cypress/e2e/opening-hours-editor.cy.ts
+++ b/cypress/e2e/opening-hours-editor.cy.ts
@@ -1,0 +1,100 @@
+const mainLibraryOpeningHoursPage = "/node/9/edit/opening-hours";
+const selectionOption = "Telefontid";
+
+const openMonthView = () => {
+  cy.visit(mainLibraryOpeningHoursPage);
+  cy.get(".fc-dayGridMonth-button").click();
+};
+
+// The datebase is seeded with opning hours but we are not interested in them for our tests
+// Therefore we delete all opening hours in the mont view if they exist before we start our tests
+const deleteAllOpeningHours = () => {
+  openMonthView();
+  // Attempt to get the elements, but do not fail the test if they do not exist
+  cy.get("body").then(($body) => {
+    if (
+      $body.find('[data-cy="opening-hours-editor-event-content"]').length > 0
+    ) {
+      cy.getBySel("opening-hours-editor-event-content").each(($el) => {
+        cy.wrap($el).click();
+        cy.getBySel("opening-hours-editor-form__remove").click();
+      });
+    } else {
+      cy.log("No opening hours elements found to delete.");
+    }
+  });
+};
+
+const selectTodayFromMonthView = () => {
+  return cy.get(".fc-day-today");
+};
+
+const createOpeningHour = () => {
+  selectTodayFromMonthView().click();
+  cy.getBySel("opening-hours-editor-form").should("be.visible");
+  cy.getBySel("opening-hours-editor-form-select").select(selectionOption);
+  cy.getBySel("opening-hours-editor-form-start-time").focus().type("10:00");
+  cy.getBySel("opening-hours-editor-form-end-time").focus().type("18:00");
+  cy.getBySel("opening-hours-editor-form-submit").click();
+  cy.getBySel("opening-hours-editor-event-content")
+    .should("be.visible")
+    .and("contain", selectionOption)
+    .and("contain", "10:00 - 18:00");
+};
+
+const updateOpeningHour = () => {
+  // Assume that the event is already created and is visible
+  cy.getBySel("opening-hours-editor-event-content")
+    .contains(selectionOption)
+    .click();
+  cy.getBySel("opening-hours-editor-form-end-time").clear().type("20:00");
+  cy.getBySel("opening-hours-editor-form-submit").click();
+  cy.getBySel("opening-hours-editor-event-content")
+    .should("be.visible")
+    .and("contain", selectionOption)
+    .and("contain", "10:00 - 20:00");
+};
+
+const deleteOpeningHour = () => {
+  // Assume that the event is already created and is visible
+  cy.getBySel("opening-hours-editor-event-content")
+    .contains(selectionOption)
+    .click();
+  cy.getBySel("opening-hours-editor-form__remove").click();
+};
+
+describe("Opening hours editor", () => {
+  beforeEach(() => {
+    cy.clearCookies();
+    cy.drupalLogin();
+
+    deleteAllOpeningHours();
+  });
+
+  it("Checks opening hours categories", () => {
+    openMonthView();
+    selectTodayFromMonthView().click();
+    cy.getBySel("opening-hours-editor-form-select")
+      .find("option")
+      .should("have.length", 5)
+      .and("contain", "Åbent")
+      .and("contain", "Borgerservice")
+      .and("contain", "Med betjening")
+      .and("contain", "Selvbetjening")
+      .and("contain", "Telefontid");
+  });
+
+  it("Can create an opening hour", () => {
+    createOpeningHour();
+  });
+
+  it("Can update an opening hour", () => {
+    createOpeningHour();
+    updateOpeningHour();
+  });
+
+  it("Can delete an opening hour", () => {
+    createOpeningHour();
+    deleteOpeningHour();
+  });
+});

--- a/cypress/e2e/opening-hours-editor.cy.ts
+++ b/cypress/e2e/opening-hours-editor.cy.ts
@@ -1,3 +1,6 @@
+const branchTitle = "Test branch";
+const formattedSearchString = branchTitle.toLowerCase().replace(/ /g, "+");
+
 enum OpeningHourCategories {
   Opening = "Åbent",
   CitizenService = "Borgerservice",
@@ -12,9 +15,9 @@ type OpeningHourFormType = {
   end: `${number}:${number}`;
 };
 
-const createBranchAndVisitOpeningHoursAdmin = () => {
+const createTestBranchAndVisitOpeningHoursAdmin = () => {
   cy.drupalLoginAndVisit("/node/add/branch");
-  cy.get("#edit-title-0-value").type("Test branch");
+  cy.get("#edit-title-0-value").type(branchTitle);
   cy.get('button[title="Show all Paragraphs"]').click();
   cy.get('button[value="Opening Hours"]').click({
     multiple: true,
@@ -39,13 +42,24 @@ const createBranchAndVisitOpeningHoursAdmin = () => {
     Cypress.env("pageUrl", pageUrl);
   });
 };
+const deleteAllTestBranchesIfExists = () => {
+  cy.drupalLogin();
+  cy.visit(
+    `/admin/content?title=${formattedSearchString}&type=All&status=All&langcode=All`
+  );
 
-const deleteBranch = () => {
-  const pageUrl = Cypress.env("pageUrl");
-  if (pageUrl) {
-    cy.visit(`${pageUrl}/delete`);
-    cy.get('input[value="Delete"]').click();
-  }
+  cy.get("tbody").then((tbody) => {
+    if (tbody.find("td.views-empty").length) {
+      cy.log("No branches to delete.");
+    } else {
+      cy.get('input[title="Select all rows in this table"]').check({
+        force: true,
+      });
+      cy.get("#edit-action").select("node_delete_action");
+      cy.contains("input", "Apply to selected items").click();
+      cy.contains("input", "Delete").click();
+    }
+  });
 };
 
 const visitOpeningHoursPage = () => {
@@ -227,11 +241,8 @@ const deleteOpeningHour = ({
 
 describe("Opening hours editor", () => {
   beforeEach(() => {
-    createBranchAndVisitOpeningHoursAdmin();
-  });
-
-  afterEach(() => {
-    deleteBranch();
+    deleteAllTestBranchesIfExists();
+    createTestBranchAndVisitOpeningHoursAdmin();
   });
 
   it("Checks opening hours categories", () => {

--- a/cypress/e2e/opening-hours-editor.cy.ts
+++ b/cypress/e2e/opening-hours-editor.cy.ts
@@ -34,6 +34,14 @@ const createBranchAndVisitOpeningHoursAdmin = () => {
   });
 };
 
+const deleteBranch = () => {
+  const pageUrl = Cypress.env("pageUrl");
+  if (pageUrl) {
+    cy.visit(`${pageUrl}/delete`);
+    cy.get('input[value="Delete"]').click();
+  }
+};
+
 const visitOpeningHoursPage = () => {
   const pageUrl = Cypress.env("pageUrl");
   if (pageUrl) {
@@ -136,8 +144,12 @@ const deleteOpeningHour = () => {
 };
 
 describe("Opening hours editor", () => {
-  before(() => {
+  beforeEach(() => {
     createBranchAndVisitOpeningHoursAdmin();
+  });
+
+  afterEach(() => {
+    deleteBranch();
   });
 
   it("Checks opening hours categories", () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -103,6 +103,12 @@ Cypress.Commands.add("drupalCron", () => {
   cy.drupalLogout();
 });
 
+Cypress.Commands.add("drupalLoginAndVisit", (url: string) => {
+  cy.clearCookies();
+  cy.drupalLogin();
+  cy.visit(url);
+});
+
 const adgangsplatformenLoginOauthMappings = ({
   userIsAlreadyRegistered,
   authorizationCode,
@@ -312,6 +318,7 @@ declare global {
       drupalLogin(): Chainable<null>;
       drupalLogout(): Chainable<null>;
       drupalCron(): Chainable<null>;
+      drupalLoginAndVisit(url: string): Chainable<null>;
       adgangsplatformenLogin(params: {
         authorizationCode: string;
         accessToken: string;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -76,7 +76,8 @@ Cypress.Commands.add("logRequests", () => {
   );
 });
 
-Cypress.Commands.add("drupalLogin", () => {
+Cypress.Commands.add("drupalLogin", (url?: string) => {
+  cy.clearCookies();
   cy.visit("/user/login");
   cy.get('[name="name"]')
     .type(Cypress.env("DRUPAL_USERNAME"))
@@ -84,6 +85,9 @@ Cypress.Commands.add("drupalLogin", () => {
     .get('[name="pass"]')
     .type(Cypress.env("DRUPAL_PASSWORD"));
   cy.get('[value="Log in"]').click();
+  if (url) {
+    cy.visit(url);
+  }
 });
 
 Cypress.Commands.add("drupalLogout", () => {
@@ -101,12 +105,6 @@ Cypress.Commands.add("drupalCron", () => {
   cy.get('[value="Run cron"]').click();
   cy.contains("Cron ran successfully.");
   cy.drupalLogout();
-});
-
-Cypress.Commands.add("drupalLoginAndVisit", (url: string) => {
-  cy.clearCookies();
-  cy.drupalLogin();
-  cy.visit(url);
 });
 
 const adgangsplatformenLoginOauthMappings = ({
@@ -315,10 +313,9 @@ declare global {
       logRequests(): Chainable<null>;
       getRequestCount(request: RequestPattern): Chainable<number>;
       resetRequests(): Chainable<null>;
-      drupalLogin(): Chainable<null>;
+      drupalLogin(url?: string): Chainable<null>;
       drupalLogout(): Chainable<null>;
       drupalCron(): Chainable<null>;
-      drupalLoginAndVisit(url: string): Chainable<null>;
       adgangsplatformenLogin(params: {
         authorizationCode: string;
         accessToken: string;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-554

#### Description

This pull request adds an end-to-end (e2e) test for the 'Opening Hours' feature. It comprehensively tests the workflow, including creating a new branch, adding an 'Opening Hours' paragraph, checking various categories of opening hours, adding hours (including for the following week), updating, and deleting opening hours. It also ensures that these changes are correctly reflected in the frontend.

The test is written to ensure that all it() functions are isolated. This means a new branch is created before each test and subsequently deleted.

I have also introduced a `drupalLoginAndVisit` command to our Cypress commands, as it will be useful for future testing.
