### PR TITLE
Allow library admins to create 'external user' roles.

### DIFF
--- a/config/sync/administerusersbyrole.settings.yml
+++ b/config/sync/administerusersbyrole.settings.yml
@@ -6,4 +6,4 @@ roles:
   editor: safe
   mediator: safe
   patron: unsafe
-  external_system: unsafe
+  external_system: safe


### PR DESCRIPTION
This is necessary for creating roles for third-party event companies that need access to the event-API, such as Place2Book.
