### PR TITLE
Add text under login and favorites

### DIFF
--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -323,6 +323,8 @@ function dpl_react_apps_texts(): array {
     'reservation-success-sub-title' => t('Click the button below to close this window', [], ['context' => 'Global']),
     'reservation-success-title' => t('Your reservation has been changed', [], ['context' => 'Global']),
     'search-header-dropdown' => t('Dropdown with additional search functions', [], ['context' => 'Global']),
+    'search-header-favorites' => t('Liked', [], ['context' => 'Global']),
+    'search-header-login' => t('Login', [], ['context' => 'Global']),
     'save-button' => t('Save', [], ['context' => 'Global']),
     'screen-reader-modal-description-email' => t('Screen reader modal description for email', [], ['context' => 'Global']),
     'screen-reader-modal-description-interest-period' => t('Screen reader modal description for interest period', [], ['context' => 'Global']),

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -28,7 +28,7 @@
             <div class="header__menu-bookmarked header__button">
                 <a href="{{ url('dpl_favorites_list.list') }}">
                     <img width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt="{{ 'List of bookmarks'|t({}, {'context': 'Header'}) }}"/>
-                    <span class="text-small-caption">{{ "Liked"|t({}, {'context' : 'Global'}) }}</span>
+                    <span class="text-small-caption">{{ "Liked"|t({}, {'context': 'Global'}) }}</span>
                 </a>
             </div>
         </nav>

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -28,6 +28,7 @@
             <div class="header__menu-bookmarked header__button">
                 <a href="{{ url('dpl_favorites_list.list') }}">
                     <img width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt="{{ 'List of bookmarks'|t({}, {'context': 'Header'}) }}"/>
+                    <span class="text-small-caption">{{ "Liked"|t({}, {'context' : 'Global'}) }}</span>
                 </a>
             </div>
         </nav>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-551

#### Description
This PR adds "Login" text under the user icon when user isn't logged in, and "Liked" under the heart icon in the nav menu, introducing two new text strings in the process.

#### Screenshot of the result
-

#### Additional comments or questions
[Sibling PR in the design system](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/603)
[Sibling PR in dpl-react](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1141)
