### PR TITLE
Fix styling of Swagger code blocks.

### DIFF
--- a/web/modules/custom/dpl_admin/assets/dpl_frontend.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_frontend.css
@@ -33,3 +33,7 @@
     height: auto;
   }
 }
+
+.swagger-ui code {
+  background: transparent;
+}


### PR DESCRIPTION
When accessing the Swagger interface without being logged in, some CSS is not loaded, meaning the code blocks are unreadable:

<img width="659" alt="Screenshot 2024-05-13 at 15 24 04" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/b0b6791c-ee02-4464-a0ce-544c002a9d52">

This is a quick fix:

<img width="523" alt="Screenshot 2024-05-13 at 15 23 41" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/8e12259f-5df4-4efa-98d4-05303f924ae3">

https://varnish.pr-1137.dpl-cms.dplplat01.dpl.reload.dk/admin/config/services/openapi/swagger/rest