### PR TITLE
Enable `page` content-type in `card_grid_manual` (News Paragraph)

### DIFF
--- a/config/sync/field.field.paragraph.card_grid_manual.field_grid_content.yml
+++ b/config/sync/field.field.paragraph.card_grid_manual.field_grid_content.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.paragraph.field_grid_content
     - paragraphs.paragraphs_type.card_grid_manual
-    - recurring_events.eventseries_type.default
   module:
     - dynamic_entity_reference
 id: paragraph.card_grid_manual.field_grid_content
@@ -26,17 +25,7 @@ settings:
         view_name: entity_reference_content
         display_name: entity_reference_1
         arguments:
-          - article
-  eventseries:
-    handler: 'default:eventseries'
-    handler_settings:
-      target_bundles:
-        default: default
-      sort:
-        field: _none
-        direction: ASC
-      auto_create: false
-      auto_create_bundle: ''
+          - article+page
   crop:
     handler: 'default:crop'
     handler_settings: {  }
@@ -45,6 +34,9 @@ settings:
     handler_settings: {  }
   eventinstance:
     handler: 'default:eventinstance'
+    handler_settings: {  }
+  eventseries:
+    handler: 'default:eventseries'
     handler_settings: {  }
   file:
     handler: 'default:file'
@@ -58,6 +50,9 @@ settings:
   paragraph:
     handler: 'default:paragraph'
     handler_settings: {  }
+  redirect:
+    handler: 'default:redirect'
+    handler_settings: {  }
   search_api_task:
     handler: 'default:search_api_task'
     handler_settings: {  }
@@ -69,9 +64,6 @@ settings:
     handler_settings: {  }
   user:
     handler: 'default:user'
-    handler_settings: {  }
-  redirect:
-    handler: 'default:redirect'
     handler_settings: {  }
   webform_submission:
     handler: 'default:webform_submission'

--- a/config/sync/views.view.entity_reference_content.yml
+++ b/config/sync/views.view.entity_reference_content.yml
@@ -376,7 +376,7 @@ display:
           case: none
           path_case: none
           transform_dash: false
-          break_phrase: false
+          break_phrase: true
       filters: {  }
       style:
         type: default


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-539

#### Description

This pull request implements the required configuration adjustments to activate the `page` content-type within the `card_grid_manual` paragraph

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/bec015a6-23e9-479f-8aa9-f7830fbe0f0f

