### PR TITLE
Tidy up admin toolbar, organizing in DDF and Drupal. DDFFORM-617

### DIFF
--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -37,3 +37,33 @@ definitions:
     weight: 5
     expanded: false
     enabled: true
+  system__admin_structure:
+    menu_name: admin
+    parent: dpl_admin.drupal
+    weight: -8
+    expanded: false
+    enabled: true
+  system__themes_page:
+    menu_name: admin
+    parent: dpl_admin.drupal
+    weight: -6
+    expanded: false
+    enabled: true
+  system__modules_list:
+    menu_name: admin
+    parent: dpl_admin.drupal
+    weight: -2
+    expanded: false
+    enabled: true
+  system__admin_config:
+    menu_name: admin
+    parent: dpl_admin.drupal
+    weight: 0
+    expanded: false
+    enabled: true
+  system__admin_reports:
+    menu_name: admin
+    parent: dpl_admin.drupal
+    weight: 5
+    expanded: false
+    enabled: true

--- a/web/modules/custom/dpl_admin/assets/dpl_frontend.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_frontend.css
@@ -25,6 +25,14 @@
   mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M5 13q-.425 0-.712-.288T4 12t.288-.712T5 11h6.6l5-5H15q-.425 0-.712-.288T14 5t.288-.712T15 4h4q.425 0 .713.288T20 5v4q0 .425-.288.713T19 10t-.712-.288T18 9V7.4l-5.025 5.025q-.275.275-.637.425t-.763.15zm10 7q-.425 0-.712-.288T14 19t.288-.712T15 18h1.6l-2.475-2.45q-.3-.3-.3-.712t.3-.713t.725-.3t.725.3L18 16.6V15q0-.425.288-.712T19 14t.713.288T20 15v4q0 .425-.288.713T19 20z"/></svg>') !important;
 }
 
+.toolbar-menu-administration .toolbar-icon-dpl-admin-drupal:before {
+  mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M12 2c0 4.308-7 6-7 12a7 7 0 0 0 14 0c0-6-7-7.697-7-12"/><path d="M12 11.33a66 66 0 0 1-2.012 2.023C8.988 14.31 8 15.32 8 17c0 2.17 1.79 4 4 4s4-1.827 4-4c0-1.676-.989-2.685-1.983-3.642q-.63-.606-5.517-5.858z"/></g></svg>') !important;
+}
+
+.toolbar-menu-administration .toolbar-icon-dpl-admin-dpl:before {
+  mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 14 14"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect width="3.5" height="13" x=".55" y=".5" rx=".5"/><rect width="3.5" height="11" x="4.05" y="2.5" rx=".5"/><rect width="3" height="11" x="9.26" y="2.3" rx=".5" transform="rotate(-14.05 10.779 7.795)"/><path d="M.55 10h3.5m0-1h3.5m2.5 2l2.88-.72"/></g></svg>') !important;
+}
+
 /* Gin wants to hide the text of the secondary toolbar items way too early. */
 @media (min-width: 61em) {
   .toolbar-horizontal .gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab .toolbar-item {

--- a/web/modules/custom/dpl_admin/dpl_admin.links.menu.yml
+++ b/web/modules/custom/dpl_admin/dpl_admin.links.menu.yml
@@ -3,18 +3,49 @@ dpl_admin.add_content:
   parent: system.admin_content
   route_name: dpl_admin.add_content
   weight: 5
+
+dpl_admin.dpl:
+  title: "DDF settings"
+  route_name: system.admin_config
+  parent: system.admin
+  weight: 100
+
+dpl_admin.novel_theme:
+  title: "Theme apperance"
+  parent: dpl_admin.dpl
+  route_name: system.theme_settings_theme
+  route_parameters: { theme: "novel" }
+
+dpl_admin.menus:
+  title: "Menus"
+  parent: dpl_admin.dpl
+  route_name: entity.menu.collection
+
+dpl_admin.taxonomies:
+  title: "Taxonomies"
+  parent: dpl_admin.dpl
+  route_name: entity.taxonomy_vocabulary.collection
+
 dpl_admin.redirect:
   title: "Redirects"
-  parent: system.admin
+  parent: dpl_admin.dpl
   route_name: redirect.list
   weight: 10
+
 dpl_admin.redirect_add:
   title: "Add redirect"
   parent: dpl_admin.redirect
   route_name: redirect.add
   weight: 1
+
 dpl_admin.logout:
   title: "Logout"
   parent: system.admin
   route_name: user.logout
   weight: 9999
+
+dpl_admin.drupal:
+  title: "Drupal"
+  route_name: system.admin_config
+  parent: system.admin
+  weight: 100

--- a/web/modules/custom/dpl_library_agency/dpl_library_agency.links.menu.yml
+++ b/web/modules/custom/dpl_library_agency/dpl_library_agency.links.menu.yml
@@ -1,7 +1,7 @@
 dpl_library_agency.settings:
   title: "Library Agency"
   route_name: dpl_library_agency.settings
-  parent: system.admin_config
+  parent: dpl_admin.dpl
   weight: -1000
 
 dpl_library_agency.general_settings_form:


### PR DESCRIPTION
The toolbar has grown massive, with a lot of useful links. A lot of the toolbar also promotes stuff that 99% of the editors will never want to see or use. (Or even have access to). Instead, we create a DDF dropdown, with relevant settings, and a Drupal dropdown, for Drupal developers (and admins).

#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-617

<img width="919" alt="Screenshot 2024-04-25 at 22 02 44" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/f3c82826-5b64-489a-8c55-1736f0ae3dd0">
<img width="603" alt="Screenshot 2024-04-25 at 22 03 01" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/67b25cdd-f056-4ced-bdb3-7d19a5c2c41b">
