### PR TITLE
Programmatically add translations for un-capitalized weekdays. DDFFORM-622

### DIFF
--- a/web/modules/custom/dpl_event/dpl_event.install
+++ b/web/modules/custom/dpl_event/dpl_event.install
@@ -6,14 +6,18 @@
  */
 
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\drupal_typed\DrupalTyped;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\locale\SourceString;
+use Drupal\locale\StringDatabaseStorage;
 
 /**
  * Implements hook_install().
  */
 function dpl_event_install(): void {
   _dpl_event_create_mock_title();
+  _dpl_event_add_weekday_translations();
 }
 
 /**
@@ -57,6 +61,13 @@ function dpl_event_update_10003(): string {
 }
 
 /**
+ * Translate weekdays to danish.
+ */
+function dpl_event_update_10004(): string {
+  return _dpl_event_add_weekday_translations();
+}
+
+/**
  * Add a mock title field to eventinstance, to fix entity reference fields.
  *
  * @see https://www.drupal.org/project/eck/issues/2956378
@@ -75,4 +86,40 @@ function _dpl_event_create_mock_title(): string {
     ->installFieldStorageDefinition('title', $entity_type, $entity_type, $field_storage_definition);
 
   return "Mock title field has been added to the $entity_type entity.";
+}
+
+/**
+ * Programmatically add translations for un-capitalized weekdays.
+ */
+function _dpl_event_add_weekday_translations(): string {
+  $translations = [
+    'monday' => 'mandag',
+    'tuesday' => 'tirsdag',
+    'wednesday' => 'onsdag',
+    'thursday' => 'torsdag',
+    'friday' => 'fredag',
+    'saturday' => 'lørdag',
+    'sunday' => 'søndag',
+  ];
+
+  $translator = DrupalTyped::service(StringDatabaseStorage::class, 'locale.storage');
+
+  foreach ($translations as $english => $danish) {
+    $string = $translator->findString(['source' => $english]);
+
+    if (is_null($string)) {
+      $string = new SourceString();
+      $string->setString($english);
+      $string->setStorage($translator);
+      $string->save();
+    }
+
+    $translator->createTranslation([
+      'lid' => $string->lid,
+      'language' => 'da',
+      'translation' => $danish,
+    ])->save();
+  }
+
+  return "Weekdays have been translated to danish.";
 }


### PR DESCRIPTION
This is particularly important for eventseries, where it currently says "Hver saturday" - DDF will not be able to translate it, until the actual word shows up, so instead, we do it for them.

https://reload.atlassian.net/browse/DDFFORM-622
