### PR TITLE
Add path aliases for views pages

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -58,6 +58,7 @@ module:
   dpl_something_similar: 0
   dpl_static_content: 0
   dpl_static_content_20240404_opening_hours: 0
+  dpl_static_content_20240418_views_aliases: 0
   dpl_url_proxy: 0
   drupal_typed: 0
   dynamic_entity_reference: 0

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240418_views_aliases/content/path_alias/333d93e2-a403-4a0b-a57e-2e74e729887f.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240418_views_aliases/content/path_alias/333d93e2-a403-4a0b-a57e-2e74e729887f.yml
@@ -1,0 +1,12 @@
+_meta:
+  version: "1.0"
+  entity_type: path_alias
+  uuid: 333d93e2-a403-4a0b-a57e-2e74e729887f
+  default_langcode: und
+default:
+  path:
+    - value: /articles
+  alias:
+    - value: /artikler
+  status:
+    - value: true

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240418_views_aliases/content/path_alias/67b61873-9ccf-4b2c-b2ee-cee553381bd2.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240418_views_aliases/content/path_alias/67b61873-9ccf-4b2c-b2ee-cee553381bd2.yml
@@ -1,0 +1,12 @@
+_meta:
+  version: "1.0"
+  entity_type: path_alias
+  uuid: 67b61873-9ccf-4b2c-b2ee-cee553381bd2
+  default_langcode: und
+default:
+  path:
+    - value: /branches
+  alias:
+    - value: /biblioteker
+  status:
+    - value: true

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240418_views_aliases/content/path_alias/fef6c6a4-f409-4ae8-84d5-c3497e2edf28.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240418_views_aliases/content/path_alias/fef6c6a4-f409-4ae8-84d5-c3497e2edf28.yml
@@ -1,0 +1,12 @@
+_meta:
+  version: "1.0"
+  entity_type: path_alias
+  uuid: fef6c6a4-f409-4ae8-84d5-c3497e2edf28
+  default_langcode: und
+default:
+  path:
+    - value: /events
+  alias:
+    - value: /arrangementer
+  status:
+    - value: true

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240418_views_aliases/dpl_static_content_20240418_views_aliases.info.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240418_views_aliases/dpl_static_content_20240418_views_aliases.info.yml
@@ -1,0 +1,15 @@
+name: "DPL static content: Views aliases"
+type: module
+description: Adds path aliases to core views pages
+package: DPL
+core_version_requirement: ^9 || ^10
+dependencies:
+  - default_content:default_content
+
+hidden: true
+
+default_content:
+  path_alias:
+    - fef6c6a4-f409-4ae8-84d5-c3497e2edf28
+    - 67b61873-9ccf-4b2c-b2ee-cee553381bd2
+    - 333d93e2-a403-4a0b-a57e-2e74e729887f


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-502

#### Description

We have a few views which are displayed as pages: Articles, events and branches. These currently have system paths e.g. /events.

Add a path alias for each of these pages to use a user friendly url for each of these as static content.

Path aliases are entities so we can continue our use of the default content module to handle this.

The Redirect module will ensure that attempts to access the system urls will redirect to the aliases.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/eefddf77-1b6f-43e1-8f31-e6fcd7fe81f6

#### Additional comments or questions

This is an alternate take on #1009 