### PR TITLE
Implement a check to warn about branch limit

### DIFF
--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -17,10 +17,25 @@ env:
   LAGOON_PROJECT: "dpl-cms"
 
 jobs:
+  BranchNameLength:
+    name: Check branch length
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Ensure branch name length
+        uses: lekterable/branchlint-action@2.1.0
+        if: github.ref_type == 'branch' || github.ref_type == 'pull_request'
+        with:
+          allowed: |
+            /^.{1,50}$/
+          errorMessage: 'Branch name too long. This cannot be deployed to Lagoon.'
+
   CheckEnvironment:
     name: Check environment
     runs-on: ubuntu-latest
     if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' }}
+    needs: [BranchNameLength]
     permissions:
       # Give the default GITHUB_TOKEN permission to create and update deployments
       deployments: write
@@ -105,6 +120,7 @@ jobs:
   InformLagoon:
     name: Send synthetic event to Lagoon
     runs-on: ubuntu-latest
+    needs: [BranchNameLength]
     steps:
     - name: Send pull request event
       uses: distributhor/workflow-webhook@v3


### PR DESCRIPTION
#### Description

When trying to create a PR environment with a long branch name the
PR environment is not created.

Looking into Lagoon API internals yields the error:

[2024-05-06 10:44:39] [error]: GraphQL field error `addOrUpdateEnvironment`: (conn=248247, no: 1406, SQLState: 22001) Data too long for column 'deploy_head_ref' at row 1
sql: insert into `environment` (`deleted`, `deploy_base_ref`, `deploy_head_ref`, `deploy_title`, `deploy_type`, `environment_type`, `name`, `openshift`, `openshift_project_name`, `openshift_project_pattern`, `project`) values (0, 'release/brahma-15-1', 'DDFLSBP-615-efter-registrering-skal-laner-force-logges-ud-og-blive-sendt-til-login-i-adgangsplatformen', 'Change post register step to keep on serving PatronRegistrationBlock', 'pullrequest', 'development', 'pr-1101', 1, 'dpl-cms-pr-1101', NULL, 1) on duplicate key update `updated` = CURRENT_TIMESTAMP,`deploy_base_ref` = 'release/brahma-15-1',`deploy_head_ref` = 'DDFLSBP-615-efter-registrering-skal-laner-force-logges-ud-og-blive-sendt-til-login-i-adgangsplatformen',`deploy_title` = 'Change post register step to keep on serving PatronRegistrationBlock',`deploy_type` = 'pullrequest',`environment_type` = 'development' - parameters:{}

As a result of this we want to warn developers in a more visible way
when branch length causes errors.

This introduces a new job in GitHub Actions which fails if the branch
length is over 50 characters long.

Other Lagoon related jobs are set to depend on this job to avoid
running them when the branch name causes problems.

I chose lekterable/branchlint-action to solve this because it supports
the needed features and seems be both maintained (recently updated)
and somewhat popular within this space.

#### Additional comments or questions

#1117 shows that this works.