### PR TITLE
Add Cypress test for recurring opening hours

### DIFF
--- a/cypress/e2e/opening-hours-editor.cy.ts
+++ b/cypress/e2e/opening-hours-editor.cy.ts
@@ -252,7 +252,7 @@ const createOpeningHoursSeries = ({
   navigateToNextWeekOrMonthAdmin();
   checkMultipleOpeningHoursExistAdmin();
   visitOpeningHoursPage();
-  // Because we use oneMonthFromToday as endDate we can check the 4 næste weeks
+  // Because we use oneMonthFromToday as endDate we can check the four next weeks
   for (let i = 0; i < 5; i++) {
     checkOpeningHoursExistPage({ openingHourCategory, start, end });
     cy.getBySel("opening-hours-next-week-button").click();


### PR DESCRIPTION
#### Link to issue



#### Description

This pull request adds a Cypress test for creating a series of opening hours on the same weekday for a month. The test covers the functionality of creating and checking the existence of multiple opening hours in the admin and user views.