### PR TITLE
Enable REST base dependency for opening hours in update hook

### DIFF
--- a/web/modules/custom/dpl_opening_hours/dpl_opening_hours.install
+++ b/web/modules/custom/dpl_opening_hours/dpl_opening_hours.install
@@ -1,6 +1,8 @@
 <?php
 
+use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\dpl_opening_hours\Mapping\OpeningHoursRepetitionType;
+use Drupal\drupal_typed\DrupalTyped;
 use function Safe\json_encode as json_encode;
 
 /**
@@ -162,12 +164,26 @@ function dpl_opening_hours_update_10000(array &$sandbox): string {
 }
 
 /**
- * Implements hook_update_N().
+ * Enable dpl_rest_base module.
  *
  * @param mixed[] $sandbox
  *   The update sandbox.
  */
 function dpl_opening_hours_update_10001(array &$sandbox) : void {
+  $module_installer = DrupalTyped::service(ModuleInstallerInterface::class, 'module_installer');
+  // The dpl_rest_base module is a dependency containing classes that this
+  // module relies on. We need to have it enabled before other update hooks
+  // can run.
+  $module_installer->install(['dpl_rest_base']);
+}
+
+/**
+ * Update repetition field description.
+ *
+ * @param mixed[] $sandbox
+ *   The update sandbox.
+ */
+function dpl_opening_hours_update_10002(array &$sandbox) : void {
   $repetition_table = 'dpl_opening_hours_repetition';
   $type_field = 'type';
   $repetition_schema = dpl_opening_hours_schema()[$repetition_table];


### PR DESCRIPTION
#### Description

Update hooks trigger a cache rebuild after each run. In this situation Our REST resources rebuilds routes. However our resources in dpl_opening_hours now depend on code in the the new  dpl_rest_base module which will be enabled during config import - not the update hooks which run before. This cause exceptions to be thrown as classes cannot be found.

To avoid this we rearrange our update hooks in dpl_opening_hours. We start by enabling the dpl_rest_base dependency. Then we can do our planned update in a subsequent update hook.

Rearranging the numbering of these hooks is normally not a good idea but since none of these update hooks have run successfully in any non-temporary environment it should be OK to do so here.