### PR TITLE
DDFFORM 615

### DIFF
--- a/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventinstance--full.html.twig
@@ -35,7 +35,7 @@
   'description': content.event_description,
   'description_items': description_items,
   'categories': content.event_categories,
-  'teaser_text': content.field_teaser_text,
+  'teaser_text': content.event_teaser_text,
   'tags': content.event_tags,
   'event_instances': event_instances,
 } only %}

--- a/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
@@ -17,6 +17,7 @@
     "event_ticket_categories": content.field_ticket_categories,
     "event_tags": content.field_tags,
     "event_branch": content.field_branch,
+    "event_teaser_text": content.field_teaser_text,
   }
 %}
 {% include '@novel/layout/eventinstance--full.html.twig' with {


### PR DESCRIPTION

#### Link to issue

[DDFFORM-615](https://reload.atlassian.net/browse/DDFFORM-615)

#### Description

This PR ensures that the image teaser text is displayed on the full page view of an eventinstance, like it is already on the full page view for eventseries. 

For the record: 
The ticket additionally describes an issue of teaser text (In actuallity the whole media_container) not being displayed on list teasers on /events. This has been fixed already and is not relevant. 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/67fe8594-0454-4ac8-9e61-1f4cce7a511b)

[DDFFORM-615]: https://reload.atlassian.net/browse/DDFFORM-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ