### PR TITLE
Replace "Files" with "Media" in Admin Tabs

### DIFF
--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -50,7 +50,6 @@ permissions:
   - 'access content overview'
   - 'access eventinstance overview'
   - 'access eventseries overview'
-  - 'access files overview'
   - 'access media overview'
   - 'access site in maintenance mode'
   - 'access taxonomy overview'

--- a/config/sync/user.role.mediator.yml
+++ b/config/sync/user.role.mediator.yml
@@ -37,7 +37,6 @@ permissions:
   - 'access content overview'
   - 'access eventinstance overview'
   - 'access eventseries overview'
-  - 'access files overview'
   - 'access media overview'
   - 'access site in maintenance mode'
   - 'access taxonomy overview'

--- a/web/modules/custom/dpl_admin/dpl_admin.links.task.yml
+++ b/web/modules/custom/dpl_admin/dpl_admin.links.task.yml
@@ -3,3 +3,9 @@ dpl_admin.events:
   route_name: view.event_series_admin.page_1
   base_route: system.admin_content
   weight: 10
+
+dpl_admin.media:
+  title: "Media"
+  route_name: view.media_library.page
+  base_route: system.admin_content
+  weight: 5

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -45,6 +45,7 @@ function dpl_admin_preprocess_html(array &$variables): void {
 function dpl_admin_local_tasks_alter(array &$local_tasks): void {
   unset($local_tasks['entity.eventseries.collection']);
   unset($local_tasks['entity.eventinstance.collection']);
+  unset($local_tasks['entity.media.collection']);
 }
 
 /**


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-746


#### Description
This Pull Request: Replace "Files" with "Media" in Admin Tabs

- Introduced a new "Media" link in the admin tabs. Although a "Media" link previously existed for the admin user, we lacked sufficient control over it. Consequently, we decided to hide the original link and create a new one.
- Removed "Files" permissions from the Editor and Mediator roles to hide the associated buttons.

<img width="1714" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/c55263a9-23d1-4087-b986-3a9e2c0ecbcf">

<img width="1714" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/6b9c4bec-f248-4f36-9327-299471bd7977">

<img width="1714" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/297f4258-e515-40b5-92cc-bb8f7dbac380">
