### PR TITLE
DDFLSBP-566/add-twig-templates-for-webform-paragraph-elements

### DIFF
--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -326,3 +326,18 @@ function novel_preprocess_views_view_unformatted(&$variables): void {
     }
   }
 }
+
+/**
+ *
+ */
+function novel_preprocess_input__submit(&$variables) {
+  $org_class = $variables['attributes']['class'];
+  $variables['attributes']['class'] += array_merge($org_class, [
+    'btn-primary',
+    'btn-filled',
+    'btn-small',
+    'arrow__hover--right-small',
+    'mt-48',
+    'mb-22',
+  ]);
+}

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -328,16 +328,27 @@ function novel_preprocess_views_view_unformatted(&$variables): void {
 }
 
 /**
- *
+ * Implements hook_preprocess_HOOK().
  */
-function novel_preprocess_input__submit(&$variables) {
-  $org_class = $variables['attributes']['class'];
-  $variables['attributes']['class'] += array_merge($org_class, [
-    'btn-primary',
-    'btn-filled',
-    'btn-small',
-    'arrow__hover--right-small',
-    'mt-48',
-    'mb-22',
-  ]);
+function novel_preprocess_input__submit(array &$variables): void {
+  $original_classes = $variables['attributes']['class'];
+
+  if (in_array('webform-button--submit', $original_classes)) {
+    $variables['attributes']['class'] += array_merge($original_classes, [
+      'btn-primary',
+      'btn-filled',
+      'btn-small',
+      'arrow__hover--right-small',
+      'dpl-button',
+    ]);
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK().
+ */
+function novel_theme_suggestions_form_element_alter(array &$suggestions, array $variables): void {
+  if (isset($variables['element']['#webform_element'])) {
+    $suggestions[] = 'form_element__webform';
+  }
 }

--- a/web/themes/custom/novel/templates/form/form-element--webform.html.twig
+++ b/web/themes/custom/novel/templates/form/form-element--webform.html.twig
@@ -1,7 +1,8 @@
 {#
 /**
  * @file
- * Theme override for a form element.
+ * Theme override for a webform form element.
+ * The template copies the form-element.html.twig template from the core system.
  *
  * Available variables:
  * - attributes: HTML attributes for the containing element.

--- a/web/themes/custom/novel/templates/form/form-element.html.twig
+++ b/web/themes/custom/novel/templates/form/form-element.html.twig
@@ -1,0 +1,95 @@
+{#
+/**
+ * @file
+ * Theme override for a form element.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - errors: (optional) Any errors for this form element, may not be set.
+ * - prefix: (optional) The form element prefix, may not be set.
+ * - suffix: (optional) The form element suffix, may not be set.
+ * - required: The required marker, or empty if the associated form element is
+ *   not required.
+ * - type: The type of the element.
+ * - name: The name of the element.
+ * - label: A rendered label element.
+ * - label_display: Label display setting. It can have these values:
+ *   - before: The label is output before the element. This is the default.
+ *     The label includes the #title and the required marker, if #required.
+ *   - after: The label is output after the element. For example, this is used
+ *     for radio and checkbox #type elements. If the #title is empty but the
+ *     field is #required, the label will contain only the required marker.
+ *   - invisible: Labels are critical for screen readers to enable them to
+ *     properly navigate through forms but can be visually distracting. This
+ *     property hides the label for everyone except screen readers.
+ *   - attribute: Set the title attribute on the element to create a tooltip but
+ *     output no label element. This is supported only for checkboxes and radios
+ *     in \Drupal\Core\Render\Element\CompositeFormElementTrait::preRenderCompositeFormElement().
+ *     It is used where a visual label is not needed, such as a table of
+ *     checkboxes where the row and column provide the context. The tooltip will
+ *     include the title and required marker.
+ * - description: (optional) A list of description properties containing:
+ *    - content: A description of the form element, may not be set.
+ *    - attributes: (optional) A list of HTML attributes to apply to the
+ *      description content wrapper. Will only be set when description is set.
+ * - description_display: Description display setting. It can have these values:
+ *   - before: The description is output before the element.
+ *   - after: The description is output after the element. This is the default
+ *     value.
+ *   - invisible: The description is output after the element, hidden visually
+ *     but available to screen readers.
+ * - disabled: True if the element is disabled.
+ * - title_display: Title display setting.
+ *
+ * @see template_preprocess_form_element()
+ */
+#}
+{%
+  set classes = [
+    'dpl-input',
+    'js-form-item',
+    'form-item',
+    'js-form-type-' ~ type|clean_class,
+    'form-item-' ~ name|clean_class,
+    'js-form-item-' ~ name|clean_class,
+    title_display not in ['after', 'before'] ? 'form-no-label',
+    disabled == 'disabled' ? 'form-disabled',
+    errors ? 'form-item--error',
+  ]
+%}
+{%
+  set description_classes = [
+    'description',
+    description_display == 'invisible' ? 'visually-hidden',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {% if label_display in ['before', 'invisible'] %}
+    {{ label }}
+  {% endif %}
+  {% if prefix is not empty %}
+    <span class="field-prefix">{{ prefix }}</span>
+  {% endif %}
+  {% if description_display == 'before' and description.content %}
+    <div{{ description.attributes }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+  {{ children }}
+  {% if suffix is not empty %}
+    <span class="field-suffix">{{ suffix }}</span>
+  {% endif %}
+  {% if label_display == 'after' %}
+    {{ label }}
+  {% endif %}
+  {% if errors %}
+    <div class="form-item--error-message">
+      {{ errors }}
+    </div>
+  {% endif %}
+  {% if description_display in ['after', 'invisible'] and description.content %}
+    <div{{ description.attributes.addClass(description_classes) }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+</div>

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--webform.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--webform.html.twig
@@ -1,0 +1,5 @@
+<div{{ attributes.addClass('dpl-form') }}>
+  <div{{ attributes.addCLass('dpl-form__body')}}>
+    {{ content }}
+  </div>
+</div>

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--webform.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--webform.html.twig
@@ -1,5 +1,3 @@
 <div{{ attributes.addClass('dpl-form') }}>
-  <div{{ attributes.addCLass('dpl-form__body')}}>
     {{ content }}
-  </div>
 </div>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-566

#### Description

In this PR we add new template for the webform paragraph. We also add a new custom template called form-element--webform.html.twig which are only targeting webform elements. 

The PR also adds 2 new hooks to the novel.theme. A preprocess hook for adding specific classes to input__submit elements on webforms only. We also add a theme suggestion hook for adding our new form-element--webform.html.twig template available. 

#### Screenshot of the result
![Screenshot 2024-04-21 at 02 05 16](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/6142323/32d67921-9d25-4014-b5a4-a33f1a0420d5)

#### Additional comments or questions

There are a few things I would like to pinpoint with this PR:
1. We currently have another [PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1005) open, which adds a new custom module called webform_configuration. I think it would make sense to move the 2 webform hooks added in this PR to the webform_configuration.module file. But this can be refactored at a later point if needed.

2. Right now we have some inconsistencies between the design-system contact-form story and the actual contact form. I think the design-system story needs some refactoring to make it up to date with how the rest of the paragraph stories is implemented. This can be discussed with the team at a later point.
