### PR TITLE
Redirect "registrering" to "opret-bruger"

### DIFF
--- a/lagoon/conf/nginx/server_append_drupal_rewrite_registration.conf
+++ b/lagoon/conf/nginx/server_append_drupal_rewrite_registration.conf
@@ -1,0 +1,2 @@
+# DDF has old links to /registrering, which should redirect to /opret-bruger
+rewrite ^/registrering(.*)$ /opret-bruger$1 redirect;

--- a/lagoon/nginx.dockerfile
+++ b/lagoon/nginx.dockerfile
@@ -14,5 +14,8 @@ RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_authorize.conf
 COPY lagoon/conf/nginx/server_append_drupal_modules_local.conf /etc/nginx/conf.d/drupal/server_append_drupal_modules_local.conf
 RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_modules_local.conf
 
+COPY lagoon/conf/nginx/server_append_drupal_rewrite_registration.conf /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_registration.conf
+RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_registration.conf
+
 # Define where the Drupal Root is located
 ENV WEBROOT=web


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-608

#### Description

DDF wants a redirect that is not editable in backend. So here it is.
The redirect makes sure that the old url works.
