### PR TITLE
Related-content slider on articles and eventinstances. DDFFORM-394

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -58,6 +58,7 @@ module:
   dpl_react: 0
   dpl_react_apps: 0
   dpl_recommender: 0
+  dpl_related_content: 0
   dpl_reservations: 0
   dpl_rest_base: 0
   dpl_something_similar: 0

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,6 +13,10 @@ parameters:
     # more detailed typing of.
     - '#.*\:\:(buildForm|getEditableConfigNames|submitForm|validateForm)\(\) .* no value type specified in iterable type array\.#'
     - '#_alter\(\) has parameter \$form with no value type specified in iterable type array\.#'
+    # Drupal *_theme() implementation returns array which we cannot provide more detailed typing of.
+    - '#Function .*_theme\(\) return type has no value type specified in iterable type array\.#'
+    # Drupal *_theme() uses arrays which we cannot provide more detailed typing of.
+    - '#Function .*_theme\(\) has parameter .* with no value type specified in iterable type array\.#'
     # Drupal preprocess functions uses variables array which we cannot provide more detailed typing of.
     - '#Function .*_preprocess_.*\(\) has parameter \$variables with no value type specified in iterable type array\.#'
     # Drupal theme suggestions uses arrays which we cannot provide more detailed typing of.

--- a/web/modules/custom/dpl_react/dpl_react.module
+++ b/web/modules/custom/dpl_react/dpl_react.module
@@ -84,20 +84,6 @@ function dpl_react_cover_service_url(): string {
 
 /**
  * Implements hook_theme().
- *
- * @param mixed[] $existing
- *   An array of existing implementations that may be used
- *   for override purposes.
- * @param string $type
- *   Whether a theme, module, etc. is being processed.
- * @param string $theme
- *   The actual name of theme, module, etc. that is being being processed.
- * @param string $path
- *   The directory path of the theme or module,
- *   so that it doesn't need to be looked up.
- *
- * @return mixed[]
- *   An associative array of information about theme implementations.
  */
 function dpl_react_theme(
   array $existing,

--- a/web/modules/custom/dpl_related_content/dpl_related_content.info.yml
+++ b/web/modules/custom/dpl_related_content/dpl_related_content.info.yml
@@ -1,5 +1,5 @@
 name: DPL related content
 description: Showing related content as a slider on articles and eventinstances.
-package: DDB
+package: DPL
 type: module
 core_version_requirement: ^10

--- a/web/modules/custom/dpl_related_content/dpl_related_content.info.yml
+++ b/web/modules/custom/dpl_related_content/dpl_related_content.info.yml
@@ -1,0 +1,5 @@
+name: DPL related content
+description: Showing related content as a slider on articles and eventinstances.
+package: DDB
+type: module
+core_version_requirement: ^10

--- a/web/modules/custom/dpl_related_content/dpl_related_content.module
+++ b/web/modules/custom/dpl_related_content/dpl_related_content.module
@@ -1,0 +1,292 @@
+<?php
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\recurring_events\Entity\EventInstance;
+
+/**
+ * Get terms from field as an array of IDs.
+ *
+ * @return array<int>
+ *   Term IDs.
+ */
+function _dpl_related_content_get_term_ids(FieldableEntityInterface $entity, string $field_name): array {
+  if (!$entity->hasField($field_name)) {
+    return [];
+  }
+
+  $terms = $entity->get($field_name)->getValue();
+  return array_column($terms, 'target_id');
+
+}
+
+/**
+ * Get matching eventinstance IDs.
+ *
+ * Allows for passing along various term IDs, that we look for in an OR group.
+ * Notice - we only look for the term values on series level, ignoring
+ * inheritance overriding in favor of a simpler codebase.
+ *
+ * @param string|null $current_uuid
+ *   A possible entity UUID, that will not get included in results.
+ * @param array<int> $tags
+ *   Tag term IDs, to look for.
+ * @param array<int> $categories
+ *   Category term IDs, to look for.
+ * @param array<int> $branches
+ *   Branch term IDs, to look for.
+ *
+ * @return array<int|string>
+ *   Matching eventinstance IDs
+ *
+ * @throws \Exception
+ */
+function _dpl_related_content_get_eventinstance_ids(?string $current_uuid, array $tags = [], array $categories = [], array $branches = []): array {
+  $date = new DrupalDateTime('today');
+  $date->setTimezone(new \DateTimezone(DateTimeItemInterface::STORAGE_TIMEZONE));
+  $formatted_date = $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
+
+  $connection = Database::getConnection();
+
+  // Prepare a subquery for eventseries IDs based on terms.
+  $subquery = $connection->select('eventseries', 'es');
+  $subquery->fields('es', ['id']);
+
+  // Join the term field tables.
+  // @todo this only looks at the values on the eventseries.
+  // Ideally, we'd want to also look if values exist on the instance level.
+  $subquery->leftJoin('eventseries__field_tags', 'es_tags', 'es.id = es_tags.entity_id');
+  $subquery->leftJoin('eventseries__field_categories', 'es_cats', 'es.id = es_cats.entity_id');
+  $subquery->leftJoin('eventseries__field_branch', 'es_bra', 'es.id = es_bra.entity_id');
+
+  if (!empty($tags) || !empty($categories) || !empty($branches)) {
+    $or_group = $subquery->orConditionGroup();
+
+    // To avoid errors, related to the OR GROUP only containing one condition,
+    // we'll add a fake condition to fill out a possible empty space.
+    $or_group->condition('title', 'ALWAYS_FALSE');
+
+    if (!empty($tags)) {
+      $or_group->condition('es_tags.field_tags_target_id', $tags, 'IN');
+    }
+
+    if (!empty($categories)) {
+      $or_group->condition('es_cats.field_categories_target_id', $categories, 'IN');
+    }
+
+    if (!empty($branches)) {
+      $or_group->condition('es_bra.field_branch_target_id', $branches, 'IN');
+    }
+
+    $subquery->condition($or_group);
+  }
+
+  $subquery->distinct(TRUE);
+
+  // Main query to select eventinstance ids, joining with
+  // eventinstance_field_data for condition fields.
+  $query = $connection->select('eventinstance_field_data', 'eid');
+  $query->join('eventinstance', 'ei', 'ei.id = eid.id');
+  $query->addField('eid', 'id', 'eventinstance_id');
+
+  if (!empty($tags) || !empty($categories) || !empty($branches)) {
+    // Use the subquery to filter by eventseries_id.
+    $query->condition('eid.eventseries_id', $subquery, 'IN');
+  }
+
+  $query->condition('ei.uuid', $current_uuid, '<>');
+
+  // We only want events in the future (e.g. - active events).
+  $query->condition('eid.date__value', $formatted_date, '>=');
+  $query->orderBy('eid.date__value', 'ASC');
+  $query->range(0, 16);
+
+  // Add a GROUP BY clause to make results distinct by eventseries_id.
+  $query->groupBy('eid.eventseries_id');
+
+  // Execute the query and return ids.
+  $result = $query->execute();
+
+  return $result?->fetchCol() ?? [];
+}
+
+/**
+ * Get matching node IDs.
+ *
+ * Allows for passing along various term IDs, that we look for in an OR group.
+ *
+ * @param string|null $current_uuid
+ *   A possible entity UUID, that will not get included in results.
+ * @param array<int> $tags
+ *   Tag term IDs, to look for.
+ * @param array<int> $categories
+ *   Category term IDs, to look for.
+ *
+ * @return array<int|string>
+ *   Matching article node IDs
+ */
+function _dpl_related_content_get_article_ids(?string $current_uuid, array $tags = [], array $categories = []): array {
+  $query = \Drupal::entityQuery('node')->accessCheck(TRUE)
+    ->condition('type', 'article')
+    ->condition('uuid', $current_uuid, '<>')
+    ->sort('created', 'DESC')
+    ->range(0, 16);
+
+  // To avoid errors, related to the OR GROUP only containing one condition,
+  // we'll add a fake condition to fill out a possible empty space.
+  if (!empty($tags) || !empty($categories)) {
+    // Use a condition group for OR logic.
+    $or_group = $query->orConditionGroup();
+
+    $or_group->condition('title', 'ALWAYS_FALSE');
+
+    if (!empty($tags)) {
+      $or_group->condition('field_tags', $tags, 'IN');
+    }
+
+    if (!empty($categories)) {
+      $or_group->condition('field_categories', $categories, 'IN');
+    }
+
+    $query->condition($or_group);
+  }
+
+  return $query->execute();
+}
+
+/**
+ * Get renderable, related content, based on current entities fields.
+ *
+ * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+ *   The current entity, to match results against.
+ *
+ * @return array<mixed>
+ *   Render arrays of eventinstances and nodes.
+ *
+ * @throws \Exception
+ */
+function _dpl_related_content_get_content(FieldableEntityInterface $entity): array {
+  $current_uuid = $entity->uuid();
+
+  $tags_field_name = 'field_tags';
+  $categories_field_name = 'field_categories';
+  $branches_field_name = 'field_branch';
+
+  // Eventinstances have different field names, as they use inheritance.
+  if ($entity instanceof EventInstance) {
+    $tags_field_name = 'event_tags';
+    $categories_field_name = 'event_categories';
+    $branches_field_name = 'branch';
+  }
+
+  $tags = _dpl_related_content_get_term_ids($entity, $tags_field_name);
+  $categories = _dpl_related_content_get_term_ids($entity, $categories_field_name);
+  $branches = _dpl_related_content_get_term_ids($entity, $branches_field_name);
+  $event_ids = [];
+  $article_ids = [];
+
+  if (!empty($tags)) {
+    // First, let's look up related content, based only on tags.
+    $event_ids = _dpl_related_content_get_eventinstance_ids($current_uuid, $tags);
+    $article_ids = _dpl_related_content_get_article_ids($current_uuid, $tags);
+  }
+
+  // If we found less than 4 results, we'll add categories to the mix in
+  // addition to tags.
+  if ((count($event_ids) + count($article_ids) < 4) && !empty($categories)) {
+
+    $event_ids = _dpl_related_content_get_eventinstance_ids($current_uuid, $tags, $categories);
+    $article_ids = _dpl_related_content_get_article_ids($current_uuid, $tags, $categories);
+  }
+
+  // If the count is still under 4, and we're on an event-page, we'll look up
+  // events with the same location.
+  if ((count($event_ids) + count($article_ids) < 4) && ($entity instanceof EventInstance) && !empty($branches)) {
+
+    $event_ids = _dpl_related_content_get_eventinstance_ids($current_uuid, $tags, $categories, $branches);
+  }
+
+  // If the count is still under 4, we'll find the upcoming events, and the
+  // latest articles instead.
+  if (count($event_ids) + count($article_ids) < 4) {
+    $event_ids = _dpl_related_content_get_eventinstance_ids($current_uuid);
+    $article_ids = _dpl_related_content_get_article_ids($current_uuid);
+  }
+
+  // If we still have less than 4, we just won't display anything.
+  if (count($event_ids) + count($article_ids) < 4) {
+    return [];
+  }
+
+  $events = EventInstance::loadMultiple($event_ids);
+  $articles = Node::loadMultiple($article_ids);
+
+  // We want to combine events and articles into a single array, however,
+  // we want to interlace them, so it becomes mixed, rather than just
+  // all the articles and then all the events.
+  // We could also sort the merging based on the actual date values, but this
+  // will be too expensive for what it is worth.
+  $content = [];
+
+  // Remove array keys, so we can do the sorting.
+  $events = array_values($events);
+  $articles = array_values($articles);
+
+  $node_view_builder = \Drupal::entityTypeManager()->getViewBuilder('node');
+  $event_view_builder = \Drupal::entityTypeManager()->getViewBuilder('eventinstance');
+
+  // First, we find the longer array.
+  $length = max(count($events), count($articles));
+
+  for ($i = 0; $i < $length; $i++) {
+    if (isset($events[$i])) {
+      $content[] = $event_view_builder->view($events[$i], 'card');
+    }
+
+    if (isset($articles[$i])) {
+      $content[] = $node_view_builder->view($articles[$i], 'card');
+    }
+  }
+
+  return $content;
+}
+
+/**
+ * Place a dynamic 'related content' list on articles and eventinstances.
+ *
+ * Content displayed is based on the field values of the current page entity.
+ */
+function dpl_related_content_preprocess_page(array &$variables): void {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  // We only want to display the related content slider on eventinstances, OR
+  // on article nodes.
+  if ($route_name === 'entity.node.canonical') {
+    $entity = \Drupal::routeMatch()->getParameter('node');
+
+    if (!($entity instanceof NodeInterface) || $entity->bundle() !== 'article') {
+      return;
+    }
+  }
+  elseif ($route_name === 'entity.eventinstance.canonical') {
+    $entity = \Drupal::routeMatch()->getParameter('eventinstance');
+  }
+  else {
+    return;
+  }
+
+  if (!($entity instanceof FieldableEntityInterface)) {
+    return;
+  }
+
+  try {
+    $variables['related_content'] = _dpl_related_content_get_content($entity);
+  }
+  catch (\Exception $e) {
+    \Drupal::logger('dpl_related_content')->error('Could not render related content slider.');
+  }
+}

--- a/web/modules/custom/dpl_related_content/dpl_related_content.module
+++ b/web/modules/custom/dpl_related_content/dpl_related_content.module
@@ -1,259 +1,9 @@
 <?php
 
-use Drupal\Core\Database\Database;
-use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\FieldableEntityInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
-use Drupal\node\Entity\Node;
+use Drupal\dpl_related_content\Services\RelatedContent;
+use Drupal\drupal_typed\DrupalTyped;
 use Drupal\node\NodeInterface;
-use Drupal\recurring_events\Entity\EventInstance;
-
-/**
- * Get terms from field as an array of IDs.
- *
- * @return array<int>
- *   Term IDs.
- */
-function _dpl_related_content_get_term_ids(FieldableEntityInterface $entity, string $field_name): array {
-  if (!$entity->hasField($field_name)) {
-    return [];
-  }
-
-  $terms = $entity->get($field_name)->getValue();
-  return array_column($terms, 'target_id');
-
-}
-
-/**
- * Get matching eventinstance IDs.
- *
- * Allows for passing along various term IDs, that we look for in an OR group.
- * Notice - we only look for the term values on series level, ignoring
- * inheritance overriding in favor of a simpler codebase.
- *
- * @param string|null $current_uuid
- *   A possible entity UUID, that will not get included in results.
- * @param array<int> $tags
- *   Tag term IDs, to look for.
- * @param array<int> $categories
- *   Category term IDs, to look for.
- * @param array<int> $branches
- *   Branch term IDs, to look for.
- *
- * @return array<int|string>
- *   Matching eventinstance IDs
- *
- * @throws \Exception
- */
-function _dpl_related_content_get_eventinstance_ids(?string $current_uuid, array $tags = [], array $categories = [], array $branches = []): array {
-  $date = new DrupalDateTime('today');
-  $date->setTimezone(new \DateTimezone(DateTimeItemInterface::STORAGE_TIMEZONE));
-  $formatted_date = $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
-
-  $connection = Database::getConnection();
-
-  // Prepare a subquery for eventseries IDs based on terms.
-  $subquery = $connection->select('eventseries', 'es');
-  $subquery->fields('es', ['id']);
-
-  // Join the term field tables.
-  // @todo this only looks at the values on the eventseries.
-  // Ideally, we'd want to also look if values exist on the instance level.
-  $subquery->leftJoin('eventseries__field_tags', 'es_tags', 'es.id = es_tags.entity_id');
-  $subquery->leftJoin('eventseries__field_categories', 'es_cats', 'es.id = es_cats.entity_id');
-  $subquery->leftJoin('eventseries__field_branch', 'es_bra', 'es.id = es_bra.entity_id');
-
-  if (!empty($tags) || !empty($categories) || !empty($branches)) {
-    $or_group = $subquery->orConditionGroup();
-
-    // To avoid errors, related to the OR GROUP only containing one condition,
-    // we'll add a fake condition to fill out a possible empty space.
-    $or_group->condition('title', 'ALWAYS_FALSE');
-
-    if (!empty($tags)) {
-      $or_group->condition('es_tags.field_tags_target_id', $tags, 'IN');
-    }
-
-    if (!empty($categories)) {
-      $or_group->condition('es_cats.field_categories_target_id', $categories, 'IN');
-    }
-
-    if (!empty($branches)) {
-      $or_group->condition('es_bra.field_branch_target_id', $branches, 'IN');
-    }
-
-    $subquery->condition($or_group);
-  }
-
-  $subquery->distinct(TRUE);
-
-  // Main query to select eventinstance ids, joining with
-  // eventinstance_field_data for condition fields.
-  $query = $connection->select('eventinstance_field_data', 'eid');
-  $query->join('eventinstance', 'ei', 'ei.id = eid.id');
-  $query->addField('eid', 'id', 'eventinstance_id');
-
-  if (!empty($tags) || !empty($categories) || !empty($branches)) {
-    // Use the subquery to filter by eventseries_id.
-    $query->condition('eid.eventseries_id', $subquery, 'IN');
-  }
-
-  $query->condition('ei.uuid', $current_uuid, '<>');
-
-  // We only want events in the future (e.g. - active events).
-  $query->condition('eid.date__value', $formatted_date, '>=');
-  $query->orderBy('eid.date__value', 'ASC');
-  $query->range(0, 16);
-
-  // Add a GROUP BY clause to make results distinct by eventseries_id.
-  $query->groupBy('eid.eventseries_id');
-
-  // Execute the query and return ids.
-  $result = $query->execute();
-
-  return $result?->fetchCol() ?? [];
-}
-
-/**
- * Get matching node IDs.
- *
- * Allows for passing along various term IDs, that we look for in an OR group.
- *
- * @param string|null $current_uuid
- *   A possible entity UUID, that will not get included in results.
- * @param array<int> $tags
- *   Tag term IDs, to look for.
- * @param array<int> $categories
- *   Category term IDs, to look for.
- *
- * @return array<int|string>
- *   Matching article node IDs
- */
-function _dpl_related_content_get_article_ids(?string $current_uuid, array $tags = [], array $categories = []): array {
-  $query = \Drupal::entityQuery('node')->accessCheck(TRUE)
-    ->condition('type', 'article')
-    ->condition('uuid', $current_uuid, '<>')
-    ->sort('created', 'DESC')
-    ->range(0, 16);
-
-  // To avoid errors, related to the OR GROUP only containing one condition,
-  // we'll add a fake condition to fill out a possible empty space.
-  if (!empty($tags) || !empty($categories)) {
-    // Use a condition group for OR logic.
-    $or_group = $query->orConditionGroup();
-
-    $or_group->condition('title', 'ALWAYS_FALSE');
-
-    if (!empty($tags)) {
-      $or_group->condition('field_tags', $tags, 'IN');
-    }
-
-    if (!empty($categories)) {
-      $or_group->condition('field_categories', $categories, 'IN');
-    }
-
-    $query->condition($or_group);
-  }
-
-  return $query->execute();
-}
-
-/**
- * Get renderable, related content, based on current entities fields.
- *
- * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
- *   The current entity, to match results against.
- *
- * @return array<mixed>
- *   Render arrays of eventinstances and nodes.
- *
- * @throws \Exception
- */
-function _dpl_related_content_get_content(FieldableEntityInterface $entity): array {
-  $current_uuid = $entity->uuid();
-
-  $tags_field_name = 'field_tags';
-  $categories_field_name = 'field_categories';
-  $branches_field_name = 'field_branch';
-
-  // Eventinstances have different field names, as they use inheritance.
-  if ($entity instanceof EventInstance) {
-    $tags_field_name = 'event_tags';
-    $categories_field_name = 'event_categories';
-    $branches_field_name = 'branch';
-  }
-
-  $tags = _dpl_related_content_get_term_ids($entity, $tags_field_name);
-  $categories = _dpl_related_content_get_term_ids($entity, $categories_field_name);
-  $branches = _dpl_related_content_get_term_ids($entity, $branches_field_name);
-  $event_ids = [];
-  $article_ids = [];
-
-  if (!empty($tags)) {
-    // First, let's look up related content, based only on tags.
-    $event_ids = _dpl_related_content_get_eventinstance_ids($current_uuid, $tags);
-    $article_ids = _dpl_related_content_get_article_ids($current_uuid, $tags);
-  }
-
-  // If we found less than 4 results, we'll add categories to the mix in
-  // addition to tags.
-  if ((count($event_ids) + count($article_ids) < 4) && !empty($categories)) {
-
-    $event_ids = _dpl_related_content_get_eventinstance_ids($current_uuid, $tags, $categories);
-    $article_ids = _dpl_related_content_get_article_ids($current_uuid, $tags, $categories);
-  }
-
-  // If the count is still under 4, and we're on an event-page, we'll look up
-  // events with the same location.
-  if ((count($event_ids) + count($article_ids) < 4) && ($entity instanceof EventInstance) && !empty($branches)) {
-
-    $event_ids = _dpl_related_content_get_eventinstance_ids($current_uuid, $tags, $categories, $branches);
-  }
-
-  // If the count is still under 4, we'll find the upcoming events, and the
-  // latest articles instead.
-  if (count($event_ids) + count($article_ids) < 4) {
-    $event_ids = _dpl_related_content_get_eventinstance_ids($current_uuid);
-    $article_ids = _dpl_related_content_get_article_ids($current_uuid);
-  }
-
-  // If we still have less than 4, we just won't display anything.
-  if (count($event_ids) + count($article_ids) < 4) {
-    return [];
-  }
-
-  $events = EventInstance::loadMultiple($event_ids);
-  $articles = Node::loadMultiple($article_ids);
-
-  // We want to combine events and articles into a single array, however,
-  // we want to interlace them, so it becomes mixed, rather than just
-  // all the articles and then all the events.
-  // We could also sort the merging based on the actual date values, but this
-  // will be too expensive for what it is worth.
-  $content = [];
-
-  // Remove array keys, so we can do the sorting.
-  $events = array_values($events);
-  $articles = array_values($articles);
-
-  $node_view_builder = \Drupal::entityTypeManager()->getViewBuilder('node');
-  $event_view_builder = \Drupal::entityTypeManager()->getViewBuilder('eventinstance');
-
-  // First, we find the longer array.
-  $length = max(count($events), count($articles));
-
-  for ($i = 0; $i < $length; $i++) {
-    if (isset($events[$i])) {
-      $content[] = $event_view_builder->view($events[$i], 'card');
-    }
-
-    if (isset($articles[$i])) {
-      $content[] = $node_view_builder->view($articles[$i], 'card');
-    }
-  }
-
-  return $content;
-}
 
 /**
  * Place a dynamic 'related content' list on articles and eventinstances.
@@ -284,9 +34,28 @@ function dpl_related_content_preprocess_page(array &$variables): void {
   }
 
   try {
-    $variables['related_content'] = _dpl_related_content_get_content($entity);
+    $service = DrupalTyped::service(RelatedContent::class, 'dpl_related_content.related_content');
+
+    $variables['related_content'] = $service->getContentFromEntity($entity);
   }
   catch (\Exception $e) {
-    \Drupal::logger('dpl_related_content')->error('Could not render related content slider.');
+    \Drupal::logger('dpl_related_content')->error(
+      'Could not render related content slider. Exception: {exception}',
+      ['exception' => $e->getMessage()]
+    );
   }
+}
+
+/**
+ * Implements hook_theme().
+ */
+function dpl_related_content_theme(array $existing, string $type, string $theme, string $path): array {
+  return [
+    'dpl_related_content_slider' => [
+      'variables' => [
+        'title' => t('Related content', [], ['context' => 'DPL related content']),
+        'items' => [],
+      ],
+    ],
+  ];
 }

--- a/web/modules/custom/dpl_related_content/dpl_related_content.module
+++ b/web/modules/custom/dpl_related_content/dpl_related_content.module
@@ -40,8 +40,8 @@ function dpl_related_content_preprocess_page(array &$variables): void {
   }
   catch (\Exception $e) {
     \Drupal::logger('dpl_related_content')->error(
-      'Could not render related content slider. Exception: {exception}',
-      ['exception' => $e->getMessage()]
+      'Could not render related content slider. Exception: @exception',
+      ['@exception' => $e->getMessage()]
     );
   }
 }

--- a/web/modules/custom/dpl_related_content/dpl_related_content.services.yml
+++ b/web/modules/custom/dpl_related_content/dpl_related_content.services.yml
@@ -1,4 +1,4 @@
 services:
   dpl_related_content.related_content:
     class: Drupal\dpl_related_content\Services\RelatedContent
-    arguments: ["@entity_type.manager"]
+    arguments: ["@entity_type.manager", "@database"]

--- a/web/modules/custom/dpl_related_content/dpl_related_content.services.yml
+++ b/web/modules/custom/dpl_related_content/dpl_related_content.services.yml
@@ -1,0 +1,4 @@
+services:
+  dpl_related_content.related_content:
+    class: Drupal\dpl_related_content\Services\RelatedContent
+    arguments: ["@entity_type.manager"]

--- a/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
+++ b/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
@@ -164,17 +164,23 @@ class RelatedContent {
     // We find the longer array, to do a simple FOR loop.
     $length = max(count($events), count($nodes));
 
-    for ($i = 0; $i < $length; $i++) {
+    for ($i = 0; $i < $length;) {
       if ($i >= $this->maxItems) {
         break;
       }
 
       if (isset($events[$i])) {
         $content[] = $event_view_builder->view($events[$i], 'card');
+        $i++;
+      }
+
+      if ($i >= $this->maxItems) {
+        break;
       }
 
       if (isset($nodes[$i])) {
         $content[] = $node_view_builder->view($nodes[$i], 'card');
+        $i++;
       }
     }
 
@@ -216,9 +222,12 @@ class RelatedContent {
 
     $query->accessCheck(TRUE);
 
+    if (!empty($excluded_uuid)) {
+      $query->condition('uuid', $excluded_uuid, '<>');
+    }
+
     $query
       ->condition('type', $this->nodeBundles, 'IN')
-      ->condition('uuid', $excluded_uuid, '<>')
       ->sort($this->nodeSortField, 'DESC')
       // We know that we will never need more than the maximum items,
       // so we will limit the query to this.
@@ -327,7 +336,9 @@ class RelatedContent {
       $query->condition('eid.eventseries_id', $subquery, 'IN');
     }
 
-    $query->condition('ei.uuid', $excluded_uuid, '<>');
+    if (!empty($excluded_uuid)) {
+      $query->condition('ei.uuid', $excluded_uuid, '<>');
+    }
 
     // The consequence of direct DB that we cant use ->access(TRUE),
     // so instead, we'll only look up published eventinstances.

--- a/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
+++ b/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
@@ -1,0 +1,371 @@
+<?php
+
+namespace Drupal\dpl_related_content\Services;
+
+use Drupal\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Database\Database;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\recurring_events\Entity\EventInstance;
+
+/**
+ * Load related nodes and events, based on filters.
+ */
+class RelatedContent {
+
+  /**
+   * The entity type interface.
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The minimum of items that must be in the slider.
+   */
+  private int $minItems = 4;
+
+  /**
+   * How many items we max display in the slider.
+   */
+  private int $maxItems = 16;
+
+  /**
+   * The field on nodes, to sort by.
+   */
+  private string $nodeSortField = 'created';
+
+  /**
+   * The node bundles that should show up in the results.
+   *
+   * @var array|string[]
+   *  List of node bundles - e.g. articles.
+   */
+  private array $nodeBundles = ['article'];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * Get related content, based on the value context of an entity.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity to check against.
+   *
+   * @return array<mixed>
+   *   List of content render arrays.
+   */
+  public function getContentFromEntity(FieldableEntityInterface $entity) {
+    $excluded_uuid = $entity->uuid();
+
+    $tags_field_name = 'field_tags';
+    $categories_field_name = 'field_categories';
+    $branches_field_name = 'field_branch';
+
+    // Eventinstances have different field names, as they use inheritance.
+    if ($entity instanceof EventInstance) {
+      $tags_field_name = 'event_tags';
+      $categories_field_name = 'event_categories';
+      $branches_field_name = 'branch';
+    }
+
+    $tags = $this->getTermIds($entity, $tags_field_name);
+    $categories = $this->getTermIds($entity, $categories_field_name);
+    $branches = $this->getTermIds($entity, $branches_field_name);
+
+    return $this->getContent($excluded_uuid, $tags, $categories, $branches);
+  }
+
+  /**
+   * Get matching node IDs.
+   *
+   * Allows for passing along various term IDs, that we look for in an OR group.
+   *
+   * @param string|null $excluded_uuid
+   *   A possible entity UUID, that will not get included in results.
+   *   We use UUID instead of IDs, as UUID will be unique across entity types,
+   *   and means we don't need to worry about sending a node UUID along to a
+   *   event query.
+   * @param array<int> $tags
+   *   Tag term IDs, to look for.
+   * @param array<int> $categories
+   *   Category term IDs, to look for.
+   * @param array<int> $branches
+   *   Branch term IDs, to look for.
+   *
+   * @return array<mixed>
+   *   List of content render arrays.
+   */
+  public function getContent(?string $excluded_uuid = NULL, $tags = [], $categories = [], $branches = []): array {
+    $event_ids = [];
+    $node_ids = [];
+
+    // First, let's look up related content, based only on tags.
+    if (!empty($tags)) {
+      $node_ids = $this->getNodeIds($excluded_uuid, $tags);
+      $event_ids = $this->getEventInstanceIds($excluded_uuid, $tags);
+    }
+
+    // If we found less than minimum results, we'll add categories to the mix in
+    // addition to tags.
+    if ((count($event_ids) + count($node_ids) < $this->minItems) && !empty($categories)) {
+      $node_ids = $this->getNodeIds($excluded_uuid, $tags, $categories);
+      $event_ids = $this->getEventInstanceIds($excluded_uuid, $tags, $categories);
+    }
+
+    // If we found less than minimum results, we'll add branches to the mix in
+    // addition to tags and categories.
+    if ((count($event_ids) + count($node_ids) < $this->minItems) && !empty($branches)) {
+      $node_ids = $this->getNodeIds($excluded_uuid, $tags, $categories, $branches);
+      $event_ids = $this->getEventInstanceIds($excluded_uuid, $tags, $categories, $branches);
+    }
+
+    // If the count is still under minimum, we'll find the upcoming events,
+    // and the latest nodes instead.
+    if (count($event_ids) + count($node_ids) < $this->minItems) {
+      $node_ids = $this->getNodeIds($excluded_uuid);
+      $event_ids = $this->getEventInstanceIds($excluded_uuid);
+    }
+
+    // If we still have less than minimum, we just won't display anything.
+    if (count($event_ids) + count($node_ids) < $this->minItems) {
+      return [];
+    }
+
+    $events = $this->entityTypeManager->getStorage('eventinstance')->loadMultiple($event_ids);
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($node_ids);
+
+    // We want to combine events and nodes into a single array, however,
+    // we want to interlace them, so it becomes mixed, rather than just
+    // all the nodes and then all the events.
+    // We could also sort the merging based on the actual date values, but this
+    // will be too expensive for what it is worth.
+    $content = [];
+
+    // Remove array keys, so we can do the sorting.
+    $events = array_values($events);
+    $nodes = array_values($nodes);
+
+    $node_view_builder = $this->entityTypeManager->getViewBuilder('node');
+    $event_view_builder = $this->entityTypeManager->getViewBuilder('eventinstance');
+
+    // We find the longer array, to do a simple FOR loop.
+    $length = max(count($events), count($nodes));
+
+    for ($i = 0; $i < $length; $i++) {
+      if ($i >= $this->maxItems) {
+        break;
+      }
+
+      if (isset($events[$i])) {
+        $content[] = $event_view_builder->view($events[$i], 'card');
+      }
+
+      if (isset($nodes[$i])) {
+        $content[] = $node_view_builder->view($nodes[$i], 'card');
+      }
+    }
+
+    return [
+      '#theme' => 'dpl_related_content_slider',
+      '#items' => $content,
+      // The results should be cached, but, they have a lot of dependencies -
+      // even depending on the current time (finding future events).
+      // The individual peices of content are cached themselves, so for the full
+      // result list, we'll add an easily-invalidated cache, with a bunch of
+      // cache tags, and even a time-based cache.
+      '#cache' => [
+        // Max age of 12 hours.
+        '#max-age' => (60 * 60 * 12),
+        '#tags' => ['eventinstance_list', 'eventseries_list', 'node_list'],
+      ],
+    ];
+  }
+
+  /**
+   * Get matching node IDs.
+   *
+   * Allows for passing along various term IDs, that we look for in an OR group.
+   *
+   * @param string|null $excluded_uuid
+   *   A possible entity UUID, that will not get included in results.
+   * @param array<int> $tags
+   *   Tag term IDs, to look for.
+   * @param array<int> $categories
+   *   Category term IDs, to look for.
+   * @param array<int> $branches
+   *   Branch term IDs, to look for.
+   *
+   * @return array<int|string>
+   *   Matching node IDs
+   */
+  private function getNodeIds(?string $excluded_uuid = NULL, array $tags = [], array $categories = [], array $branches = []): array {
+    $query = $this->entityTypeManager->getStorage('node')->getQuery();
+
+    $query->accessCheck(TRUE);
+
+    $query
+      ->condition('type', $this->nodeBundles, 'IN')
+      ->condition('uuid', $excluded_uuid, '<>')
+      ->sort($this->nodeSortField, 'DESC')
+      // We know that we will never need more than the maximum items,
+      // so we will limit the query to this.
+      ->range(0, $this->maxItems);
+
+    if (!empty($tags) || !empty($categories) || empty($branches)) {
+      // Use a condition group for OR logic.
+      $or_group = $query->orConditionGroup();
+
+      // To avoid errors, related to the OR GROUP only containing one condition,
+      // we'll add a fake condition to fill out a possible empty space.
+      $or_group->condition('title', 'ALWAYS_FALSE');
+
+      if (!empty($tags)) {
+        $or_group->condition('field_tags', $tags, 'IN');
+      }
+
+      if (!empty($categories)) {
+        $or_group->condition('field_categories', $categories, 'IN');
+      }
+
+      if (!empty($branches)) {
+        $or_group->condition('field_branch', $branches, 'IN');
+      }
+
+      $query->condition($or_group);
+    }
+
+    return $query->execute();
+  }
+
+  /**
+   * Get matching eventinstance IDs.
+   *
+   * Allows for passing along various term IDs, that we look for in an OR group.
+   * Notice - we only look for the term values on series level, ignoring
+   * inheritance overriding in favor of a simpler codebase.
+   *
+   * @param string|null $excluded_uuid
+   *   A possible entity UUID, that will not get included in results.
+   * @param array<int> $tags
+   *   Tag term IDs, to look for.
+   * @param array<int> $categories
+   *   Category term IDs, to look for.
+   * @param array<int> $branches
+   *   Branch term IDs, to look for.
+   *
+   * @return array<int|string>
+   *   Matching eventinstance IDs
+   *
+   * @throws \Exception
+   */
+  private function getEventInstanceIds(?string $excluded_uuid = NULL, array $tags = [], array $categories = [], array $branches = []): array {
+    $date = new DrupalDateTime('today');
+    $date->setTimezone(new \DateTimezone(DateTimeItemInterface::STORAGE_TIMEZONE));
+    $formatted_date = $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
+
+    // Ideally, we'd use EntityQueries instead of a direct DB connection, but
+    // because we need to do some pretty complicated JOINs and subqueries, it
+    // is not an option.
+    $connection = Database::getConnection();
+
+    // Prepare a subquery for eventseries IDs based on terms.
+    $subquery = $connection->select('eventseries', 'es');
+    $subquery->fields('es', ['id']);
+
+    // Join the term field tables.
+    // @todo this only looks at the values on the eventseries.
+    // Ideally, we'd want to also look if values exist on the instance level.
+    $subquery->leftJoin('eventseries__field_tags', 'es_tags', 'es.id = es_tags.entity_id');
+    $subquery->leftJoin('eventseries__field_categories', 'es_cats', 'es.id = es_cats.entity_id');
+    $subquery->leftJoin('eventseries__field_branch', 'es_bra', 'es.id = es_bra.entity_id');
+
+    if (!empty($tags) || !empty($categories) || !empty($branches)) {
+      $or_group = $subquery->orConditionGroup();
+
+      // To avoid errors, related to the OR GROUP only containing one condition,
+      // we'll add a fake condition to fill out a possible empty space.
+      $or_group->condition('title', 'ALWAYS_FALSE');
+
+      if (!empty($tags)) {
+        $or_group->condition('es_tags.field_tags_target_id', $tags, 'IN');
+      }
+
+      if (!empty($categories)) {
+        $or_group->condition('es_cats.field_categories_target_id', $categories, 'IN');
+      }
+
+      if (!empty($branches)) {
+        $or_group->condition('es_bra.field_branch_target_id', $branches, 'IN');
+      }
+
+      $subquery->condition($or_group);
+    }
+
+    $subquery->distinct(TRUE);
+
+    // Main query to select eventinstance ids, joining with
+    // eventinstance_field_data for condition fields.
+    $query = $connection->select('eventinstance_field_data', 'eid');
+    $query->join('eventinstance', 'ei', 'ei.id = eid.id');
+    $query->addField('eid', 'id', 'eventinstance_id');
+
+    if (!empty($tags) || !empty($categories) || !empty($branches)) {
+      // Use the subquery to filter by eventseries_id.
+      $query->condition('eid.eventseries_id', $subquery, 'IN');
+    }
+
+    $query->condition('ei.uuid', $excluded_uuid, '<>');
+
+    // The consequence of direct DB that we cant use ->access(TRUE),
+    // so instead, we'll only look up published eventinstances.
+    $query->condition('eid.status', 1);
+
+    // We only want events in the future (e.g. - active events).
+    $query->condition('eid.date__value', $formatted_date, '>=');
+    $query->orderBy('eid.date__value', 'ASC');
+    // We know that we will never need more than the maximum items,
+    // so we will limit the query to this.
+    $query->range(0, $this->maxItems);
+
+    // Add a GROUP BY clause to make results distinct by eventseries_id.
+    // E.g. - don't show eventinstances that look identical.
+    $query->groupBy('eid.eventseries_id');
+
+    // Execute the query and return ids.
+    $result = $query->execute();
+
+    return $result?->fetchCol() ?? [];
+  }
+
+  /**
+   * Get terms from field as an array of IDs.
+   *
+   * @return array<int>
+   *   Term IDs.
+   */
+  private function getTermIds(FieldableEntityInterface $entity, string $field_name): array {
+    if (!$entity->hasField($field_name)) {
+      return [];
+    }
+
+    $terms = $entity->get($field_name)->getValue();
+    return array_column($terms, 'target_id');
+  }
+
+}

--- a/web/modules/custom/dpl_related_content/templates/dpl-related-content-slider.html.twig
+++ b/web/modules/custom/dpl_related_content/templates/dpl-related-content-slider.html.twig
@@ -1,0 +1,5 @@
+{{ title }}
+
+{% for item in items %}
+  {{ item }}
+{% endfor %}

--- a/web/themes/custom/novel/templates/components/dpl-related-content-slider.html.twig
+++ b/web/themes/custom/novel/templates/components/dpl-related-content-slider.html.twig
@@ -1,0 +1,7 @@
+<div class="mt-64">
+  {% include '@novel/components/slider.html.twig'
+    with {
+    'title': title,
+    'items': items,
+  } only %}
+</div>

--- a/web/themes/custom/novel/templates/layout/page.html.twig
+++ b/web/themes/custom/novel/templates/layout/page.html.twig
@@ -72,6 +72,16 @@
         } only %}
       </div>
     {% endif %}
+
+    {% if related_content %}
+      <div class="mt-64">
+        {% include '@novel/components/slider.html.twig'
+          with {
+          'title': 'Related content'|trans,
+          'items': related_content,
+        } only %}
+      </div>
+    {% endif %}
   </main>
 
   {% include '@novel/layout/footer.html.twig'

--- a/web/themes/custom/novel/templates/layout/page.html.twig
+++ b/web/themes/custom/novel/templates/layout/page.html.twig
@@ -73,15 +73,7 @@
       </div>
     {% endif %}
 
-    {% if related_content %}
-      <div class="mt-64">
-        {% include '@novel/components/slider.html.twig'
-          with {
-          'title': 'Related content'|trans,
-          'items': related_content,
-        } only %}
-      </div>
-    {% endif %}
+    {{ related_content }}
   </main>
 
   {% include '@novel/layout/footer.html.twig'


### PR DESCRIPTION
Place a dynamic 'related content' list on articles and eventinstances. Content displayed is based on the field values of the current page entity.

We go through several checks, until we find a result that shows more than 3 items:

- Only tags
- Tags OR Categories
- Tags, Categories OR events with same branch
- Upcoming events / Newest articles

If nothing is available, it wont display the slider. See more about the logic in the JIRA ticket:
https://reload.atlassian.net/browse/DDFFORM-394
