### PR TITLE
Include missing `category` in 'card' display

### DIFF
--- a/config/sync/core.entity_view_display.node.article.card.yml
+++ b/config/sync/core.entity_view_display.node.article.card.yml
@@ -22,6 +22,14 @@ targetEntityType: node
 bundle: article
 mode: card
 content:
+  field_categories:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
   field_subtitle:
     type: basic_string
     label: hidden
@@ -49,7 +57,6 @@ content:
 hidden:
   field_branch: true
   field_canonical_url: true
-  field_categories: true
   field_override_author: true
   field_paragraphs: true
   field_show_override_author: true


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-670


#### Description
This pull request adds the missing `category` field to the 'card' display for articles in `Card grid - automatic`.


#### Screenshot of the result

<img width="810" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/5ec281b9-acc0-49ec-98d4-1f6e93dedeaf">
