### PR TITLE
DDFFORM 494

### DIFF
--- a/web/modules/custom/dpl_fbi/dpl_fbi.install
+++ b/web/modules/custom/dpl_fbi/dpl_fbi.install
@@ -70,4 +70,31 @@ function dpl_fbi_update_10000() :void {
       }
     }
   }
+
+}
+
+/**
+ * Update the CQL search field to have a max length of 16000.
+ */
+function dpl_fbi_update_10001():void {
+  $database = \Drupal::database();
+  $tables = [
+    'paragraph__field_cql_search',
+    'paragraph_revision__field_cql_search',
+  ];
+
+  $spec = [
+    'type' => 'varchar',
+    'length' => 16000,
+    'not null' => FALSE,
+  ];
+
+  foreach ($tables as $table_name) {
+    if ($database->schema()->fieldExists($table_name, 'field_cql_search_value')) {
+      $database->schema()->changeField($table_name, 'field_cql_search_value', 'field_cql_search_value', $spec);
+    }
+    else {
+      throw new \Exception("Field 'field_cql_search_value' does not exist in the table {$table_name}");
+    }
+  }
 }

--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldType/CqlSearchItem.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldType/CqlSearchItem.php
@@ -61,7 +61,7 @@ final class CqlSearchItem extends FieldItemBase {
 
     $constraint_manager = $this->getTypedDataManager()->getValidationConstraintManager();
 
-    $options['value']['Length']['max'] = 255;
+    $options['value']['Length']['max'] = 16000;
 
     $constraints[] = $constraint_manager->create('ComplexData', $options);
     return $constraints;
@@ -80,7 +80,7 @@ final class CqlSearchItem extends FieldItemBase {
         'type' => 'varchar',
         'not null' => FALSE,
         'description' => 'CQL search string.',
-        'length' => 255,
+        'length' => 16000,
       ],
     ];
 


### PR DESCRIPTION
#### Link to issue

[DDFFORM-494](https://reload.atlassian.net/browse/DDFFORM-494)

#### Description

This PR sets the max length of the varchar field CQL_search_string to 16000 instead of 255. 
This is allow longer CQL strings. 

An update hook for applying this change to already used fields is also added. 

#### Additional comments or questions

Test that you can save the paragraph with a field containing a longer than 255 value. 


[DDFFORM-494]: https://reload.atlassian.net/browse/DDFFORM-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ