### PR TITLE
Replace /articles with search API view, along with facets. DDFFORM-472

### DIFF
--- a/config/sync/facets.facet.content_branch.yml
+++ b/config/sync/facets.facet.content_branch.yml
@@ -1,31 +1,31 @@
-uuid: 1e4784c6-e3ae-4abd-9644-53954a3bfe9a
+uuid: 5beee186-e4f0-407f-a0f9-16b42ca79c5f
 langcode: en
 status: true
 dependencies:
   config:
-    - search_api.index.events
-    - views.view.events
+    - search_api.index.content
+    - views.view.articles
   module:
     - search_api
-id: event_categories
-name: Category
+id: content_branch
+name: Branch
 weight: 0
 min_count: 1
 missing: false
 missing_label: others
-url_alias: event_categories
-facet_source_id: 'search_api:views_page__events__all'
-field_identifier: event_categories
+url_alias: branch
+facet_source_id: 'search_api:views_page__articles__all'
+field_identifier: field_branch
 query_operator: or
 hard_limit: 0
 exclude: false
-use_hierarchy: true
+use_hierarchy: false
 keep_hierarchy_parents_active: false
 hierarchy:
   type: taxonomy
   config: {  }
-expand_hierarchy: true
-enable_parent_when_child_gets_disabled: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
 widget:
   type: dropdown
   config:
@@ -58,16 +58,16 @@ processor_configs:
   hierarchy_processor:
     processor_id: hierarchy_processor
     weights:
-      build: -8
+      build: 100
     settings: {  }
   translate_entity:
     processor_id: translate_entity
     weights:
-      build: -10
+      build: 5
     settings: {  }
   url_processor_handler:
     processor_id: url_processor_handler
     weights:
       pre_query: 50
-      build: -9
+      build: 15
     settings: {  }

--- a/config/sync/facets.facet.content_categories.yml
+++ b/config/sync/facets.facet.content_categories.yml
@@ -1,21 +1,21 @@
-uuid: 1e4784c6-e3ae-4abd-9644-53954a3bfe9a
+uuid: 811ccfe3-1a37-48dd-bd47-3ee62391da36
 langcode: en
 status: true
 dependencies:
   config:
-    - search_api.index.events
-    - views.view.events
+    - search_api.index.content
+    - views.view.articles
   module:
     - search_api
-id: event_categories
+id: content_categories
 name: Category
 weight: 0
 min_count: 1
 missing: false
 missing_label: others
-url_alias: event_categories
-facet_source_id: 'search_api:views_page__events__all'
-field_identifier: event_categories
+url_alias: categories
+facet_source_id: 'search_api:views_page__articles__all'
+field_identifier: field_categories
 query_operator: or
 hard_limit: 0
 exclude: false
@@ -58,16 +58,16 @@ processor_configs:
   hierarchy_processor:
     processor_id: hierarchy_processor
     weights:
-      build: -8
+      build: 100
     settings: {  }
   translate_entity:
     processor_id: translate_entity
     weights:
-      build: -10
+      build: 5
     settings: {  }
   url_processor_handler:
     processor_id: url_processor_handler
     weights:
       pre_query: 50
-      build: -9
+      build: 15
     settings: {  }

--- a/config/sync/facets.facet_source.search_api__views_page__articles__all.yml
+++ b/config/sync/facets.facet_source.search_api__views_page__articles__all.yml
@@ -1,0 +1,9 @@
+uuid: 9a264e37-7129-4a7c-86bd-bd5a52387313
+langcode: en
+status: true
+dependencies: {  }
+id: search_api__views_page__articles__all
+name: 'search_api:views_page__articles__all'
+filter_key: null
+url_processor: query_string
+breadcrumb: {  }

--- a/config/sync/search_api.index.content.yml
+++ b/config/sync/search_api.index.content.yml
@@ -1,0 +1,87 @@
+uuid: 60c71c87-5d98-47a0-9f28-10af48e55feb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_branch
+    - field.storage.node.field_categories
+    - search_api.server.db_search
+  module:
+    - node
+    - search_api
+id: content
+name: Content
+description: ''
+read_only: false
+field_settings:
+  created:
+    label: 'Authored on'
+    datasource_id: 'entity:node'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - node
+  field_branch:
+    label: Branch
+    datasource_id: 'entity:node'
+    property_path: field_branch
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_branch
+  field_categories:
+    label: Categories
+    datasource_id: 'entity:node'
+    property_path: field_categories
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_categories
+  status:
+    label: Published
+    datasource_id: 'entity:node'
+    property_path: status
+    type: boolean
+    dependencies:
+      module:
+        - node
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: string
+    dependencies:
+      module:
+        - node
+  type:
+    label: 'Content type'
+    datasource_id: 'entity:node'
+    property_path: type
+    type: string
+    dependencies:
+      module:
+        - node
+datasource_settings:
+  'entity:node':
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  custom_value: {  }
+  entity_type: {  }
+  language_with_fallback: {  }
+  rendered_item: {  }
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  cron_limit: 50
+  index_directly: true
+  track_changes_in_references: true
+server: db_search

--- a/config/sync/search_api.index.events.yml
+++ b/config/sync/search_api.index.events.yml
@@ -45,6 +45,14 @@ field_settings:
     dependencies:
       module:
         - field_inheritance
+  status:
+    label: Published
+    datasource_id: 'entity:eventinstance'
+    property_path: status
+    type: boolean
+    dependencies:
+      module:
+        - recurring_events
 datasource_settings:
   'entity:eventinstance':
     bundles:

--- a/config/sync/views.view.articles.yml
+++ b/config/sync/views.view.articles.yml
@@ -1,15 +1,12 @@
-uuid: e444e056-ebea-4e77-9250-06f723585181
+uuid: 78eb1cc7-ec47-471e-a5b6-f90708d9ce1e
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.list_teaser
-    - node.type.article
-    - taxonomy.vocabulary.categories
+    - field.storage.node.field_branch
+    - search_api.index.content
   module:
-    - better_exposed_filters
-    - node
-    - taxonomy
+    - search_api
     - user
     - views_infinite_scroll
 id: articles
@@ -17,8 +14,8 @@ label: Articles
 module: views
 description: ''
 tag: ''
-base_table: node_field_data
-base_field: nid
+base_table: search_api_index_content
+base_field: search_api_id
 display:
   default:
     id: default
@@ -28,26 +25,44 @@ display:
     display_options:
       title: Articles
       fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
+        field_branch:
+          id: field_branch
+          table: search_api_index_content
+          field: field_branch
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: field
+          entity_type: null
+          entity_field: null
+          plugin_id: search_api_field
           label: ''
           exclude: false
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
             absolute: false
-            word_boundary: false
-            ellipsis: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
             strip_tags: false
             trim: false
+            preserve_tags: ''
             html: false
           element_type: ''
           element_class: ''
@@ -61,11 +76,10 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings: {  }
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -75,6 +89,14 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods: {  }
       pager:
         type: infinite_scroll
         options:
@@ -98,7 +120,7 @@ display:
             automatically_load_content: false
             initially_load_all_pages: true
       exposed_form:
-        type: bef
+        type: basic
         options:
           submit_button: Apply
           reset_button: false
@@ -107,99 +129,95 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
-          text_input_required: 'Select any filter and click on Apply to see results'
-          text_input_required_format: basic
-          bef:
-            general:
-              autosubmit: true
-              autosubmit_exclude_textfield: false
-              autosubmit_textfield_delay: 500
-              autosubmit_hide: true
-              input_required: false
-              allow_secondary: false
-              secondary_label: 'Advanced options'
-              secondary_open: false
-              reset_button_always_show: false
       access:
         type: perm
         options:
           perm: 'access content'
       cache:
-        type: tag
+        type: none
         options: {  }
       empty: {  }
       sorts:
         created:
           id: created
-          table: node_field_data
+          table: search_api_index_content
           field: created
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: node
-          entity_field: created
-          plugin_id: date
+          plugin_id: search_api
           order: DESC
           expose:
             label: ''
             field_identifier: ''
           exposed: false
-          granularity: second
       arguments: {  }
       filters:
         status:
           id: status
-          table: node_field_data
+          table: search_api_index_content
           field: status
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
-          value: '1'
-          group: 1
-          expose:
-            operator: ''
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          value:
-            article: article
-        field_categories_target_id:
-          id: field_categories_target_id
-          table: node__field_categories
-          field: field_categories_target_id
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: taxonomy_index_tid
-          operator: or
-          value: {  }
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '1'
           group: 1
-          exposed: true
+          exposed: false
           expose:
-            operator_id: field_categories_target_id_op
-            label: 'Article category'
+            operator_id: ''
+            label: ''
             description: ''
             use_operator: false
-            operator: field_categories_target_id_op
+            operator: ''
             operator_limit_selection: false
             operator_list: {  }
-            identifier: field_categories_target_id
+            identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              local_administrator: '0'
-              editor: '0'
-              mediator: '0'
-              patron: '0'
-              external_system: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: search_api_index_content
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            article: article
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
             reduce: false
           is_grouped: false
           group_info:
@@ -214,28 +232,25 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          vid: categories
-          type: select
-          hierarchy: true
-          limit: true
-          error_message: true
       style:
         type: default
       row:
-        type: 'entity:node'
+        type: search_api
         options:
-          relationship: none
-          view_mode: list_teaser
+          view_modes:
+            'entity:node':
+              article: list_teaser
+              branch: list_teaser
+              campaign: list_teaser
+              page: list_teaser
       query:
-        type: views_query
+        type: search_api_query
         options:
-          query_comment: ''
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
+          bypass_access: false
+          skip_access: false
+          preserve_facet_query_args: false
           query_tags: {  }
       relationships: {  }
-      use_ajax: true
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -244,14 +259,15 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
-  page_1:
-    id: page_1
+      tags:
+        - 'config:field.storage.node.field_branch'
+        - 'config:search_api.index.content'
+        - 'search_api_list:content'
+  all:
+    id: all
     display_title: Page
     display_plugin: page
     position: 1
@@ -263,9 +279,10 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_branch'
+        - 'config:search_api.index.content'
+        - 'search_api_list:content'

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -223,6 +223,44 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        status:
+          id: status
+          table: search_api_index_events
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
       row:
@@ -258,59 +296,9 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      filters:
-        end_value:
-          id: end_value
-          table: search_api_index_events
-          field: end_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: search_api_date
-          operator: '>='
-          value:
-            min: ''
-            max: ''
-            value: today
-            type: offset
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            min_placeholder: ''
-            max_placeholder: ''
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
       defaults:
-        filters: false
-        filter_groups: false
+        filters: true
+        filter_groups: true
       display_extenders: {  }
       path: events
     cache_metadata:

--- a/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
+++ b/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
@@ -189,7 +189,7 @@ class BreadcrumbHelper {
     if ($node->bundle() === 'article') {
       $breadcrumb->addLink(Link::createFromRoute(
         $this->translation->translate('Articles'),
-        'view.articles.page_1'
+        'view.articles.all'
       ));
     }
 

--- a/web/themes/custom/novel/templates/views/views-view--articles.html.twig
+++ b/web/themes/custom/novel/templates/views/views-view--articles.html.twig
@@ -1,1 +1,10 @@
 {% extends '@novel/views/views-view--content-list-page.html.twig' %}
+
+{% block facets %}
+  <div class="content-list-page__filter">
+    {{ drupal_block("facet_block:content_categories") }}
+  </div>
+  <div class="content-list-page__filter">
+    {{ drupal_block("facet_block:content_branch") }}
+  </div>
+{% endblock %}


### PR DESCRIPTION
**Replace /articles with search API view, along with facets. DDFFORM-472**

Up until now, we've used exposed filters on /articles, and a search API view on /events, with facets.
This replaces the /articles view with the same kind of facet-view that /events uses.

https://reload.atlassian.net/browse/DDFFORM-472

----

Also a little extra thing: Making sure that /events only shows published events.

Test it by looking at  https://varnish.pr-985.dpl-cms.dplplat01.dpl.reload.dk/articles :)