### PR TITLE
Allow editors to create tags from content creation. DDFFORM-671

### DIFF
--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -29,7 +29,8 @@ dependencies:
     - paragraphs
     - paragraphs_ee
     - paragraphs_features
-    - select2_multicheck
+    - path
+    - select2
 third_party_settings:
   field_group:
     group_teaser_card:
@@ -95,18 +96,24 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_branch:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 0
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_categories:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 5
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_description:
     type: string_textarea
@@ -184,10 +191,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_event_state:
-    type: options_select
+    type: select2
     weight: 6
     region: content
-    settings: {  }
+    settings:
+      width: 100%
     third_party_settings: {  }
   field_event_title:
     type: string_textfield
@@ -198,11 +206,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_tags:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 6
     region: content
     settings:
       width: 100%
+      autocomplete: true
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_teaser_image:
     type: media_library_widget

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -28,9 +28,10 @@ dependencies:
     - paragraphs
     - paragraphs_ee
     - paragraphs_features
+    - path
     - recurring_events
     - scheduler
-    - select2_multicheck
+    - select2
 third_party_settings:
   field_group:
     group_teaser_card:
@@ -110,18 +111,24 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_branch:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 0
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_categories:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 11
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_description:
     type: string_textarea
@@ -199,18 +206,21 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_event_state:
-    type: select2_multicheck
+    type: select2
     weight: 9
     region: content
     settings:
       width: 100%
     third_party_settings: {  }
   field_tags:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 12
     region: content
     settings:
       width: 100%
+      autocomplete: true
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_teaser_image:
     type: media_library_widget
@@ -276,7 +286,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   recur_type:
-    type: select2_multicheck
+    type: select2
     weight: 3
     region: content
     settings:

--- a/config/sync/core.entity_form_display.media.document.default.yml
+++ b/config/sync/core.entity_form_display.media.document.default.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - file
     - path
-    - select2_multicheck
+    - select2
 id: media.document.default
 targetEntityType: media
 bundle: document
@@ -56,11 +56,14 @@ content:
       display_label: true
     third_party_settings: {  }
   uid:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 4
     region: content
     settings:
       width: 100%
+      autocomplete: true
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
 hidden:
   publish_on: true

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - media
     - path
-    - select2_multicheck
+    - select2
 id: media.video.default
 targetEntityType: media
 bundle: video
@@ -49,11 +49,14 @@ content:
       display_label: true
     third_party_settings: {  }
   uid:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 5
     region: content
     settings:
       width: 100%
+      autocomplete: true
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
 hidden:
   name: true

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -25,7 +25,6 @@ dependencies:
     - path
     - scheduler
     - select2
-    - select2_multicheck
 third_party_settings:
   field_group:
     group_article_meta_tags:
@@ -102,11 +101,14 @@ bundle: article
 mode: default
 content:
   field_branch:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 0
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_canonical_url:
     type: link_default
@@ -117,11 +119,14 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
   field_categories:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 7
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_override_author:
     type: string_textfield
@@ -175,11 +180,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_tags:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 8
     region: content
     settings:
       width: 100%
+      autocomplete: true
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_teaser_image:
     type: media_library_widget
@@ -236,7 +244,7 @@ content:
     region: content
     settings:
       width: 100%
-      autocomplete: false
+      autocomplete: true
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -21,7 +21,7 @@ dependencies:
     - paragraphs_features
     - path
     - scheduler
-    - select2_multicheck
+    - select2
 third_party_settings:
   field_group:
     group_teaser_card:
@@ -47,18 +47,24 @@ bundle: page
 mode: default
 content:
   field_branch:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 0
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_breadcrumb_parent:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 1
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_display_titles:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.paragraph.card_grid_automatic.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.card_grid_automatic.default.yml
@@ -10,7 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.card_grid_automatic
   module:
     - field_group
-    - select2_multicheck
+    - select2
 third_party_settings:
   field_group:
     group_filters:
@@ -35,25 +35,34 @@ bundle: card_grid_automatic
 mode: default
 content:
   field_filter_branches:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 8
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_filter_categories:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 7
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_filter_tags:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 6
     region: content
     settings:
       width: 100%
+      autocomplete: true
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_title:
     type: string_textfield

--- a/config/sync/core.entity_form_display.paragraph.filtered_event_list.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.filtered_event_list.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - paragraphs.paragraphs_type.filtered_event_list
   module:
     - field_group
-    - select2_multicheck
+    - select2
 third_party_settings:
   field_group:
     group_filters:
@@ -42,25 +42,34 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_filter_branches:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 8
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_filter_categories:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 7
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_filter_tags:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 6
     region: content
     settings:
       width: 100%
+      autocomplete: true
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_title:
     type: string_textfield

--- a/config/sync/core.entity_form_display.paragraph.hero.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.hero.default.yml
@@ -15,7 +15,7 @@ dependencies:
     - datetime
     - link
     - media_library
-    - select2_multicheck
+    - select2
     - text
 id: paragraph.hero.default
 targetEntityType: paragraph
@@ -23,11 +23,14 @@ bundle: hero
 mode: default
 content:
   field_hero_categories:
-    type: select2_multicheck
+    type: select2_entity_reference
     weight: 0
     region: content
     settings:
       width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_hero_content_type:
     type: string_textfield

--- a/config/sync/core.entity_form_display.paragraph.user_registration_item.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.user_registration_item.default.yml
@@ -13,7 +13,7 @@ dependencies:
     - paragraphs.paragraphs_type.user_registration_item
   module:
     - linkit
-    - select2_multicheck
+    - select2
     - text
 id: paragraph.user_registration_item.default
 targetEntityType: paragraph
@@ -44,7 +44,7 @@ content:
       display_label: true
     third_party_settings: {  }
   field_link_target:
-    type: select2_multicheck
+    type: select2
     weight: 6
     region: content
     settings:

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -133,7 +133,6 @@ module:
   search_api: 0
   search_api_db: 0
   select2: 0
-  select2_multicheck: 0
   serialization: 0
   simple_menu_permissions: 0
   system: 0

--- a/config/sync/taxonomy.vocabulary.breadcrumb_structure.yml
+++ b/config/sync/taxonomy.vocabulary.breadcrumb_structure.yml
@@ -18,7 +18,7 @@ third_party_settings:
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
-name: 'Breadcrumb and URL structure'
+name: 'Brødkrummer og URL struktur'
 vid: breadcrumb_structure
 description: ''
 weight: 0


### PR DESCRIPTION
Replaces a multiselect field, with the "tag-style" search field. That way, the editors can actually create new tags directly.

https://reload.atlassian.net/browse/DDFFORM-671 