### PR TITLE
Remove mnsami/composer-custom-directory-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,6 @@
         "drupal/view_unpublished": "^1.1",
         "drupal/views_infinite_scroll": "^2.0",
         "drush/drush": "^12",
-        "mnsami/composer-custom-directory-installer": "^2.0",
         "myclabs/php-enum": "^1.8",
         "phpdocumentor/reflection-docblock": "^5.3",
         "spatie/color": "^1.5",
@@ -186,8 +185,7 @@
             "drupal/core-project-message": true,
             "phpstan/extension-installer": true,
             "zaporylie/composer-drupal-optimizations": true,
-            "drupal/console-extend-plugin": true,
-            "mnsami/composer-custom-directory-installer": true
+            "drupal/console-extend-plugin": true
         }
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0577451567c03064dcf25675dde4f465",
+    "content-hash": "f9224d111fc10ac1b46386f95e4e920a",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -8390,62 +8390,6 @@
                 }
             ],
             "time": "2023-11-14T22:47:32+00:00"
-        },
-        {
-            "name": "mnsami/composer-custom-directory-installer",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mnsami/composer-custom-directory-installer.git",
-                "reference": "85f66323978d0b1cb0e6acc7f69b3e7b912f82d9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mnsami/composer-custom-directory-installer/zipball/85f66323978d0b1cb0e6acc7f69b3e7b912f82d9",
-                "reference": "85f66323978d0b1cb0e6acc7f69b3e7b912f82d9",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": [
-                    "Composer\\CustomDirectoryInstaller\\LibraryPlugin",
-                    "Composer\\CustomDirectoryInstaller\\PearPlugin",
-                    "Composer\\CustomDirectoryInstaller\\PluginPlugin"
-                ],
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Composer\\CustomDirectoryInstaller": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mina Nabil Sami",
-                    "email": "mina.nsami@gmail.com"
-                }
-            ],
-            "description": "A composer plugin, to help install packages of different types in custom paths.",
-            "keywords": [
-                "composer",
-                "composer-installer",
-                "composer-plugin"
-            ],
-            "support": {
-                "issues": "https://github.com/mnsami/composer-custom-directory-installer/issues",
-                "source": "https://github.com/mnsami/composer-custom-directory-installer/tree/2.0.0"
-            },
-            "time": "2020-08-18T11:00:11+00:00"
         },
         {
             "name": "myclabs/php-enum",


### PR DESCRIPTION
#### Description

This was originally added when[ adding the Swagger UI module](https://www.drupal.org/project/openapi_ui_swagger).

This composer installer plugin is no longer needed when placing named packages in custom directories. Consequently we no longer need this to place the Swagger UI library in web/libraries.

Consequently we can remove this and reduce complexity in our dependency chain.

#### Additional comments or questions

This can be tested by checking that Swagger UI is shown.