### PR TITLE
Set danish names for view pages, such as /articles. DDFFORM-502

### DIFF
--- a/config/sync/views.view.articles.yml
+++ b/config/sync/views.view.articles.yml
@@ -273,7 +273,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: articles
+      path: artikler
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.branches.yml
+++ b/config/sync/views.view.branches.yml
@@ -179,7 +179,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: branches
+      path: filialer
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -300,7 +300,7 @@ display:
         filters: true
         filter_groups: true
       display_extenders: {  }
-      path: events
+      path: arrangementer
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/modules/custom/dpl_example_content/content/menu_link_content/ff6db3ce-49e0-4107-b283-3403e22c5e6d.yml
+++ b/web/modules/custom/dpl_example_content/content/menu_link_content/ff6db3ce-49e0-4107-b283-3403e22c5e6d.yml
@@ -16,7 +16,7 @@ default:
       value: main
   link:
     -
-      uri: 'internal:/events'
+      uri: 'internal:/arrangementer'
       title: ''
       options: {  }
   external:


### PR DESCRIPTION
Ideally, we'd want to actually translate the path, but this is not an option in Drupal. We could create a URL alias, but then /articles would still be active.
I found a module named https://www.drupal.org/project/tvp that seemed to solve the problem, but in reality, it still relies on us creating a path alias, which has the same problem.

https://reload.atlassian.net/browse/DDFFORM-502