### PR TITLE
Add more editor-controls on breadcrumb item. DDFFORM-562 DDFFORM-565 

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.breadcrumb_structure.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.breadcrumb_structure.default.yml
@@ -3,14 +3,45 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.breadcrumb_structure.field_children_title
     - field.field.taxonomy_term.breadcrumb_structure.field_content
     - field.field.taxonomy_term.breadcrumb_structure.field_show_children
+    - field.field.taxonomy_term.breadcrumb_structure.field_show_children_subtitles
     - taxonomy.vocabulary.breadcrumb_structure
+  module:
+    - field_group
+third_party_settings:
+  field_group:
+    group_related_children:
+      children:
+        - field_show_children
+        - field_children_title
+        - field_show_children_subtitles
+      label: 'Related children'
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
 id: taxonomy_term.breadcrumb_structure.default
 targetEntityType: taxonomy_term
 bundle: breadcrumb_structure
 mode: default
 content:
+  field_children_title:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: 'Related content for "@title"'
+    third_party_settings: {  }
   field_content:
     type: entity_reference_autocomplete
     weight: 1
@@ -23,7 +54,14 @@ content:
     third_party_settings: {  }
   field_show_children:
     type: boolean_checkbox
-    weight: 2
+    weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_show_children_subtitles:
+    type: boolean_checkbox
+    weight: 5
     region: content
     settings:
       display_label: true
@@ -38,7 +76,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 3
+    weight: 99
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.taxonomy_term.breadcrumb_structure.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.breadcrumb_structure.default.yml
@@ -3,8 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.breadcrumb_structure.field_children_title
     - field.field.taxonomy_term.breadcrumb_structure.field_content
     - field.field.taxonomy_term.breadcrumb_structure.field_show_children
+    - field.field.taxonomy_term.breadcrumb_structure.field_show_children_subtitles
     - taxonomy.vocabulary.breadcrumb_structure
   module:
     - text
@@ -19,6 +21,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_children_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
     region: content
   field_content:
     type: entity_reference_label
@@ -37,6 +47,16 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_show_children_subtitles:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 4
     region: content
 hidden:
   langcode: true

--- a/config/sync/field.field.taxonomy_term.breadcrumb_structure.field_children_title.yml
+++ b/config/sync/field.field.taxonomy_term.breadcrumb_structure.field_children_title.yml
@@ -1,0 +1,19 @@
+uuid: 55aa9fbe-f468-46f9-97d4-906ff437965a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_children_title
+    - taxonomy.vocabulary.breadcrumb_structure
+id: taxonomy_term.breadcrumb_structure.field_children_title
+field_name: field_children_title
+entity_type: taxonomy_term
+bundle: breadcrumb_structure
+label: 'Children title'
+description: 'The title that is shown above the list of referenced content. Will not be shown, if there are no children displayed.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.taxonomy_term.breadcrumb_structure.field_show_children_subtitles.yml
+++ b/config/sync/field.field.taxonomy_term.breadcrumb_structure.field_show_children_subtitles.yml
@@ -1,0 +1,21 @@
+uuid: 79edbae3-50bc-42be-bace-f9cb93bf488a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_show_children_subtitles
+    - taxonomy.vocabulary.breadcrumb_structure
+id: taxonomy_term.breadcrumb_structure.field_show_children_subtitles
+field_name: field_show_children_subtitles
+entity_type: taxonomy_term
+bundle: breadcrumb_structure
+label: 'Show children subtitles'
+description: 'If this is checked, the children teasers will be expanded with possible subtitle descriptions.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.taxonomy_term.field_children_title.yml
+++ b/config/sync/field.storage.taxonomy_term.field_children_title.yml
@@ -1,0 +1,21 @@
+uuid: b8ac41d6-f229-41c1-9fbb-7c9468e20f70
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_children_title
+field_name: field_children_title
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_show_children_subtitles.yml
+++ b/config/sync/field.storage.taxonomy_term.field_show_children_subtitles.yml
@@ -1,0 +1,18 @@
+uuid: 778a0314-2cca-4ac1-b0e7-e1ac4c6be2de
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_show_children_subtitles
+field_name: field_show_children_subtitles
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
+++ b/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
@@ -22,8 +22,8 @@ function dpl_breadcrumb_form_taxonomy_term_breadcrumb_structure_form_alter(array
 
   $form['breadcrumb_children'] = [
     '#type' => 'details',
-    '#title' => t('View content that has set this breadcrumb as a parent', [], ['context' => 'DPL admin UX']),
-    '#weight' => 10,
+    '#title' => t('Content that has set this breadcrumb as a parent', [], ['context' => 'DPL admin UX']),
+    '#weight' => 5,
     'items' => $service->getRenderedReferencingNodes($breadcrumb_item, 'teaser'),
   ];
 }

--- a/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
+++ b/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
@@ -88,8 +88,26 @@ function dpl_breadcrumb_preprocess_page(array &$variables): void {
   // This is seperate from the breadcrumb that is dispalyed on the page.
   $breadcrumb_item = $service->getBreadcrumbItem($entity);
 
-  if ($breadcrumb_item instanceof TermInterface && $breadcrumb_item->get('field_show_children')->getString() == '1') {
-    $variables['related_children'] = $service->getRenderedReferencingNodes($breadcrumb_item);
+  if ($breadcrumb_item instanceof TermInterface &&
+      $breadcrumb_item->get('field_show_children')->getString() == '1') {
+    // Turning a checkbox field into a TRUE/FALSE.
+    $show_subtitles = $breadcrumb_item->hasField('field_show_children_subtitles') &&
+      $breadcrumb_item->get('field_show_children_subtitles')->getString() == '1';
+
+    $custom_title = $breadcrumb_item->hasField('field_children_title') ?
+      $breadcrumb_item->get('field_children_title')->getString() : NULL;
+
+    $default_title = t(
+      'Related content for "@title"',
+      ['@title' => $breadcrumb_item->getName()],
+      ['context' => 'DPL breadcrumb']
+    );
+
+    $variables['related_children'] = [
+      'items' => $service->getRenderedReferencingNodes($breadcrumb_item),
+      'title' => !empty($custom_title) ? $custom_title : $default_title,
+      'show_subtitles' => $show_subtitles,
+    ];
 
     // Drupal will cache the whole page, as it does not know that it is
     // embedding a dynamic list. We'll add a simple cache tag,

--- a/web/themes/custom/novel/templates/components/breadcrumb-children.html.twig
+++ b/web/themes/custom/novel/templates/components/breadcrumb-children.html.twig
@@ -1,8 +1,8 @@
 {% include '@novel/components/nav-grid.html.twig'
   with {
+  attributes: create_attribute(),
   title: title,
   items: items,
   show_all: true,
-  show_subtitles: false,
-  attributes: create_attribute(),
+  show_subtitles: show_subtitles,
 } only %}

--- a/web/themes/custom/novel/templates/layout/page.html.twig
+++ b/web/themes/custom/novel/templates/layout/page.html.twig
@@ -61,13 +61,14 @@
   <main id="main-content" role="main">
     {{ page.content }}
 
-    {% if related_children %}
+    {% if related_children.items %}
       {# @todo - this needs to be replaced by proper styling. #}
       <div class="mt-64">
         {% include '@novel/components/breadcrumb-children.html.twig'
           with {
-          title: 'Related content'|trans,
-          items: related_children,
+          title: related_children.title,
+          show_subtitles: related_children.show_subtitles,
+          items: related_children.items,
         } only %}
       </div>
     {% endif %}


### PR DESCRIPTION
Rather than a hardcoded version, the editor can now choose
options for the list of related children, shown on breacrumb items.
The editor can choose if subtitles should be shown, and also choose
a manual title.
This also includes a new and better fallback title.

https://reload.atlassian.net/browse/DDFFORM-562

https://reload.atlassian.net/browse/DDFFORM-565

It now looks like this:

<img width="644" alt="Screenshot 2024-04-12 at 10 54 41" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/4ea3fa5a-ad6b-44ff-9047-9db980c66609">
