### PR TITLE
Generate RELEASE_IMAGE_REGISTRY from reflection instead of using hardcoded Taskfile default

### DIFF
--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build and publish source
         run: |
           echo "Publishing tag: $RELEASE_TAG"
-          RELEASE_IMAGE_TAG=$RELEASE_TAG task source:deploy
+          RELEASE_IMAGE_TAG=$RELEASE_TAG RELEASE_IMAGE_REGISTRY=ghcr.io/${{ github.repository_owner}} task source:deploy
         if: ${{ steps.detect_tag.outputs.IS_RELEASE_TAG == 'true' }}
         env:
           CR_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Link to issue

[DDFDRIFT-73](https://reload.atlassian.net/browse/DDFDRIFT-73?atlOrigin=eyJpIjoiNGEzOGI0ODQ1YTQ0NDRhZGIxZTVlNmU1MGNlMTQxZTIiLCJwIjoiaiJ9)

#### Description

When testing how easy it is to create a release from a fork of dpl-cms I hit this one issue, which blocks creation: the default `RELEASE_IMAGE_REGISTRY` in the Taskfile is ghcr.io/danskernesdigitalebibliotek, which means we cannot create releases proeprly.

This fixes the reference, so it still works on the official dpl-cms repo, but will also work out of the box on forks.

[DDFDRIFT-73]: https://reload.atlassian.net/browse/DDFDRIFT-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ