### PR TITLE
Check CMS API package drift

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -256,6 +256,10 @@ jobs:
         run: task ci:openapi:download
       - name: Ensure specification has not drifted
         run: git diff --ignore-space-at-eol --exit-code openapi.json
+      - name: Generate package for CMS API specification
+        run: task dev:codegen:dpl-cms
+      - name: Ensure CMS API package code has not drifted
+        run: git diff --ignore-space-at-eol --exit-code packages/cms-api/*
 
   CheckDrupalConfig:
     name: Check Drupal Config

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -299,7 +299,7 @@ tasks:
     desc: Generate CMS API package from OpenAPI specification
     cmds:
       - cmd: |
-          cd Mpackages/cms-api && find . ! -name '.' ! -name '..' ! -name '.openapi-generator-ignore' -type df -exec rm -rf {} +
+          cd packages/cms-api && find . ! -name '.' ! -name '..' ! -name '.openapi-generator-ignore' -type df -exec rm -rf {} +
       - cmd: |
           docker run --rm \
           -v ${PWD}:/local \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -299,7 +299,7 @@ tasks:
     desc: Generate CMS API package from OpenAPI specification
     cmds:
       - cmd: |
-          cd packages/cms-api && find . ! -name '.' ! -name '..' ! -name '.openapi-generator-ignore' -type df -exec rm -rf {} +
+          cd packages/cms-api && find . ! -name '.' ! -name '..' ! -name '.openapi-generator-ignore' -type d -type f -exec rm -rf {} +
       - cmd: |
           docker run --rm \
           -v ${PWD}:/local \

--- a/packages/cms-api/README.md
+++ b/packages/cms-api/README.md
@@ -106,8 +106,8 @@ Class | Method | HTTP request | Description
 *DefaultApiInterface* | [**dplOpeningHoursDeleteDELETE**](docs/Api/DefaultApiInterface.md#dplopeninghoursdeletedelete) | **DELETE** /dpl_opening_hours/{id} | Delete individual opening hours
 *DefaultApiInterface* | [**dplOpeningHoursListGET**](docs/Api/DefaultApiInterface.md#dplopeninghourslistget) | **GET** /dpl_opening_hours | List all opening hours
 *DefaultApiInterface* | [**dplOpeningHoursUpdatePATCH**](docs/Api/DefaultApiInterface.md#dplopeninghoursupdatepatch) | **PATCH** /dpl_opening_hours/{id} | Update individual opening hours
-*DefaultApiInterface* | [**eventPATCH**](docs/Api/DefaultApiInterface.md#eventpatch) | **PATCH** /dpl_event/{uuid} | Update single events
-*DefaultApiInterface* | [**eventsGET**](docs/Api/DefaultApiInterface.md#eventsget) | **GET** /dpl_event | Retrieve all events
+*DefaultApiInterface* | [**eventPATCH**](docs/Api/DefaultApiInterface.md#eventpatch) | **PATCH** /api/v1/events/{uuid} | Update single events
+*DefaultApiInterface* | [**eventsGET**](docs/Api/DefaultApiInterface.md#eventsget) | **GET** /api/v1/events | Retrieve all events
 *DefaultApiInterface* | [**proxyUrlGET**](docs/Api/DefaultApiInterface.md#proxyurlget) | **GET** /dpl-url-proxy | Generate proxy url
 
 
@@ -129,7 +129,6 @@ Class | Method | HTTP request | Description
  - [EventsGET200ResponseInnerImage](docs/Model/EventsGET200ResponseInnerImage.md)
  - [EventsGET200ResponseInnerSeries](docs/Model/EventsGET200ResponseInnerSeries.md)
  - [EventsGET200ResponseInnerTicketCategoriesInner](docs/Model/EventsGET200ResponseInnerTicketCategoriesInner.md)
- - [EventsGET200ResponseInnerTicketCategoriesInnerCount](docs/Model/EventsGET200ResponseInnerTicketCategoriesInnerCount.md)
  - [EventsGET200ResponseInnerTicketCategoriesInnerPrice](docs/Model/EventsGET200ResponseInnerTicketCategoriesInnerPrice.md)
  - [ProxyUrlGET200Response](docs/Model/ProxyUrlGET200Response.md)
  - [ProxyUrlGET200ResponseData](docs/Model/ProxyUrlGET200ResponseData.md)


### PR DESCRIPTION
#### Description

When we update the specification for the CMS API then our
corresponding PHP package should be updated as well.

We use an specification first approach to the API. The generated
package should help ensure that our request/response handling complies
with the specification.

If the package is not updated with the specification we may face
errors where the specification is updated but the actual code is not.

The test failure for [ec78975](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1026/commits/ec78975e84907f761933fa677d7c839308437b48) and the fix in [41d6302](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1026/commits/41d6302aa04b0a760cf3e1568f3caa7ea86ccc92) shows that it works.