### PR TITLE
Limit OpenAPI access

### DIFF
--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -39,6 +39,7 @@ dependencies:
     - locale
     - media
     - node
+    - openapi
     - openid_connect
     - paragraphs
     - path
@@ -63,6 +64,7 @@ permissions:
   - 'access eventseries overview'
   - 'access files overview'
   - 'access media overview'
+  - 'access openapi api docs'
   - 'access site in maintenance mode'
   - 'access site reports'
   - 'access taxonomy overview'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -10,7 +10,6 @@ dependencies:
   module:
     - filter
     - media
-    - openapi
     - recurring_events
     - rest
     - system
@@ -22,7 +21,6 @@ weight: 1
 is_admin: false
 permissions:
   - 'access content'
-  - 'access openapi api docs'
   - 'restful get dpl_opening_hours_list'
   - 'restful get proxy-url'
   - 'restful post campaign:match'

--- a/config/sync/user.role.external_system.yml
+++ b/config/sync/user.role.external_system.yml
@@ -14,6 +14,7 @@ label: 'External system'
 weight: 7
 is_admin: null
 permissions:
+  - 'access administration pages'
   - 'access openapi api docs'
   - 'access toolbar'
   - 'restful patch event'

--- a/config/sync/user.role.external_system.yml
+++ b/config/sync/user.role.external_system.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - rest.resource.event
   module:
+    - openapi
     - rest
     - system
     - toolbar
@@ -13,6 +14,7 @@ label: 'External system'
 weight: 7
 is_admin: null
 permissions:
+  - 'access openapi api docs'
   - 'access toolbar'
   - 'restful patch event'
   - 'view the administration theme'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -35,6 +35,7 @@ dependencies:
     - locale
     - media
     - node
+    - openapi
     - openid_connect
     - paragraphs
     - path
@@ -59,6 +60,7 @@ permissions:
   - 'access eventseries overview'
   - 'access files overview'
   - 'access media overview'
+  - 'access openapi api docs'
   - 'access site in maintenance mode'
   - 'access site reports'
   - 'access taxonomy overview'


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-617

#### Description

Currently all authenticated users have access to the OpenAPI Docs.
With updated menu structure this also means that the corresponding
menu item will be visible in the admin UI.

This is a bit confusing as these users do not needs to access the
specification at all.

Update permissions so only relevant roles have access to the API:
- Local administrators and administrators as they may need to document
  things to external partners
- External systems in case they log in to access the administrative UI


#### Screenshot of the result

Editor

<img width="1392" alt="Monosnap editor | DPL CMS — Privat browsing 2024-04-29 17-14-28" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/c6912e6e-65df-477b-9050-fd100143e673">
(No OpenAPI access)


External system:

<img width="1392" alt="Monosnap OpenAPI Documentation | DPL CMS | Logged in — Privat browsing 2024-04-29 17-10-55" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/08210dc0-0435-446e-bc79-847c473f58de">

