### PR TITLE
Make sure structure menu is accessible for editors. DDFFORM-617

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -280,6 +280,7 @@
                 "2280639: Add the FieldStorageDefinition class to define field storage definitions in hook_entity_field_storage_info()": "https://www.drupal.org/files/issues/2023-09-05/2280639-d10-reroll-156.patch",
                 "3402656: Toolbar causes a Javascript error if the subtrees content changes between page loads": "https://git.drupalcode.org/issue/drupal-3402656/-/commit/61ac007a84014f54a07825f8f92bb6bc0dfbd170.patch",
                 "2259567: Support SVG files for theme logo setting": "https://www.drupal.org/files/issues/2023-05-08/2259567-168.patch",
+                "296693: Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
                 "Always assume chmod succeeds": "patches/core-304fd8b-chmod-true.patch"
             },
             "drupal/date_range_formatter": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a0f2698fd37dc8bbe2e1036dc6d92c5",
+    "content-hash": "c388e091cf4e007c336721aee9a08520",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -44,6 +44,7 @@ label: Editor
 weight: 4
 is_admin: null
 permissions:
+  - 'access administration pages'
   - 'access content overview'
   - 'access eventinstance overview'
   - 'access eventseries overview'

--- a/config/sync/user.role.mediator.yml
+++ b/config/sync/user.role.mediator.yml
@@ -33,6 +33,7 @@ label: Mediator
 weight: 5
 is_admin: null
 permissions:
+  - 'access administration pages'
   - 'access content overview'
   - 'access eventinstance overview'
   - 'access eventseries overview'


### PR DESCRIPTION
Apparantly, to have access to the structure menu in general, users need a generic permission.

There's a bug in Core, that means that links show up in the config dropdown, despite not being accessible. I've added a patch against this.

https://reload.atlassian.net/browse/DDFFORM-617