### PR TITLE
Refactor logo structure.

### DIFF
--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -1,9 +1,7 @@
 {{ attach_library('novel/header') }}
 <header class="header">
     <div class="header__logo-desktop">
-        <a class="header__logo-desktop-link" href="/">
-                {{ logo }}
-        </a>
+            {{ logo }}
     </div>
     <div class="header__menu">
         <nav class="header__menu-first" aria-label="Primary site navigation">

--- a/web/themes/custom/novel/templates/novel-logo.html.twig
+++ b/web/themes/custom/novel/templates/novel-logo.html.twig
@@ -1,11 +1,13 @@
 {% set has_image = (image is not empty) and logo_img_enable %}
 
-<figure class="logo">
+<a href="{{ path('<front>') }}" class="logo" aria-label="{{ 'Go to frontpage'|t({}, {'context': 'Logo aria-label'}) }}">
+  <figure class="logo__content">
     {% if has_image %}
-        {{ image }}
+      {{ image }}
     {% endif %}
-    <figcaption class="logo-fallback {{ has_image ? 'logo-fallback--has-image' : '' }}">
-        <p class=" logo-fallback__text-name">{{ title }}</p>
-        <p class="logo-fallback__text-libraries">{{ place }}</p>
-    </figcaption>
-</figure>
+    <div class="logo__description  {{ has_image ? 'logo__description--has-image' : '' }}">
+      <p class="logo__library-name">{{ title }}</p>
+      <p>{{ place }}</p>
+    </div>
+  </figure>
+</a>


### PR DESCRIPTION
This updates the logo structure with the new structure from the designsystem.

The intension is the use the same logo template everywhere the logo is necessary, and keep the href logic inside this template.

This also adds an aria-label as requested in a seperate ticket: DDFFORM-750

DDFFORM-696

#### Link to issue

This PR covers two tickets: 

[DDFFORM-696](https://reload.atlassian.net/browse/DDFFORM-696)

[DDFFORM-709](https://reload.atlassian.net/browse/DDFFORM-709)

Depends on PR in design system: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/621

#### Description

This PR updates the markup for the logo template. 

The aim is to ensure that the logo is rendered the same way in both header/footer and handles the redirect to the frontpage.

This also adds an aria-label as requested in [DDFFORM-709](https://reload.atlassian.net/browse/DDFFORM-709)

[DDFFORM-696]: https://reload.atlassian.net/browse/DDFFORM-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDFFORM-709]: https://reload.atlassian.net/browse/DDFFORM-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDFFORM-709]: https://reload.atlassian.net/browse/DDFFORM-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ