### PR TITLE
DDFFORM 668

### DIFF
--- a/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
+++ b/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
@@ -82,7 +82,7 @@ function dpl_paragraphs_preprocess_paragraph__links(array &$variables): void {
       elseif ($normalized_path === $search_base_path || $normalized_path === $advanced_search_base_path) {
         $link_type = 'search';
       }
-
+      $href = $url->isExternal() ? $url->toUriString() : $url->toString();
       $linkIconClass = ($link_type === 'internal') ? 'link-with-icon__icon--rotate-180' : '';
 
       $attributes = [
@@ -93,7 +93,7 @@ function dpl_paragraphs_preprocess_paragraph__links(array &$variables): void {
       ][$link_type];
 
       $variables['links'][] = [
-        'href' => $url->toUriString(),
+        'href' => $href,
         'linkText' => $item['title'],
         'linkType' => $link_type,
         'target' => $attributes['target'],


### PR DESCRIPTION

- **Fix broken link in link paragraph.**

#### Link to issue

Current ticket: [DDFFORM-668](https://reload.atlassian.net/browse/DDFFORM-668)

Old relevant ticket: [DDFFORM-431](https://reload.atlassian.net/browse/DDFFORM-431)


#### Description

This PR should ensure that all links use in links-paragraph work. 

Please test internal links, external links and redirects? Example could be this: http://bib101.bibbaser.dk/login?url=https://www.pressreader.com  or similar. 



[DDFFORM-668]: https://reload.atlassian.net/browse/DDFFORM-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDFFORM-431]: https://reload.atlassian.net/browse/DDFFORM-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ