### PR TITLE
Opening hours API cacheable list responses

### DIFF
--- a/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursCreateResource.php
+++ b/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursCreateResource.php
@@ -64,7 +64,10 @@ final class OpeningHoursCreateResource extends OpeningHoursResourceBase {
     try {
       $requestData = $this->deserialize(OpeningHoursRequest::class, $request);
       $instance = $this->mapper->fromRequest($requestData);
+
       $createdInstances = $this->repository->insert($instance);
+      $this->invalidateCache();
+
       $responseData = array_map(function (OpeningHoursInstance $instance) {
         return $this->mapper->toResponse($instance);
       }, $createdInstances);

--- a/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursDeleteResource.php
+++ b/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursDeleteResource.php
@@ -72,6 +72,7 @@ final class OpeningHoursDeleteResource extends OpeningHoursResourceBase {
       throw new BadRequestHttpException("No instance for id '{$id}'");
     }
 
+    $this->invalidateCache();
     return new Response("", Response::HTTP_NO_CONTENT);
   }
 

--- a/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResource.php
+++ b/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResource.php
@@ -6,6 +6,7 @@ namespace Drupal\dpl_opening_hours\Plugin\rest\resource\v1;
 
 use DanskernesDigitaleBibliotek\CMS\Api\Model\DplOpeningHoursListGET200ResponseInner as OpeningHoursResponse;
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Cache\CacheableResponse;
 use Drupal\dpl_opening_hours\Model\OpeningHoursInstance;
 use Drupal\drupal_typed\RequestTyped;
 use Symfony\Component\HttpFoundation\Request;
@@ -97,7 +98,8 @@ final class OpeningHoursResource extends OpeningHoursResourceBase {
         return $this->mapper->toResponse($instance);
       }, $openingHoursInstances);
 
-      return new Response($this->serializer->serialize($responseData, $this->serializerFormat($request)));
+      return (new CacheableResponse($this->serializer->serialize($responseData, $this->serializerFormat($request))))
+        ->addCacheableDependency($this->cachableMetadata());
     }
     catch (\TypeError $e) {
       throw new BadRequestHttpException("Invalid input: {$e->getMessage()}",);

--- a/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResourceBase.php
+++ b/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResourceBase.php
@@ -179,7 +179,10 @@ abstract class OpeningHoursResourceBase extends RestResourceBase {
       // Provide a single cache tag for all responses. This provides a single,
       // simple way to clear the entire response cache when any opening hour
       // is updated.
-      ->setCacheTags([self::CACHE_TAG_LIST])
+      // We also include the list cache tag for opening hours categories to
+      // ensure that any changes here (labels and colors) are reflected
+      // immediately.
+      ->setCacheTags([self::CACHE_TAG_LIST, 'taxonomy_term_list:opening_hours_categories'])
       // Vary all responses based on url. Path and query arguments are used
       // to filter opening hours so this provides individual cache entries
       // per argument combination.
@@ -191,7 +194,7 @@ abstract class OpeningHoursResourceBase extends RestResourceBase {
    */
   protected function invalidateCache(): void {
     // Cache can only be invalidated by tags - not contexts.
-    $this->cacheTagsInvalidator->invalidateTags($this->cachableMetadata()->getCacheTags());
+    $this->cacheTagsInvalidator->invalidateTags([self::CACHE_TAG_LIST]);
   }
 
 }

--- a/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursUpdateResource.php
+++ b/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursUpdateResource.php
@@ -71,9 +71,11 @@ final class OpeningHoursUpdateResource extends OpeningHoursResourceBase {
       if (!$instance) {
         throw new NotFoundHttpException("Invalid instance id: '{$id}'");
       }
-
       $updateInstance = $this->mapper->fromRequest($requestData);
+
       $updatedInstances = $this->repository->update($updateInstance);
+      $this->invalidateCache();
+
       $responseData = array_map(function (OpeningHoursInstance $instance) {
         return $this->mapper->toResponse($instance);
       }, $updatedInstances);


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-634

#### Description

[Add support for caching opening hours list requests](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1104/commits/a1ffa8f3616679fd55216142e9466c41588b49c4)
[a1ffa8f](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1104/commits/a1ffa8f3616679fd55216142e9466c41588b49c4)

This updates the list resource to return cacheable responses. These
can then be cached at different points on the way to the end user -
most prominently in Varnish.

We only use a single cache tag to handle all lists and use cache
contexts to create variations. This way we only have to invalidate
this tag after any operation that might affect any list. Somewhat
crude but also simple.

Update our test to show that cache tags are returned an invalidated
as expected.

#### Additional comments or questions

If you want to test this do the following:

- Go to a page that fetches opening hours in the frontend of your local development environment (patron facing, Swagger UI or curl)
- Check the API response in the developer tools.
- See that the response headers contain `X-Varnish-Cache` and `X-Drupal-Dynamic-Cache`. From now on if you are accessing the API from swagger UI we use the header `X-Drupal-Dynamic-Cache` and from patron facing UIs or Curl ``X-Varnish-Cache`.
- See that it probably says `MISS` on the initial page load
- Refresh the page
- See that the header now says `HIT`
- Update opening hours using the editor, Swagger UI or the like (create, edit or delete and instance)
- Fetch opening hours again
- See that it says `MISS` on the initial request
- Fetch the opening hours again
- See that the header now says `HIT`
- Call the API with other parameters e.g. from date or to date
- See that the header now says `MISS`


API response when using Swagger UI as an authenticated user
![Monosnap OpenAPI Documentation | DPL CMS | Logged in 2024-05-07 10-30-48](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/836e2db8-6381-443c-b127-5cb67886f1ec)

API response when using curl (remember to include `-v` to see headers)

![Monosnap kasper@Hypercycle:~ 2024-05-07 10-33-29](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/d4ff8075-c99d-4e65-8d71-94d0ae667eef)
