### PR TITLE
Make multiline scripts fail if single command fails

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -10,6 +10,7 @@ tasks:
     - run:
         name: If drupal is not installed
         command: |
+          set -e
           if tables=$(drush sqlq "show tables like 'node';") && [ -z "$tables" ]; then
             # Install and set the admin password to a Lagoon variable if it exists.
             if [[ -n $PR_DRUPAL_PWD ]]; then
@@ -28,6 +29,7 @@ tasks:
     - run:
         name: drush deploy
         command: |
+          set -e
           if [[ -f config/sync/system.site.yml ]]; then
             echo "Config detected, doing a drush deploy"
             drush deploy
@@ -47,6 +49,7 @@ tasks:
         # it will be gone.
         name: Create module upload directory in public files
         command: |
+          set -e
           if [[ ! -d "web/sites/default/files/modules_local" ]]; then
             echo "Creating directory for module uploads"
             mkdir web/sites/default/files/modules_local
@@ -55,12 +58,14 @@ tasks:
     - run:
         name: Import translations
         command: |
+          set -e;
           drush locale-check
           drush locale-update
         service: cli
     - run:
         name: Create test users
         command: |
+          set -e
           drush user:create editor --password="$PR_DRUPAL_PWD"
           drush user:role:add 'editor' editor
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-760

#### Description

We have seen deployments where a command which is a part of the deployment fails but the deployment continues.

Add set -e to all multiline scripts to make them fail the first time a command fails.

This should be added to the .lagoon.yml file for all sites also.

#### Additional comments or questions

This depends on #1112 as the deployments hook currently fail. Without this change they will continue anyway. 