### PR TITLE
Update `footer-accordions.html.twig` template to use `settings.footer_items` values

### DIFF
--- a/web/themes/custom/novel/templates/components/footer-accordions.html.twig
+++ b/web/themes/custom/novel/templates/components/footer-accordions.html.twig
@@ -1,7 +1,7 @@
 {{ attach_library('novel/footer-accordions') }}
 
 <ul class="footer-accordions" data-footer-accordions="true">
-    {% for item in footer %}
+    {% for item in settings.footer_items %}
         {% set startsOpen = loop.index == 1 %}
         <li class="footer-accordion">
             <h3 class="footer-accordion__header footer__title">


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-686

#### Description

This pull request updates the `footer-accordions.html.twig` template to use `settings.footer_items` instead of the `footer` variable.

This change addresses a leftover issue from [PR #935](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/935).

#### Screenshot of the result
<img width="404" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/27834d79-aa47-4422-b77d-d1f33c7edd29">
