### PR TITLE
Add links to "/articles" in `card_grid_automatic`

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.card_grid_automatic.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.card_grid_automatic.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.card_grid_automatic.field_card_grid_link
     - field.field.paragraph.card_grid_automatic.field_filter_branches
     - field.field.paragraph.card_grid_automatic.field_filter_categories
     - field.field.paragraph.card_grid_automatic.field_filter_tags
@@ -10,6 +11,7 @@ dependencies:
     - paragraphs.paragraphs_type.card_grid_automatic
   module:
     - field_group
+    - link
     - select2
 third_party_settings:
   field_group:
@@ -34,6 +36,14 @@ targetEntityType: paragraph
 bundle: card_grid_automatic
 mode: default
 content:
+  field_card_grid_link:
+    type: link_default
+    weight: 9
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   field_filter_branches:
     type: select2_entity_reference
     weight: 8

--- a/config/sync/core.entity_view_display.paragraph.card_grid_automatic.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.card_grid_automatic.default.yml
@@ -3,16 +3,31 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.card_grid_automatic.field_card_grid_link
     - field.field.paragraph.card_grid_automatic.field_filter_branches
     - field.field.paragraph.card_grid_automatic.field_filter_categories
     - field.field.paragraph.card_grid_automatic.field_filter_tags
     - field.field.paragraph.card_grid_automatic.field_title
     - paragraphs.paragraphs_type.card_grid_automatic
+  module:
+    - link
 id: paragraph.card_grid_automatic.default
 targetEntityType: paragraph
 bundle: card_grid_automatic
 mode: default
-content: {  }
+content:
+  field_card_grid_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   field_filter_branches: true
   field_filter_categories: true

--- a/config/sync/core.entity_view_display.paragraph.card_grid_automatic.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.card_grid_automatic.preview.yml
@@ -4,16 +4,31 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.card_grid_automatic.field_card_grid_link
     - field.field.paragraph.card_grid_automatic.field_filter_branches
     - field.field.paragraph.card_grid_automatic.field_filter_categories
     - field.field.paragraph.card_grid_automatic.field_filter_tags
     - field.field.paragraph.card_grid_automatic.field_title
     - paragraphs.paragraphs_type.card_grid_automatic
+  module:
+    - link
 id: paragraph.card_grid_automatic.preview
 targetEntityType: paragraph
 bundle: card_grid_automatic
 mode: preview
 content:
+  field_card_grid_link:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
   field_filter_branches:
     type: entity_reference_label
     label: above

--- a/config/sync/field.field.paragraph.card_grid_automatic.field_card_grid_link.yml
+++ b/config/sync/field.field.paragraph.card_grid_automatic.field_card_grid_link.yml
@@ -1,0 +1,28 @@
+uuid: e64d7556-0379-4b8a-93ab-1104362bf884
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_card_grid_link
+    - paragraphs.paragraphs_type.card_grid_automatic
+  module:
+    - link
+id: paragraph.card_grid_automatic.field_card_grid_link
+field_name: field_card_grid_link
+entity_type: paragraph
+bundle: card_grid_automatic
+label: 'Card grid link'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    attributes: {  }
+    uri: 'internal:/articles'
+    title: 'Show all news'
+    options: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 1
+field_type: link

--- a/config/sync/field.storage.paragraph.field_card_grid_link.yml
+++ b/config/sync/field.storage.paragraph.field_card_grid_link.yml
@@ -1,0 +1,19 @@
+uuid: 5867ffd7-f793-4091-8ba1-90b0e8060283
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_card_grid_link
+field_name: field_card_grid_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/dpl_filter_paragraphs/dpl_filter_paragraphs.module
+++ b/web/modules/custom/dpl_filter_paragraphs/dpl_filter_paragraphs.module
@@ -18,6 +18,13 @@ use Drupal\views\Views;
 function dpl_filter_paragraphs_preprocess_paragraph__card_grid_automatic(array &$variables): void {
   $variables = _dpl_filter_paragraphs_prepare_filter_view($variables, 'content_paragraphs', 'card_grid', NULL);
 
+  $paragraph = $variables['paragraph'] ?? NULL;
+
+  if ($paragraph instanceof Paragraph && $paragraph->hasField('field_card_grid_link') && !$paragraph->get('field_card_grid_link')->isEmpty()) {
+    $link = $paragraph->get('field_card_grid_link')->view('full');
+    $link['#attributes']['class'][] = 'card-grid__link';
+    $variables['content']['view']['#view']->display_handler->setOption('custom_card_grid_link', $link);
+  }
 }
 
 /**
@@ -151,4 +158,35 @@ function dpl_filter_paragraphs_preprocess_paragraph__filtered_event_list(array &
   }
 
   $variables = _dpl_filter_paragraphs_prepare_filter_view($variables, 'filtered_event_list', 'default', $amount_of_events_to_display);
+}
+
+/**
+ * Helper: Re-save all card_grid_automatic paragraphs.
+ *
+ * This is needed to show the field_card_grid_link field in the view.
+ */
+function _dpl_filter_paragraphs_resave_card_grid_automatic() : string {
+  $pids = \Drupal::entityQuery('paragraph')
+    ->condition('type', 'card_grid_automatic')
+    ->accessCheck(FALSE)
+    ->execute();
+
+  if (!is_array($pids)) {
+    $pids = [];
+  }
+
+  $paragraphs = \Drupal::entityTypeManager()->getStorage('paragraph')->loadMultiple($pids);
+
+  foreach ($paragraphs as $paragraph) {
+    $paragraph->save();
+  }
+
+  return t('Finished re-saving all card_grid_automatic paragraphs.');
+}
+
+/**
+ * Re-save all card_grid_automatic paragraphs.
+ */
+function dpl_filter_paragraphs_deploy_resave_card_grid_automatic() : string {
+  return _dpl_filter_paragraphs_resave_card_grid_automatic();
 }

--- a/web/themes/custom/novel/templates/components/card-grid.html.twig
+++ b/web/themes/custom/novel/templates/components/card-grid.html.twig
@@ -12,7 +12,7 @@
     {% endif %}
 
     {% if link %}
-      <div class="card-grid__link">{{ link }}</div>
+      {{ link }}
     {% endif %}
   </div>
   <div class="card-grid__items-wrapper">

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--card-grid-automatic.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--card-grid-automatic.html.twig
@@ -1,0 +1,1 @@
+{{ content.view }}

--- a/web/themes/custom/novel/templates/views/views-view-unformatted--content-paragraphs--card-grid.html.twig
+++ b/web/themes/custom/novel/templates/views/views-view-unformatted--content-paragraphs--card-grid.html.twig
@@ -1,6 +1,9 @@
+{% set custom_card_grid_link = view.display_handler.getOption('custom_card_grid_link') %}
+
 {% include '@novel/components/card-grid.html.twig'
   with {
   'attributes': attributes,
   'title': view.getTitle(),
   'items': rows,
+  'link': custom_card_grid_link
 } only %}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-525

#### Description
This pull request adds links to "/articles" in card_grid_automatic.

I have added a new field, field_card_grid_link, with default values. I've incorporated this field into the view and included the CSS class name. Additionally, I added a template to ensure that only the view is rendered. I also implemented dpl_filter_paragraphs_resave_card_grid_automatic to guarantee link presence in existing paragraphs.

#### Screenshot of the result
 (Links seem to be placed too far to the right because we only have 3 articles in our default content) 
<img width="1105" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/bd5cec7b-e93e-4c05-b403-3d0484c298bf">

