### PR TITLE
DDFLSBP-603: Disable relations option on Webform Emails Categories taxonomy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
         "drupal/facets": "^2.0",
         "drupal/field_group": "^3.4",
         "drupal/field_inheritance": "^2.0",
+        "drupal/flat_taxonomy": "^2.0",
         "drupal/focal_point": "^2.0",
         "drupal/gin": "^3.0@RC",
         "drupal/gin_toolbar": "^1.0@RC",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96535d5f8d25ee8866b257464aff5c38",
+    "content-hash": "d70baba854f9be8c0730bc118ca0cdb6",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -3902,6 +3902,50 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/field_inheritance",
                 "issues": "https://www.drupal.org/project/issues/field_inheritance"
+            }
+        },
+        {
+            "name": "drupal/flat_taxonomy",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/flat_taxonomy.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/flat_taxonomy-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "b85d1bde4d8de589cd0dfc77b846e66f0906a0ce"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1688494925",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "vbouchet",
+                    "homepage": "https://www.drupal.org/user/1671428"
+                }
+            ],
+            "description": "Provides tools to force selected taxonomies to be flat.",
+            "homepage": "https://www.drupal.org/project/flat_taxonomy",
+            "support": {
+                "source": "https://git.drupalcode.org/project/flat_taxonomy"
             }
         },
         {

--- a/config/sync/core.entity_form_display.paragraph.webform.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.webform.default.yml
@@ -17,7 +17,7 @@ content:
     weight: 0
     region: content
     settings:
-      default_data: true
+      default_data: false
       webforms: {  }
     third_party_settings: {  }
 hidden:

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -79,6 +79,7 @@ module:
   field_inheritance: 0
   file: 0
   filter: 0
+  flat_taxonomy: 0
   focal_point: 0
   gin_toolbar: 0
   handy_cache_tags: 0

--- a/config/sync/taxonomy.vocabulary.opening_hours_categories.yml
+++ b/config/sync/taxonomy.vocabulary.opening_hours_categories.yml
@@ -3,6 +3,7 @@ langcode: da
 status: true
 dependencies:
   module:
+    - flat_taxonomy
     - scheduler
 third_party_settings:
   scheduler:
@@ -18,6 +19,8 @@ third_party_settings:
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
+  flat_taxonomy:
+    flat: 1
 name: Åbningstidskategorier
 vid: opening_hours_categories
 description: 'Kategorier af åbningstider, f.eks. "Åbent" eller "Telefontid"'

--- a/config/sync/taxonomy.vocabulary.webform_email_categories.yml
+++ b/config/sync/taxonomy.vocabulary.webform_email_categories.yml
@@ -3,6 +3,7 @@ langcode: da
 status: true
 dependencies:
   module:
+    - flat_taxonomy
     - scheduler
 third_party_settings:
   scheduler:
@@ -18,6 +19,8 @@ third_party_settings:
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
+  flat_taxonomy:
+    flat: 1
 name: 'Webform email categories'
 vid: webform_email_categories
 description: 'List of email categories used for sending webform submissions. Each category is associated with an email address.'


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-603

#### Description

This PR aims to limit the configuration possibilities when adding webform paragraphs to content as well as limiting the nesting possibility on specific taxonomy terms to avoid accidentally adding nested terms.

The following changes is done:
- Added and enabled the 'flat_taxonomy' module.
- Enabled flat taxonomy on 'Opening Hours Categories' and 'Webform Email Categories' taxonomies.
- Disabled 'default_data' on webform paragraph, which removes the possibility to add custom YAML configuration on the chosen webform.
