### PR TITLE
Update `checkMultipleOpeningHoursExistAdmin` to `checkAtLeastOneOpeningHoursExistAdmin`

### DIFF
--- a/cypress/e2e/opening-hours-editor.cy.ts
+++ b/cypress/e2e/opening-hours-editor.cy.ts
@@ -175,12 +175,12 @@ const checkOpeningHoursExistPage = ({
     .and("contain", `${start} - ${end}`);
 };
 
-const checkMultipleOpeningHoursExistAdmin = () => {
+const checkAtLeastOneOpeningHoursExistAdmin = () => {
   cy.get('tbody[role="presentation"]')
     .should("be.visible")
     .find('div[data-cy="opening-hours-editor-event-content"]')
     .its("length")
-    .should("be.gt", 1);
+    .should("be.gte", 1);
 };
 
 const checkOpeningHoursNotPresentInPage = ({
@@ -248,9 +248,9 @@ const createOpeningHoursSeries = ({
   submitOpeningHourForm();
   checkConfirmationDialog({ openingHourCategory, start, end, endDate });
   confirmRepeatedOpeningHourForm();
-  checkMultipleOpeningHoursExistAdmin();
+  checkAtLeastOneOpeningHoursExistAdmin();
   navigateToNextWeekOrMonthAdmin();
-  checkMultipleOpeningHoursExistAdmin();
+  checkAtLeastOneOpeningHoursExistAdmin();
   visitOpeningHoursPage();
   // Because we use oneMonthFromToday as endDate we can check the four next weeks
   for (let i = 0; i < 5; i++) {


### PR DESCRIPTION


#### Description

This revision ensures the system properly handles scenarios where only a single opening hour exists at the end of the first month or the start of the next month. This behavior stems from the use of `oneMonthFromToday` as the end date in our opening time series.
