### PR TITLE
CKEditor frontend tweaks. DDFFORM-543 DDFFORM-467

### DIFF
--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -2,6 +2,15 @@
  * This file is loaded into admin pages.
  */
 
+/*
+ * We dont want the filter help link below CKEditor, as it just confuses more
+ * than it helps, and we already make sure to show the styles directly
+ * in the editor.
+ */
+.filter-help {
+  display: none;
+}
+
 /* Overriding wrong styling from reset.scss */
 .button:focus {
   padding: calc(var(--gin-spacing-m) - 2px) calc(var(--gin-spacing-l) - 2px);

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--accordion.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--accordion.html.twig
@@ -5,7 +5,7 @@
     </h3>
       <img class="disclosure__expand" src="{{ absoluteBaseUrl ~ '/' ~ baseIconPath ~ '/collection/ExpandMore.svg' }}" alt="Icon Description" />
   </summary>
-  <div class="disclosure__content-padding">
+  <div class="disclosure__content-padding rich-text">
     {{ content.field_accordion_description }}
   </div>
 </details>


### PR DESCRIPTION
Hide 'filter help' for CKEditor. https://reload.atlassian.net/browse/DDFFORM-543

We dont want the filter help link below CKEditor, as it just confuses more
than it helps, and we already make sure to show the styles directly
in the editor.

-----

Make sure CKEditor styling is added to accordion. https://reload.atlassian.net/browse/DDFFORM-467

<img width="936" alt="Screenshot 2024-04-11 at 23 01 53" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/e248f07f-188d-4182-808f-a8323fea930f">

<img width="908" alt="Screenshot 2024-04-11 at 23 01 56" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/f27e9c87-ed69-46f0-b2ee-4c32004b6a61">
