### PR TITLE
DDFLSBP-528/create contact page and contact page content

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -58,6 +58,7 @@ module:
   dpl_something_similar: 0
   dpl_static_content: 0
   dpl_static_content_20240404_opening_hours: 0
+  dpl_static_content_20240422_contact_page: 0
   dpl_url_proxy: 0
   dpl_webform_configuration: 0
   drupal_typed: 0

--- a/config/sync/language.content_settings.taxonomy_term.webform_email_categories.yml
+++ b/config/sync/language.content_settings.taxonomy_term.webform_email_categories.yml
@@ -1,0 +1,11 @@
+uuid: db31e630-0c41-4a67-a420-4b86a82381a8
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.webform_email_categories
+id: taxonomy_term.webform_email_categories
+target_entity_type_id: taxonomy_term
+target_bundle: webform_email_categories
+default_langcode: da
+language_alterable: false

--- a/config/sync/taxonomy.vocabulary.webform_email_categories.yml
+++ b/config/sync/taxonomy.vocabulary.webform_email_categories.yml
@@ -1,5 +1,5 @@
 uuid: bccf012f-fa36-4344-bdfb-34e443371f4e
-langcode: en
+langcode: da
 status: true
 dependencies:
   module:

--- a/config/sync/taxonomy_unique.settings.yml
+++ b/config/sync/taxonomy_unique.settings.yml
@@ -1,2 +1,4 @@
 opening_hours_categories: 1
 opening_hours_categories_message: 'Term %term already exists in vocabulary %vocabulary.'
+webform_email_categories: 1
+webform_email_categories_message: 'Term %term already exists in vocabulary %vocabulary.'

--- a/config/sync/webform.webform.contact.yml
+++ b/config/sync/webform.webform.contact.yml
@@ -14,37 +14,40 @@ uid: null
 template: false
 archive: false
 id: contact
-title: Contact
-description: '<p>Basic email contact webform.</p>'
+title: Kontaktformular
+description: '<p>Standard kontaktformular.</p>'
 categories: {  }
 elements: |-
   name:
     '#type': textfield
-    '#title': 'Your Name'
+    '#title': 'Dit navn'
     '#required': true
   email:
     '#type': email
-    '#title': 'Your Email'
+    '#title': 'Din e-mailadresse'
     '#required': true
   category:
     '#type': webform_term_select
-    '#title': Category
+    '#title': Kategori
     '#required': true
     '#vocabulary': webform_email_categories
   subject:
-    '#title': Subject
     '#type': textfield
+    '#title': Emne
     '#required': true
     '#test': 'Testing contact webform from [site:name]'
   message:
-    '#title': Message
     '#type': textarea
+    '#title': Besked
     '#required': true
     '#test': 'Please ignore this email.'
   actions:
     '#type': webform_actions
     '#title': 'Submit button(s)'
-    '#submit__label': 'Send message'
+    '#submit__label': 'Send besked'
+  notice:
+    '#type': webform_markup
+    '#markup': '<p>BEMÆRK! Indsæt aldrig CPR-nummer eller følsomme oplysninger i formularen.</p><p>Læs mere om <a href="/privatlivspolitik" target="_blank">behandling af persondata i vores privatlivspolitik.</a></p>'
 css: ''
 javascript: ''
 settings:
@@ -149,10 +152,10 @@ settings:
   draft_loaded_message: ''
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
-  confirmation_type: url_message
+  confirmation_type: message
   confirmation_url: '<front>'
   confirmation_title: ''
-  confirmation_message: 'Your message has been sent.'
+  confirmation_message: '<p>Din besked er blevet sendt.</p>'
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/node/d50683cc-8011-49ba-a6ea-82e56de97b80.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/node/d50683cc-8011-49ba-a6ea-82e56de97b80.yml
@@ -1,0 +1,63 @@
+_meta:
+  version: "1.0"
+  entity_type: node
+  uuid: d50683cc-8011-49ba-a6ea-82e56de97b80
+  bundle: page
+  default_langcode: da
+default:
+  revision_uid:
+    - target_id: 1
+  status:
+    - value: true
+  uid:
+    - target_id: 1
+  title:
+    - value: Kontakt
+  created:
+    - value: 1713877854
+  promote:
+    - value: false
+  sticky:
+    - value: false
+  revision_translation_affected:
+    - value: true
+  entity_clone_template_active:
+    - value: false
+  metatag:
+    - tag: meta
+      attributes:
+        name: title
+        content: "Kontakt | DPL CMS"
+  path:
+    - alias: /kontakt
+      langcode: und
+      pathauto: 1
+  field_display_titles:
+    - value: true
+  field_hero_title:
+    - value: Kontakt
+  field_paragraphs:
+    - entity:
+        _meta:
+          version: "1.0"
+          entity_type: paragraph
+          uuid: 325c097a-7abc-47f9-ba77-f3e5a30a0fb2
+          bundle: webform
+          default_langcode: da
+        default:
+          status:
+            - value: true
+          created:
+            - value: 1713910314
+          behavior_settings:
+            - value: {}
+          revision_translation_affected:
+            - value: true
+          field_webform:
+            - target_id: contact
+              default_data: ""
+              status: open
+              open: ""
+              close: ""
+  field_subtitle:
+    - value: "Kontakt dit lokale bibliotek ved at udfylde formularen nedenfor."

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/taxonomy_term/6d9e3138-f948-4d8b-aba1-3ca46a05175e.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/taxonomy_term/6d9e3138-f948-4d8b-aba1-3ca46a05175e.yml
@@ -1,0 +1,31 @@
+_meta:
+  version: "1.0"
+  entity_type: taxonomy_term
+  uuid: 6d9e3138-f948-4d8b-aba1-3ca46a05175e
+  bundle: webform_email_categories
+  default_langcode: da
+default:
+  status:
+    - value: true
+  name:
+    - value: "Spørgsmål til biblioteket"
+  weight:
+    - value: 0
+  parent:
+    - target_id: 0
+  revision_translation_affected:
+    - value: true
+  metatag:
+    - tag: meta
+      attributes:
+        name: title
+        content: "Spørgsmål til biblioteket | DPL CMS"
+    - tag: link
+      attributes:
+        rel: canonical
+        href: "http://dapple-cms.docker/taxonomy/term/22"
+  path:
+    - alias: ""
+      langcode: da
+  field_email:
+    - value: questions@test.dk

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/taxonomy_term/b42cf13a-4047-4a36-b451-f632472c8035.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/taxonomy_term/b42cf13a-4047-4a36-b451-f632472c8035.yml
@@ -1,0 +1,31 @@
+_meta:
+  version: "1.0"
+  entity_type: taxonomy_term
+  uuid: b42cf13a-4047-4a36-b451-f632472c8035
+  bundle: webform_email_categories
+  default_langcode: da
+default:
+  status:
+    - value: true
+  name:
+    - value: "Gebyrer og erstatninger"
+  weight:
+    - value: 0
+  parent:
+    - target_id: 0
+  revision_translation_affected:
+    - value: true
+  metatag:
+    - tag: meta
+      attributes:
+        name: title
+        content: "Gebyrer og erstatninger | DPL CMS"
+    - tag: link
+      attributes:
+        rel: canonical
+        href: "http://dapple-cms.docker/taxonomy/term/25"
+  path:
+    - alias: ""
+      langcode: da
+  field_email:
+    - value: fees@test.dk

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/taxonomy_term/b97946d7-f415-45e7-bd48-131d3675fbd0.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/taxonomy_term/b97946d7-f415-45e7-bd48-131d3675fbd0.yml
@@ -1,0 +1,31 @@
+_meta:
+  version: "1.0"
+  entity_type: taxonomy_term
+  uuid: b97946d7-f415-45e7-bd48-131d3675fbd0
+  bundle: webform_email_categories
+  default_langcode: da
+default:
+  status:
+    - value: true
+  name:
+    - value: "Hjemmeside og app"
+  weight:
+    - value: 0
+  parent:
+    - target_id: 0
+  revision_translation_affected:
+    - value: true
+  metatag:
+    - tag: meta
+      attributes:
+        name: title
+        content: "Hjemmeside og app | DPL CMS"
+    - tag: link
+      attributes:
+        rel: canonical
+        href: "http://dapple-cms.docker/taxonomy/term/24"
+  path:
+    - alias: ""
+      langcode: da
+  field_email:
+    - value: web@test.dk

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/taxonomy_term/bb4917fe-2197-4d53-b3e8-4a04ce074c29.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/content/taxonomy_term/bb4917fe-2197-4d53-b3e8-4a04ce074c29.yml
@@ -1,0 +1,31 @@
+_meta:
+  version: 1".0"
+  entity_type: taxonomy_term
+  uuid: bb4917fe-2197-4d53-b3e8-4a04ce074c29
+  bundle: webform_email_categories
+  default_langcode: da
+default:
+  status:
+    - value: true
+  name:
+    - value: "Forslag til indkøb"
+  weight:
+    - value: 0
+  parent:
+    - target_id: 0
+  revision_translation_affected:
+    - value: true
+  metatag:
+    - tag: meta
+      attributes:
+        name: title
+        content: "Forslag til indkøb | DPL CMS"
+    - tag: link
+      attributes:
+        rel: canonical
+        href: "http://dapple-cms.docker/taxonomy/term/23"
+  path:
+    - alias: ""
+      langcode: da
+  field_email:
+    - value: suggestions@test.dk

--- a/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/dpl_static_content_20240422_contact_page.info.yml
+++ b/web/modules/custom/dpl_static_content/modules/dpl_static_content_20240422_contact_page/dpl_static_content_20240422_contact_page.info.yml
@@ -1,0 +1,21 @@
+name: "DPL static content: Contact page"
+type: module
+description: Adds default contact page and contact webform categories
+package: DPL
+core_version_requirement: ^9 || ^10
+dependencies:
+  - default_content:default_content
+
+hidden: true
+
+default_content:
+  node:
+    # Pages
+    - d50683cc-8011-49ba-a6ea-82e56de97b80 # Contact Page
+
+  taxonomy_term:
+    # Contact webform categories
+    - bb4917fe-2197-4d53-b3e8-4a04ce074c29 # Forslag til indkøb
+    - b42cf13a-4047-4a36-b451-f632472c8035 # Gebyrer og erstatninger
+    - b97946d7-f415-45e7-bd48-131d3675fbd0 # Hjemmeside og app
+    - 6d9e3138-f948-4d8b-aba1-3ca46a05175e # Spørgsmål til biblioteket

--- a/web/themes/custom/novel/templates/status-message.html.twig
+++ b/web/themes/custom/novel/templates/status-message.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Custom status message template
+ *
+ * Used to display status messages.
+ *
+ * Available variables:
+ * - message: The status message to show.
+ */
+#}
+
+ <div class="status-message">
+  <div class="status-message__icon">
+    <img
+      src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-check.svg"
+      alt="{{ 'Status message icon'|t({}, {'context': 'Status message handling'}) }}"
+    />
+  </div>
+  <div class="status-message__description">
+    {{ message }}
+  </div>
+</div>

--- a/web/themes/custom/novel/templates/status-messages.html.twig
+++ b/web/themes/custom/novel/templates/status-messages.html.twig
@@ -33,21 +33,23 @@
       <ul>
         {% for message in messages %}
           <li>
-            {% if type != 'error' %}
-              {{ message }}
-            {% endif %}
             {% if type == 'error' %}
               {% include '@novel/error-message.html.twig' with {message: message} %}
+            {% elseif type == 'status' %}
+              {% include '@novel/status-message.html.twig' with {message: message} %}
+            {% else %}
+              {{ message }}
             {% endif %}
           </li>
         {% endfor %}
       </ul>
     {% else %}
-      {% if type != 'error' %}
-        {{ messages|first }}
-      {% endif %}
       {% if type == 'error' %}
         {% include '@novel/error-message.html.twig' with {message: messages|first} %}
+      {% elseif type == 'status' %}
+        {% include '@novel/status-message.html.twig' with {message: messages|first} %}
+      {% else %}
+        {{ messages|first }}
       {% endif %}
     {% endif %}
     {% if type == 'error' %}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-528

#### Description

This PR adds a few new things:
1. Adds a new static content module used for creating a default contact page containing a contact webform paragraph. It also adds 4 taxonomy terms in webform_email_categories, which are used in the contact webform.

2. Updates the contact webform configuration with the following changes:
- Adds a new html element that adds a notice for the user not to enter CPR numbers or other sensitive data.
- Adds danish labels for the contact elements as well as the naming of the form itself.

3. Updates the webform_email_categories taxonomy configuration with the following changes:
- Make sure that all terms added to the vocabulary is unique as we don't want duplicate terms.
- Make sure that the terms default language is danish.

4. Adds a new template for status-messages of the type "status" which are now used when showing status messages to the user. An example of this could be when a user submits a webform successfully. I have created a story for it in the design system as well as adding the new styling: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/607 

#### Screenshot of the result
![Screenshot 2024-04-24 at 01 11 42](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/6142323/3dcbab95-7e74-4480-8a3a-19f1373290ce)
