### PR TITLE
Fix eventinstance list rendering in normal and stacked mode

### DIFF
--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -322,5 +322,12 @@ function novel_preprocess_views_view_unformatted(&$variables): void {
     if ($shouldBeStacked) {
       $row['content']['#view_mode'] = 'stacked_event';
     }
+
+    // Add cache tags to ensure stacked view is recalculated for factors that
+    // can affect the order:
+    // - Events are created/updated/deleted
+    // - Path and url arguments as this can effect filtering and ordering.
+    $row['content']['#cache']['tags'][] = 'eventinstance_list';
+    $row['content']['#cache']['contexts'][] = 'url';
   }
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-709

#### Description

Event instances can be rendered lists in normal and stacked (compact) view mode. The stacked mode is intended to be used if the preceeding instance in the list belongs to the same event series.

However we have seen the stacked mode being used even if the preceeding element was not in the same series.

This situation is caused by cached rendering of the instance. If the instance is initially rendered in the compact mode then this render will be reused in subsequent situations where the instance is rendered.

This is problematic as these situations can alter the instances in the list through editorial management of instances and through filtering of the list in the view and/or by the end user. The ordering of the list can also be affected in similar ways.

To ensure that these elements are taken into account when caching we add the eventinstance_list cache tag and the url cache context.

The `eventinstance_list` cache tag ensures that cache entries for these renders are cleared every time an event instance is created, updated or deleted.

The `url` cache context ensures that the cache varies by url which may include contextual filters and sorting applied by the user or even different pages where the instance is rendered using different views which have different sorting or filtering.

#### Additional comments or questions

You can recreate the problem as follows:

- Enable caching like on live sites locally by [setting `LAGOON_ENVIRONMENT_TYPE: production` i `docker-compose.yml`](https://github.com/danskernesdigitalebibliotek/dpl-cms/blob/develop/docker-compose.yml#L32-L36)
- Run `task dev:reset`
- View the event list page on `/events`
- Create a new event series which will interleave with the current recurring event "Fars legestue" e.g. by running on mondays every second week. Place it on a different branch.


![Screenshot 2024-05-13 at 08-23-02 Create Default Event DPL CMS Logged in](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/b59920ab-27b8-4acc-94b6-ed58df36ee41)

- Go to `/events` 
- See that stacked views of Fars legestue is mixed with the new recurring event (which is rendered properly)

![Screenshot 2024-05-13 at 08-23-55 Arrangementer DPL CMS](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/e06cfd2a-feba-4d41-a01b-a74d4cb43fe6)

- Filter by the brach which the new event was created on.
- See that the new event is not rendered properly where normal views are used when they should be stacked.
 
![Screenshot 2024-05-13 at 08-24-22 Arrangementer DPL CMS](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/b122781e-a323-4f04-993d-3949c7bd5a38)

Rerun the problem with this change and see that the correct view modes are used.


