### PR TITLE
Fix ssh access: Introduce `ssh` and `api` config keys in .lagoon.yml

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -2,6 +2,9 @@ docker-compose-yaml: docker-compose.yml
 
 project: dpl-cms-core
 
+ssh: 20.238.147.183:22
+api: https://api.lagoon.dplplat01.dpl.reload.dk/graphql
+
 tasks:
   post-rollout:
     - run:


### PR DESCRIPTION
#### Link to issue

[DDFDRIFT-37](https://reload.atlassian.net/browse/DDFDRIFT-37?atlOrigin=eyJpIjoiNDNiOGRjYTU1NmVlNGUyMDkyOGY3MDljNjdiMmQ1NDciLCJwIjoiaiJ9)

#### Description

These config keys are read by drush in running environments, no matter what is in their own .lagoon.yml. This avoid having to set env keys for every single environment.

We didn't really like adding these files here, but we have done the same in `assets/lagoon.site.yml` where the same keys are set. It is unfortunate that this ties the code to our particular infrastructure, but untangling the two will have to be a future project.

[DDFDRIFT-37]: https://reload.atlassian.net/browse/DDFDRIFT-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ