### PR TITLE
Prevent failing event deployment hook on new sites

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -10,6 +10,7 @@ tasks:
     - run:
         name: If drupal is not installed
         command: |
+          set -e
           if tables=$(drush sqlq "show tables like 'node';") && [ -z "$tables" ]; then
             # Install and set the admin password to a Lagoon variable if it exists.
             if [[ -n $PR_DRUPAL_PWD ]]; then
@@ -28,6 +29,7 @@ tasks:
     - run:
         name: drush deploy
         command: |
+          set -e
           if [[ -f config/sync/system.site.yml ]]; then
             echo "Config detected, doing a drush deploy"
             drush deploy
@@ -47,6 +49,7 @@ tasks:
         # it will be gone.
         name: Create module upload directory in public files
         command: |
+          set -e
           if [[ ! -d "web/sites/default/files/modules_local" ]]; then
             echo "Creating directory for module uploads"
             mkdir web/sites/default/files/modules_local
@@ -55,12 +58,14 @@ tasks:
     - run:
         name: Import translations
         command: |
+          set -e;
           drush locale-check
           drush locale-update
         service: cli
     - run:
         name: Create test users
         command: |
+          set -e
           drush user:create editor --password="$PR_DRUPAL_PWD"
           drush user:role:add 'editor' editor
 

--- a/web/modules/custom/dpl_event/dpl_event.deploy.php
+++ b/web/modules/custom/dpl_event/dpl_event.deploy.php
@@ -28,15 +28,15 @@ function dpl_event_deploy_port_description_fields() : string {
 function _dpl_event_port_wysiwyg(string $entity_type, string $source_field, string $target_field): string {
   $ids =
     \Drupal::entityQuery($entity_type)
-      ->condition($source_field, '', '<>')
       ->accessCheck(FALSE)
       ->execute();
 
   $entities =
     \Drupal::entityTypeManager()->getStorage($entity_type)->loadMultiple($ids);
 
+  $numEntitiesUpdated = 0;
   foreach ($entities as $entity) {
-    if (!($entity instanceof FieldableEntityInterface) || !$entity->hasField($target_field)) {
+    if (!($entity instanceof FieldableEntityInterface) || !$entity->hasField($source_field) || $entity->get($source_field)->isEmpty() || !$entity->hasField($target_field)) {
       continue;
     }
 
@@ -47,10 +47,12 @@ function _dpl_event_port_wysiwyg(string $entity_type, string $source_field, stri
     $entity->set($target_field, $text);
     $entity->set($source_field, NULL);
     $entity->save();
+
+    $numEntitiesUpdated++;
   }
 
   return t("Updated @count description fields on @entity_type \r\n", [
-    "@count" => count($entities),
+    "@count" => $numEntitiesUpdated,
     "@entity_type" => $entity_type,
   ])->render();
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-760

#### Description

Apparently existing deployment hooks are run on both existing and new installations. This causes problems with an event deployment hook where the entity query refers to a field which does not exists on new installations:

```
[notice] Deploy hook started: dpl_event_deploy_port_description_fields
[error]  'field_event_description' not found
[error]  Deploy hook failed: dpl_event_deploy_port_description_fields
```

Update the deployment hook to load all entities but only affect entities which actually have a nonempty value the source field.

This way the deploy hook can run on new sites but since they do not have the old field - or it is empty because it is hidden - it will not do anything.
