### PR TITLE
Revert "Disable `daily` and `yearly` events"

### DIFF
--- a/config/sync/recurring_events.eventseries.config.yml
+++ b/config/sync/recurring_events.eventseries.config.yml
@@ -9,7 +9,7 @@ days: 'monday,tuesday,wednesday,thursday,friday,saturday,sunday'
 limit: 10
 excludes: 1
 includes: 1
-enabled_fields: 'consecutive_recurring_date,weekly_recurring_date,monthly_recurring_date,custom'
+enabled_fields: 'consecutive_recurring_date,daily_recurring_date,weekly_recurring_date,monthly_recurring_date,yearly_recurring_date,custom'
 threshold_warning: 1
 threshold_count: 200
 threshold_message: 'Saving this series will create up to @total event instances. This could result in memory exhaustion or site instability.'


### PR DESCRIPTION
This change causes multiple problems:

1. Multiple PHP warnings are shown when creating event series
2. Event instances are shown without a title

Reverts danskernesdigitalebibliotek/dpl-cms#1065


<img width="1919" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/3323c085-bd24-4d1f-b935-5d9abe0ec101">
