### PR TITLE
Increase branch length limit for Lagoon integration to 100

### DIFF
--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -28,7 +28,7 @@ jobs:
         if: github.ref_type == 'branch' || github.ref_type == 'pull_request'
         with:
           allowed: |
-            /^.{1,50}$/
+            /^.{1,100}$/
           errorMessage: 'Branch name too long. This cannot be deployed to Lagoon.'
 
   CheckEnvironment:


### PR DESCRIPTION
#### Description

[Further deep dive into the Lagoon codebase shows that the actual limits for refs is 100](https://github.com/uselagoon/lagoon/blob/26f57ef11f87fda9a2692e22ca9d7be7c9f69b03/services/api/database/migrations/20220908065119_initial_db.js#L80). Bump our own limit to match this limit.

The current limit of 50 is a problem for pull requests created by Dependabot. They are created with longer branch names.
Example: #1140.
