### PR TITLE
Add `address` prop to `list-item.html.twig`

### DIFF
--- a/web/themes/custom/novel/templates/components/list-item.html.twig
+++ b/web/themes/custom/novel/templates/components/list-item.html.twig
@@ -19,9 +19,14 @@
 
     <h2 class="content-list-item__title">{{ title }}</h2>
 
-    {% if description %}
+    {% if description or address %}
       <div class="content-list-item__description">
-        <p> {{ description }} </p>
+      {% if description %}
+        <p>{{ description }}</p>
+      {% endif %}
+      {% if address %}
+        {{ address }}
+      {% endif %}
       </div>
     {% endif %}
     {% if bottom.0 %}

--- a/web/themes/custom/novel/templates/components/list-item.html.twig
+++ b/web/themes/custom/novel/templates/components/list-item.html.twig
@@ -19,14 +19,9 @@
 
     <h2 class="content-list-item__title">{{ title }}</h2>
 
-    {% if description or address %}
+    {% if description %}
       <div class="content-list-item__description">
-      {% if description %}
-        <p>{{ description }}</p>
-      {% endif %}
-      {% if address %}
-        {{ address }}
-      {% endif %}
+        {{ description }}
       </div>
     {% endif %}
     {% if bottom.0 %}

--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-description--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-description--list-teaser.html.twig
@@ -1,0 +1,5 @@
+<p>
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+</p>

--- a/web/themes/custom/novel/templates/fields/field--node--field-address--branch--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-address--branch--list-teaser.html.twig
@@ -1,13 +1,13 @@
 <address>
-	{# This should never contain more than 2 lines inside due to the truncation in the "content-list-item__description" class that this item is inside #}
-	{% if items.0.content.address_line1["#value"] %}
-		<p>{{ items.0.content.address_line1["#value"] }}</p>
-	{% endif %}
-	{% if items.0.content.postal_code["#value"] or items.0.content.locality["#value"] or items.0.content.country["#value"] %}
-		<p>
-			{{ items.0.content.postal_code["#value"] is not empty ? items.0.content.postal_code["#value"] ~ " " : "" }}
-			{{ items.0.content.locality["#value"] is not empty ? items.0.content.locality["#value"] ~ ", " : "" }}
-			{{ items.0.content.country["#value"] is not empty ? items.0.content.country["#value"] : "" }}
-		</p>
-	{% endif %}
+  {# This should never contain more than 2 lines inside due to the layout #}
+  {% if items.0.content.address_line1["#value"] %}
+    <p>{{ items.0.content.address_line1["#value"] }}</p>
+  {% endif %}
+  {% if items.0.content.postal_code["#value"] or items.0.content.locality["#value"] or items.0.content.country["#value"] %}
+    <p>
+      {{ items.0.content.postal_code["#value"] is not empty ? items.0.content.postal_code["#value"] ~ " " : "" }}
+      {{ items.0.content.locality["#value"] is not empty ? items.0.content.locality["#value"] ~ ", " : "" }}
+      {{ items.0.content.country["#value"] is not empty ? items.0.content.country["#value"] : "" }}
+    </p>
+  {% endif %}
 </address>

--- a/web/themes/custom/novel/templates/fields/field--node--field-address--branch--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-address--branch--list-teaser.html.twig
@@ -1,0 +1,13 @@
+<address>
+	{# This should never contain more than 2 lines inside due to the truncation in the "content-list-item__description" class that this item is inside #}
+	{% if items.0.content.address_line1["#value"] %}
+		<p>{{ items.0.content.address_line1["#value"] }}</p>
+	{% endif %}
+	{% if items.0.content.postal_code["#value"] or items.0.content.locality["#value"] or items.0.content.country["#value"] %}
+		<p>
+			{{ items.0.content.postal_code["#value"] is not empty ? items.0.content.postal_code["#value"] ~ " " : "" }}
+			{{ items.0.content.locality["#value"] is not empty ? items.0.content.locality["#value"] ~ ", " : "" }}
+			{{ items.0.content.country["#value"] is not empty ? items.0.content.country["#value"] : "" }}
+		</p>
+	{% endif %}
+</address>

--- a/web/themes/custom/novel/templates/fields/field--node--field-subtitle--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-subtitle--list-teaser.html.twig
@@ -1,0 +1,5 @@
+<p>
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+</p>

--- a/web/themes/custom/novel/templates/layout/eventinstance--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--list-teaser.html.twig
@@ -7,7 +7,7 @@
   categories: content.event_categories,
   date: content.date,
   title: content.title,
-  description: content.event_description.0,
+  description: content.event_description,
   bottom: content.branch,
   start_date: start_date,
   end_date: end_date,

--- a/web/themes/custom/novel/templates/layout/node--article--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--article--list-teaser.html.twig
@@ -7,6 +7,6 @@
   image: content.field_teaser_image.0,
   categories: content.field_categories,
   date: node.changed.value|date('U')|format_date('date_short_month'),
-  description: content.field_subtitle.0,
+  description: content.field_subtitle,
   bottom: content.field_branch,
 } only %}

--- a/web/themes/custom/novel/templates/layout/node--branch--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--branch--list-teaser.html.twig
@@ -5,5 +5,5 @@
   image: content.field_main_media.0,
   baseIconPath: baseIconPath,
   title: label,
-  address: content.field_address
+  description: content.field_address
 } only %}

--- a/web/themes/custom/novel/templates/layout/node--branch--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--branch--list-teaser.html.twig
@@ -5,5 +5,5 @@
   image: content.field_main_media.0,
   baseIconPath: baseIconPath,
   title: label,
-  description: content.field_address
+  address: content.field_address
 } only %}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-486


#### Description
This pull request introduces a new address prop to `list-item.html.twig`, enabling the display of addresses within the `.content-list-item__description` By incorporating this new prop, we eliminate the <p> tag with truncate CSS.

It's crucial to ensure that the address content never exceeds two lines to maintain design consistency.

#### Screenshot of the result
<img width="1321" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/0835816d-03c9-4446-9c50-0ec96d663736">


#### Depend on:
https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/594