### PR TITLE
Remove `<p>` tags from events and articles

### DIFF
--- a/web/themes/custom/novel/templates/components/list-item.html.twig
+++ b/web/themes/custom/novel/templates/components/list-item.html.twig
@@ -29,6 +29,7 @@
         {{ description }}
       </div>
     {% endif %}
+
     {% if bottom.0 %}
       <div class="content-list-item__content-bottom-container">
         {{ bottom }}

--- a/web/themes/custom/novel/templates/fields/field--eventinstance--event-description--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--eventinstance--event-description--list-teaser.html.twig
@@ -1,5 +1,0 @@
-<p>
-  {% for item in items %}
-    {{ item.content }}
-  {% endfor %}
-</p>

--- a/web/themes/custom/novel/templates/fields/field--node--field-subtitle--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--node--field-subtitle--list-teaser.html.twig
@@ -1,5 +1,3 @@
-<p>
-  {% for item in items %}
-    {{ item.content }}
-  {% endfor %}
-</p>
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/web/themes/custom/novel/templates/layout/eventinstance--list-teaser-stacked-parent.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--list-teaser-stacked-parent.html.twig
@@ -8,7 +8,7 @@
   categories: content.event_categories,
   date: content.date,
   title: content.title,
-  description: content.event_description.0,
+  description: content.event_description,
   bottom: content.branch,
   start_date: start_time,
   end_date: end_time,


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-753

#### Description
This pull request removes the `<p>` for events and articles. 

#### Screenshot of the result
<img width="1717" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/606ae0e8-dcc6-4aec-b8a1-6301c8e1c8b7">

<img width="1717" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/124a8909-8bbd-4162-bf20-43da16f8d87c">

<img width="1717" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/1a98186f-dcaf-4f2b-ad83-dcf98daff60d">
