### PR TITLE
Ensure menu cache is cleared when first item is added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -341,7 +341,7 @@
                 "3105637: Edit, install and uninstall permission": "https://www.drupal.org/files/issues/2024-02-01/theme-permission-edit-install-uninstall-3105637-7.patch"
             },
             "drupal/twig_tweak": {
-                "3428226: Clear menu cache when adding first item": "https://git.drupalcode.org/project/twig_tweak/-/merge_requests/47.patch"
+                "3428226: Clear menu cache when adding first item": "https://git.drupalcode.org/project/twig_tweak/-/commit/6fd3997d45fe90fdf6545a3c85ff1c5b68e9bde1.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77b9e91fc5d40c7b09902e036719875b",
+    "content-hash": "4c197c783595cc443eb373f03cfe6896",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-618

#### Description

This PR switches the patch uses to solve this issue. It turns out the current approach is not correct so we try again by providing a new patch.

#### Additional comments or questions

This can be tested on the PR environment by:

1. Emptying any existing menu items
2. Rendering the front page
3. Adding a new menu item to the main menu
4. Rendering the front page
5. Seeing that the new menu item is added
