### PR TITLE
DDFFORM 126

### DIFF
--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -195,6 +195,23 @@ function dpl_event_preprocess_eventseries(array &$variables): void {
   $variables['formatted_date'] =
     \Drupal::service('dpl_event.reoccurring_date_formatter')
       ->getSeriesDateString($event_series);
+
+  if ($event_series->getInstanceCount() < 2) {
+    return;
+  }
+
+  // Load event instances related to this series and prepare them for rendering.
+  $eventinstances_in_series = $event_series->get('event_instances')->referencedEntities();
+
+  $variables['event_instances'] = [];
+  foreach ($eventinstances_in_series as $index => $eventInstance) {
+    $viewMode = $index === 0 ? 'list_teaser_stacked_parent' : 'stacked_event';
+
+    $renderable_instances = \Drupal::entityTypeManager()
+      ->getViewBuilder('eventinstance')->view($eventInstance, $viewMode);
+
+    $variables['event_instances'][] = $renderable_instances;
+  }
 }
 
 /**

--- a/web/themes/custom/novel/templates/components/full-event.html.twig
+++ b/web/themes/custom/novel/templates/components/full-event.html.twig
@@ -29,5 +29,14 @@
     } only %}
   </section>
 
+  {% if event_instances %}
+    <section class="event-list-stacked">
+      <h2 class="event-list-stacked__heading">{{ 'Upcoming events'|t }}</h2>
+      {% for instance in event_instances %}
+          {{ instance }}
+      {% endfor %}
+    </section>
+  {% endif %}
+
   {{ paragraphs }}
 </article>

--- a/web/themes/custom/novel/templates/fields/field--field-event-paragraphs.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-event-paragraphs.html.twig
@@ -1,0 +1,5 @@
+{% include '@novel/components/paragraphs.html.twig'
+  with {
+  attributes: attributes,
+  items: items
+} only %}

--- a/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
@@ -37,4 +37,5 @@
   'categories': content.event_categories,
   'teaser_text': content.field_teaser_text,
   'tags': content.event_tags,
+  'event_instances': event_instances,
 } only %}

--- a/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
@@ -22,5 +22,3 @@
 {% include '@novel/layout/eventinstance--full.html.twig' with {
     content: content|merge(instancelike_content)
 } %}
-
-{{ content.event_instances }}


### PR DESCRIPTION
#### Link to issue

[DDFFORM-126](https://reload.atlassian.net/browse/DDFFORM-126)

Related design system PR: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/613

#### Description

This PR adds a section on an eventseries page that will show the eventinstances for that series. It uses the same view as stack_parent + stacked_event as on /events page. 



#### Screenshots

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/c5af839f-dc64-4ce7-8034-ee8b6563f326)



[DDFFORM-126]: https://reload.atlassian.net/browse/DDFFORM-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ