### PR TITLE
Add metrics endpoint for prometheus and other nosey services

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -45,6 +45,7 @@ module:
   dpl_login: 0
   dpl_mail: 0
   dpl_mapp: 0
+  dpl_metrics: 0
   dpl_opening_hours: 0
   dpl_paragraphs: 0
   dpl_patron_menu: 0

--- a/config/sync/rest.resource.metrics.metrics.yml
+++ b/config/sync/rest.resource.metrics.metrics.yml
@@ -1,0 +1,18 @@
+uuid: 42de1706-05a1-4c55-bedf-05addcca17a3
+langcode: en
+status: true
+dependencies:
+  module:
+    - dpl_metrics
+    - serialization
+    - user
+id: metrics.metrics
+plugin_id: 'metrics:metrics'
+granularity: resource
+configuration:
+  methods:
+    - GET
+  formats:
+    - json
+  authentication:
+    - cookie

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - rest.resource.campaign.match
     - rest.resource.dpl_opening_hours_list
+    - rest.resource.metrics.metrics
     - rest.resource.proxy-url
   module:
     - media
@@ -22,6 +23,7 @@ permissions:
   - 'access content'
   - 'access openapi api docs'
   - 'restful get dpl_opening_hours_list'
+  - 'restful get metrics:metrics'
   - 'restful get proxy-url'
   - 'restful post campaign:match'
   - 'view eventinstance entity'

--- a/openapi.json
+++ b/openapi.json
@@ -933,6 +933,52 @@
         ]
       }
     },
+    "/api/v1/metrics": {
+      "get": {
+        "parameters": [
+          {
+            "name": "_format",
+            "in": "query",
+            "type": "string",
+            "enum": ["json"],
+            "required": true,
+            "description": "Request format",
+            "default": "json"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "description": "Metrics information",
+                  "properties": {
+                    "cms-release-version": {
+                      "type": "string",
+                      "description": "The dpl-cms build version"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get status information about running site",
+        "operationId": "metrics:metrics:GET",
+        "schemes": ["http"],
+        "security": [
+          {
+            "cookie": []
+          }
+        ]
+      }
+    },
     "/dpl-url-proxy": {
       "get": {
         "parameters": [

--- a/web/modules/custom/dpl_metrics/dpl_metrics.info.yml
+++ b/web/modules/custom/dpl_metrics/dpl_metrics.info.yml
@@ -1,0 +1,5 @@
+name: "dpl_metrics"
+type: module
+description: "A moduke that collects and exposes information about the running site"
+package: "DPL"
+core_version_requirement: ^9 || ^10

--- a/web/modules/custom/dpl_metrics/dpl_metrics.yml
+++ b/web/modules/custom/dpl_metrics/dpl_metrics.yml
@@ -1,0 +1,5 @@
+name: "DPL Metrics"
+type: module
+description: "A moduke that collects and exposes information about the running site"
+package: "DPL"
+core_version_requirement: ^9 || ^10

--- a/web/modules/custom/dpl_metrics/src/Plugin/rest/resource/v1/MetricsResource.php
+++ b/web/modules/custom/dpl_metrics/src/Plugin/rest/resource/v1/MetricsResource.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Drupal\dpl_metrics\Plugin\rest\resource\v1;
+
+use Drupal\dpl_admin\Services\VersionHelper;
+use Drupal\rest\ModifiedResourceResponse;
+use Drupal\rest\Plugin\ResourceBase;
+use Drupal\rest\ResourceResponseInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use function Safe\sprintf;
+
+// Descriptions quickly become long and Doctrine annotations have no good way
+// of handling multiline strings.
+// phpcs:disable Drupal.Files.LineLength.TooLong
+/**
+ * A resource for obtaining and exposing status information about running site.
+ *
+ * @RestResource(
+ *   id = "metrics:metrics",
+ *   label = @Translation("Get status information about running site"),
+ *   serialization_class = "",
+ *
+ *   uri_paths = {
+ *     "canonical" = "/api/v1/metrics",
+ *   },
+ *
+ *   responses = {
+ *     200 = {
+ *       "description" = "OK",
+ *       "schema" = {
+ *         "type" = "object",
+ *         "properties" = {
+ *           "data" = {
+ *             "type" = "object",
+ *             "description" = "Metrics information",
+ *             "properties" = {
+ *                "cms-release-version" = {
+ *                 "type" = "string",
+ *                 "description" = "The dpl-cms build version",
+ *               },
+ *             },
+ *           },
+ *         },
+ *       },
+ *     },
+ *     500 = {
+ *       "description" = "Internal server error"
+ *     },
+ *   }
+ * )
+ */
+class MetricsResource extends ResourceBase {
+  /**
+   * The version helper.
+   *
+   * @var \Drupal\dpl_admin\Services\VersionHelper
+   */
+  protected VersionHelper $versionHelper;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->getParameter('serializer.formats'),
+      $container->get('logger.factory')->get('rest')
+    );
+
+    $instance->versionHelper = $container->get('dpl_admin.version_helper');
+
+    return $instance;
+  }
+
+  /**
+   * Get site stats.
+   *
+   * @return \Drupal\rest\ResourceResponseInterface
+   *   The response containing matching campaign.
+   */
+  public function get(Request $request): ResourceResponseInterface {
+    switch ($request->headers->get('Accept')) {
+      case 'application/json':
+        $response = new ModifiedResourceResponse([
+          'versions' => [
+            'cms' => $this->versionHelper->getVersion(),
+          ],
+        ]);
+        break;
+
+      case 'text/plain':
+      default:
+        $response = new ModifiedResourceResponse();
+        $response->headers->set('Content-Type', 'text/plain');
+        $response->setContent(implode("\n\n", $this->collectPrometheusMetricLines()));
+        break;
+    }
+
+    return $response;
+  }
+
+  /**
+   * Collect Prometheus metric lines.
+   *
+   * @return mixed[]
+   *   The Prometheus metric lines.
+   */
+  private function collectPrometheusMetricLines(): array {
+    $lines = [];
+    $lines[] = $this->prometheusLine('versions', [
+      'application' => 'cms',
+      'version' => $this->versionHelper->getVersion(),
+    ]);
+    return $lines;
+  }
+
+  /**
+   * Create a Prometheus formatted metrics line.
+   *
+   * @param string $metric
+   *   The metric name (category).
+   * @param mixed[] $values
+   *   The metric values (label => value).
+   */
+  private function prometheusLine(string $metric, array $values): string {
+    $elements = array_reduce(array_keys($values), function ($carry, $label) use ($values) {
+      $carry[] = sprintf('%s="%s"', $label, $values[$label]);
+      return $carry;
+    }, []);
+
+    return sprintf('%s{%s}', $metric, implode(', ', $elements));
+  }
+
+}


### PR DESCRIPTION

#### Description

Metrics endpoint can expose stats in different formats:

Prometheus specific text format or JSON payload based on "Accept" header.


#### Screenshot of the result


Prometheus format:
![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/998889/803275d2-611a-4c0c-a073-179ec94ee49f)

JSON format:
![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/998889/9af9b44b-2efd-4072-bb3b-ce85fd3f8154)

