### PR TITLE
Set default admin language to Danish

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,6 +95,7 @@
         "deoliveiralucas/array-keys-case-transform": "^1.1",
         "drupal/address": "^1.0",
         "drupal/admin_toolbar": "^3.4",
+        "drupal/admin_user_language": "^1.1",
         "drupal/administerusersbyrole": "^3.4",
         "drupal/color_field": "^3.0",
         "drupal/config_ignore": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d41e20a2746479c5f7e3bd99124f6c06",
+    "content-hash": "7ea4bbbbddb2a258cf247af24e22ce02",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2209,6 +2209,68 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/admin_toolbar",
                 "issues": "https://www.drupal.org/project/issues/admin_toolbar"
+            }
+        },
+        {
+            "name": "drupal/admin_user_language",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/admin_user_language.git",
+                "reference": "8.x-1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/admin_user_language-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "7118a2e8919cfdf1f466e2ab84c055e88bb095e1"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.1",
+                    "datestamp": "1692365693",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Alessio De Francesco",
+                    "homepage": "https://github.com/aless-io",
+                    "email": "alessio.de.francesco@pwc-digital.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Whiston",
+                    "homepage": "https://github.com/twhiston",
+                    "email": "tom.whiston@pwc-digital.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "DieterHolvoet",
+                    "homepage": "https://www.drupal.org/user/3567222"
+                }
+            ],
+            "description": "Forces a preferred administration pages language on user creation/update",
+            "homepage": "https://www.drupal.org/project/admin_user_language",
+            "keywords": [
+                "Drupal",
+                "admin_user_language",
+                "pwc",
+                "user language"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/admin_user_language"
             }
         },
         {

--- a/config/sync/admin_user_language.settings.yml
+++ b/config/sync/admin_user_language.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: Ir73Ap5R12vU3J0EYOYeNAYHOZ8mCp1q6nN2lLvqLNs
+default_language_to_assign: da
+prevent_user_override: false

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -3,6 +3,7 @@ _core:
 module:
   address: 0
   admin_toolbar: 0
+  admin_user_language: 0
   administerusersbyrole: 0
   basic_auth: 0
   better_exposed_filters: 0


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-673

#### Description

Add and enable admin User Language module.

This allows us to set a default language for administration pages
which users are assigned when created. Normally this can only be
controlled by editing the user afterwards.

Use the module to configure accounts to be created use to Danish as admin language.

#### Additional comments or questions

In itself the code behind the module is quite simple but the module
seems to do its job well and is covered by the Drupal security
advisory policy so it should be good to accept.
