### PR TITLE
Disable `daily` and `yearly` events

### DIFF
--- a/config/sync/recurring_events.eventseries.config.yml
+++ b/config/sync/recurring_events.eventseries.config.yml
@@ -9,7 +9,7 @@ days: 'monday,tuesday,wednesday,thursday,friday,saturday,sunday'
 limit: 10
 excludes: 1
 includes: 1
-enabled_fields: 'consecutive_recurring_date,daily_recurring_date,weekly_recurring_date,monthly_recurring_date,yearly_recurring_date,custom'
+enabled_fields: 'consecutive_recurring_date,weekly_recurring_date,monthly_recurring_date,custom'
 threshold_warning: 1
 threshold_count: 200
 threshold_message: 'Saving this series will create up to @total event instances. This could result in memory exhaustion or site instability.'


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-521

#### Description

This pull request disables the `daily` and `yearly` events in favor of using `Consecutive Event`. This change aims to reduce confusion

#### Screenshot of the result
<img width="1241" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/69512e8b-38bd-4c0b-823c-8add26e74a59">
