### PR TITLE
Migrate admins

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,6 +23,8 @@ parameters:
     - '#Function .*_requirements\(\) return type has no value type specified in iterable type array\.#'
     # Drupal hook_schema() implementation returns array which we cannot provide more detailed typing of.
     - '#Function .*_schema\(\) return type has no value type specified in iterable type array\.#'
+    # Drupal hook_update() sandbox which we cannot provide more detailed typing of.
+    - '#Function .*_update_\d+\(\) has parameter \$sandbox with no value type specified in iterable type array\.#'
     # Ignore Plugin configuration parameter.
     - '#Drupal\\.*\\Plugin\\.*::__construct\(\) .* no value type specified in iterable type array\.#'
     - '#Drupal\\.*\\Plugin\\.*::create\(\) .* no value type specified in iterable type array\.#'

--- a/task/Taskfile.lagoon.yml
+++ b/task/Taskfile.lagoon.yml
@@ -3,10 +3,6 @@
 # the project.
 version: "3"
 
-vars:
-  # The name of the project on Lagoon.
-  LAGOON_PROJECT: "dpl-cms"
-
 tasks:
   backup:restore:
     desc: Restore the latest backup of files and database from a Lagoon project
@@ -49,7 +45,7 @@ tasks:
     deps: [deps:lagoon, deps:jq, login]
     cmds:
       - |
-        RUN=$(lagoon run -p {{.LAGOON_PROJECT}} -e pr-"$PR" custom --command "{{.CLI_ARGS}}" --name "{{.CLI_ARGS}} from Taskfile" --output-json);
+        RUN=$(lagoon run -p ${LAGOON_PROJECT:-dpl-cms} -e ${LAGOON_ENVIRONMENT:-main} custom --command "{{.CLI_ARGS}}" --name "{{.CLI_ARGS}} from Taskfile" --output-json);
         TASK_ID=$(echo $RUN | jq .data.id);
         STATUS="pending";
         while [ $STATUS != "complete" ]; do
@@ -59,9 +55,6 @@ tasks:
           STATUS=$(echo $TASK | jq -r .data[0].status);
         done
         echo -e "\n$(echo $TASK | jq -r .data[0].logs)";
-    preconditions:
-      - sh: "[ -v PR ]"
-        msg: Please provide a PR environment variable with the pull request number for the environment
 
   login:
     internal: true

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Query\QueryException;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Password\DefaultPasswordGenerator;
 use Drupal\dpl_admin\Services\VersionHelper;
 use Drupal\drupal_typed\DrupalTyped;
@@ -87,7 +88,7 @@ function dpl_admin_update_10000(array &$sandbox) : string {
   $password_generator = DrupalTyped::service(DefaultPasswordGenerator::class, 'password_generator');
   $user_1->setPassword($password_generator->generate());
 
-  $language_manager = DrupalTyped::service(\Drupal\Core\Language\LanguageManagerInterface::class, 'language_manager');
+  $language_manager = DrupalTyped::service(LanguageManagerInterface::class, 'language_manager');
   $user_1->set('preferred_admin_langcode', $language_manager->getDefaultLanguage()->getId());
 
   $user_1->save();

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -17,6 +17,7 @@ use Drupal\dpl_admin\Services\VersionHelper;
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\user\Entity\User;
 use Drupal\user\EntityOwnerInterface;
+use Drupal\user\UserInterface;
 
 /**
  * Implements hook_requirements().
@@ -156,4 +157,18 @@ function dpl_admin_update_10000(array &$sandbox) : string {
   $feedback[] = "Released all content locks for user 1";
 
   return implode("\n", $feedback);
+}
+
+/**
+ * Migrate administrators to local administrators.
+ */
+function dpl_admin_update_10001(array &$sandbox): string {
+  $administrators = \Drupal::entityTypeManager()->getStorage('user')->loadByProperties(['roles' => 'administrator']);
+  $updates = array_map(function (UserInterface $administrator) {
+      $administrator->removeRole('administrator');
+      $administrator->addRole('local_administrator');
+      $administrator->save();
+      return "Converted user {$administrator->id()} from administrator to local administrator";
+  }, $administrators);
+  return implode("\n", $updates);
 }

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -111,7 +111,7 @@ function dpl_admin_update_10000(array &$sandbox) : string {
     ->condition('uid', $new_user->id())
     ->execute();
   $feedback[] = "Transferred password hash from user 1 to new user {$new_user->id()}";
-  
+
   // Use a direct database connection here instead of SessionManager as this
   // does not allow ending sessions from the CLI.
   \Drupal::database()->delete('sessions')

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -100,7 +100,8 @@ function dpl_admin_update_10000(array &$sandbox) : string {
   }, $user_1->getRoles(exclude_locked_roles: TRUE));
   $user_1->save();
   $removed_roles_string = implode(', ', $removed_roles);
-  $feedback[] = "Removed roles {$removed_roles_string} from user 1";
+  $removed_role_count = count($removed_roles);
+  $feedback[] = "Removed {$removed_role_count} roles {$removed_roles_string} from user 1";
 
   $new_user->save();
   $feedback[] = "Created new user {$new_user->id()} with local administrator role";

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -11,7 +11,6 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Query\QueryException;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Session\SessionManagerInterface;
 use Drupal\Core\Password\DefaultPasswordGenerator;
 use Drupal\dpl_admin\Services\VersionHelper;
 use Drupal\drupal_typed\DrupalTyped;
@@ -138,8 +137,11 @@ function dpl_admin_update_10000(array &$sandbox) : string {
   }, $user_owned_entities_by_types, array_keys($user_owned_entities_by_types));
   $feedback = array_merge($feedback, $status_by_types);
 
-  $session_manager = DrupalTyped::service(SessionManagerInterface::class, 'session_manager');
-  $session_manager->delete((int) $user_1->id());
+  // Use a direct database connection here instead of SessionManager as this
+  // does not allow ending sessions from the CLI.
+  \Drupal::database()->delete('sessions')
+    ->condition('uid', $user_1->id())
+    ->execute();
   $feedback[] = "Deleted existing sessions for user 1";
 
   $content_lock = DrupalTyped::service(ContentLock::class, 'content_lock');

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Query\QueryException;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Session\SessionManagerInterface;
+use Drupal\Core\Password\DefaultPasswordGenerator;
 use Drupal\dpl_admin\Services\VersionHelper;
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\user\Entity\User;
@@ -79,11 +80,12 @@ function dpl_admin_update_10000(array &$sandbox) : string {
   // Use random data for both username and password as this user is only meant
   // to be used with onetime login links.
   $random = new Random();
+  $password_generator = DrupalTyped::service(DefaultPasswordGenerator::class, 'password_generator');
   $user_1
     ->set('field_author_name', "Administrator")
     ->setUsername('admin_' . $random->name())
     ->setEmail('')
-    ->setPassword($random->string(32));
+    ->setPassword($password_generator->generate());
   $user_1->save();
   $feedback[] = "Reset username and password for user 1";
 

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -79,12 +79,17 @@ function dpl_admin_update_10000(array &$sandbox) : string {
   // Use random data for both username and password as this user is only meant
   // to be used with onetime login links.
   $random = new Random();
-  $password_generator = DrupalTyped::service(DefaultPasswordGenerator::class, 'password_generator');
   $user_1
     ->set('field_author_name', "Administrator")
     ->setUsername('admin_' . $random->name())
-    ->setEmail('')
-    ->setPassword($password_generator->generate());
+    ->setEmail('');
+
+  $password_generator = DrupalTyped::service(DefaultPasswordGenerator::class, 'password_generator');
+  $user_1->setPassword($password_generator->generate());
+
+  $language_manager = DrupalTyped::service(\Drupal\Core\Language\LanguageManagerInterface::class, 'language_manager');
+  $user_1->set('preferred_admin_langcode', $language_manager->getDefaultLanguage()->getId());
+
   $user_1->save();
   $feedback[] = "Reset username and password for user 1";
 

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -54,7 +54,7 @@ function dpl_admin_update_10000(array &$sandbox) : string {
     throw new RuntimeException('Unable to load user 1');
   }
 
-  // Some field values should not been transfered between the users as we
+  // Some field values should not been transferred between the users as we
   // intentionally want them to be unique.
   $excluded_fields = ['uid' => TRUE, 'uuid' => TRUE, 'roles' => TRUE];
   $user_1_fields = array_diff_key($user_1->getFields(include_computed: FALSE), $excluded_fields);
@@ -100,7 +100,7 @@ function dpl_admin_update_10000(array &$sandbox) : string {
   }, $user_1->getRoles(exclude_locked_roles: TRUE));
   $user_1->save();
   $removed_roles_string = implode(', ', $removed_roles);
-  $feedback[] = "Removed roles {$removed_roles_string} for user 1";
+  $feedback[] = "Removed roles {$removed_roles_string} from user 1";
 
   $new_user->save();
   $feedback[] = "Created new user {$new_user->id()} with local administrator role";

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -105,6 +105,7 @@ function dpl_admin_update_10000(array &$sandbox) : string {
   $feedback[] = "Transferred password hash from user 1 to new user {$new_user->id()}";
 
   // Migrate entity ownership to the new user.
+  // Retrieve all entities currently owned by user 1 grouped by entity type.
   $entities_by_types = array_map(function (EntityTypeInterface $entity_type) use ($user_1) {
     try {
       return \Drupal::entityTypeManager()->getStorage($entity_type->id())->loadByProperties(['uid' => $user_1->id()]);
@@ -116,11 +117,16 @@ function dpl_admin_update_10000(array &$sandbox) : string {
     }
   }, \Drupal::entityTypeManager()->getDefinitions());
 
+  // Only consider entities of a type which implements EntityOwnerInterface.
+  // This is required for us to update ownership.
   /** @var array<string, array<EntityInterface&EntityOwnerInterface>> $user_owned_entities_by_types */
   $user_owned_entities_by_types = array_filter($entities_by_types, function (array $entities) {
     return count($entities) > 0 && reset($entities) instanceof EntityOwnerInterface;
   });
 
+  // Update owner for all relevant entities, save them. This functionality is
+  // spread across multiple interfaces.
+  // For each type generate an appropriate status message.
   $status_by_types = array_map(function (array $entities, string $entity_type) use ($new_user) {
     $entities = array_map(fn (EntityOwnerInterface $entity) => $entity->setOwner($new_user), $entities);
     $entities = array_map(fn (EntityInterface $entity) => $entity->save(), $entities);

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -77,6 +77,14 @@ function dpl_admin_update_10000(array &$sandbox) : string {
   $user_1->save();
   $feedback[] = "Reset username and password for user 1";
 
+  $removed_roles = array_map(function (string $role) use ($user_1) {
+      $user_1->removeRole($role);
+      return $role;
+  }, $user_1->getRoles(exclude_locked_roles: TRUE));
+  $user_1->save();
+  $removed_roles_string = implode(', ', $removed_roles);
+  $feedback[] = "Removed roles {$removed_roles_string} for user 1";
+
   $new_user->save();
   $feedback[] = "Created new user {$new_user->id()} with local administrator role";
 

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -111,6 +111,13 @@ function dpl_admin_update_10000(array &$sandbox) : string {
     ->condition('uid', $new_user->id())
     ->execute();
   $feedback[] = "Transferred password hash from user 1 to new user {$new_user->id()}";
+  
+  // Use a direct database connection here instead of SessionManager as this
+  // does not allow ending sessions from the CLI.
+  \Drupal::database()->delete('sessions')
+    ->condition('uid', $user_1->id())
+    ->execute();
+  $feedback[] = "Deleted existing sessions for user 1";
 
   // Migrate entity ownership to the new user.
   // Retrieve all entities currently owned by user 1 grouped by entity type.
@@ -143,13 +150,6 @@ function dpl_admin_update_10000(array &$sandbox) : string {
     return "Updated owner for {$num_entities} {$entity_type} entities";
   }, $user_owned_entities_by_types, array_keys($user_owned_entities_by_types));
   $feedback = array_merge($feedback, $status_by_types);
-
-  // Use a direct database connection here instead of SessionManager as this
-  // does not allow ending sessions from the CLI.
-  \Drupal::database()->delete('sessions')
-    ->condition('uid', $user_1->id())
-    ->execute();
-  $feedback[] = "Deleted existing sessions for user 1";
 
   $content_lock = DrupalTyped::service(ContentLock::class, 'content_lock');
   $content_lock->releaseAllUserLocks((int) $user_1->id());

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -61,6 +61,16 @@ function dpl_admin_update_10000(array &$sandbox) : string {
     return $field->value;
   }, $user_1_fields);
 
+  $result = \Drupal::database()->select('users_field_data')
+    ->fields('users_field_data', ['pass'])
+    ->condition('uid', $user_1->id())
+    ->execute();
+  if (!$result) {
+    throw new RuntimeException('Unable to retrieve password hash for user 1');
+  }
+  $password_hash = $result->fetchField();
+  $feedback[] = "Retrieved password hash for user 1";
+
   // Transfer field data.
   $new_user = (User::create($user_1_field_values))
     ->addRole('local_administrator');
@@ -87,6 +97,12 @@ function dpl_admin_update_10000(array &$sandbox) : string {
 
   $new_user->save();
   $feedback[] = "Created new user {$new_user->id()} with local administrator role";
+
+  \Drupal::database()->update('users_field_data')
+    ->fields(['pass' => $password_hash])
+    ->condition('uid', $new_user->id())
+    ->execute();
+  $feedback[] = "Transferred password hash from user 1 to new user {$new_user->id()}";
 
   // Migrate entity ownership to the new user.
   $entities_by_types = array_map(function (EntityTypeInterface $entity_type) use ($user_1) {

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -5,8 +5,17 @@
  * DPL Admin install file.
  */
 
+use Drupal\Component\Utility\Random;
+use Drupal\content_lock\ContentLock\ContentLock;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\Query\QueryException;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Session\SessionManagerInterface;
 use Drupal\dpl_admin\Services\VersionHelper;
 use Drupal\drupal_typed\DrupalTyped;
+use Drupal\user\Entity\User;
+use Drupal\user\EntityOwnerInterface;
 
 /**
  * Implements hook_requirements().
@@ -31,4 +40,79 @@ function dpl_admin_requirements(string $phase): array {
   ];
 
   return $requirements;
+}
+
+/**
+ * Migrate administrative role to new user.
+ */
+function dpl_admin_update_10000(array &$sandbox) : string {
+  $feedback = [];
+
+  $user_1 = User::load(1);
+  if (!$user_1) {
+    throw new RuntimeException('Unable to load user 1');
+  }
+
+  // Some field values should not been transfered between the users as we
+  // intentionally want them to be unique.
+  $excluded_fields = ['uid' => TRUE, 'uuid' => TRUE, 'roles' => TRUE];
+  $user_1_fields = array_diff_key($user_1->getFields(include_computed: FALSE), $excluded_fields);
+  $user_1_field_values = array_map(function (FieldItemListInterface $field) {
+    return $field->value;
+  }, $user_1_fields);
+
+  // Transfer field data.
+  $new_user = (User::create($user_1_field_values))
+    ->addRole('local_administrator');
+
+  // Reset the existing user 1 account.
+  // Use random data for both username and password as this user is only meant
+  // to be used with onetime login links.
+  $random = new Random();
+  $user_1
+    ->set('field_author_name', "Administrator")
+    ->setUsername('admin_' . $random->name())
+    ->setEmail('')
+    ->setPassword($random->string(32));
+  $user_1->save();
+  $feedback[] = "Reset username and password for user 1";
+
+  $new_user->save();
+  $feedback[] = "Created new user {$new_user->id()} with local administrator role";
+
+  // Migrate entity ownership to the new user.
+  $entities_by_types = array_map(function (EntityTypeInterface $entity_type) use ($user_1) {
+    try {
+      return \Drupal::entityTypeManager()->getStorage($entity_type->id())->loadByProperties(['uid' => $user_1->id()]);
+    }
+    catch (QueryException $e) {
+      // An exception if thrown for entity types without an uid property. Ignore
+      // these as they do not have relations to the existing user.
+      return [];
+    }
+  }, \Drupal::entityTypeManager()->getDefinitions());
+
+  /** @var array<string, array<EntityInterface&EntityOwnerInterface>> $user_owned_entities_by_types */
+  $user_owned_entities_by_types = array_filter($entities_by_types, function (array $entities) {
+    return count($entities) > 0 && reset($entities) instanceof EntityOwnerInterface;
+  });
+
+  $status_by_types = array_map(function (array $entities, string $entity_type) use ($new_user) {
+    $entities = array_map(fn (EntityOwnerInterface $entity) => $entity->setOwner($new_user), $entities);
+    $entities = array_map(fn (EntityInterface $entity) => $entity->save(), $entities);
+
+    $num_entities = count($entities);
+    return "Updated owner for {$num_entities} {$entity_type} entities";
+  }, $user_owned_entities_by_types, array_keys($user_owned_entities_by_types));
+  $feedback = array_merge($feedback, $status_by_types);
+
+  $session_manager = DrupalTyped::service(SessionManagerInterface::class, 'session_manager');
+  $session_manager->delete((int) $user_1->id());
+  $feedback[] = "Deleted existing sessions for user 1";
+
+  $content_lock = DrupalTyped::service(ContentLock::class, 'content_lock');
+  $content_lock->releaseAllUserLocks((int) $user_1->id());
+  $feedback[] = "Released all content locks for user 1";
+
+  return implode("\n", $feedback);
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-768

#### Description

When some sites where initially created, library organizations got
access to the initial administrative Drupal user, user 1. This user
has special privileges which are not intended for the library
organizations.

To address this situation we create a new administrative user to be
used by the libraries instead.

To make this transfer as smooth as possible we transfer as much data
as possible from the existing user 1 to to the new user. This includes
user data and entity ownership.

It is not easy to transfer content locks so instead we reset all locks
that user 1 may have.

#### Screenshot of the result

##### Gentofte (non-pilot library)

###### Output during update hook

```
> >  [notice] Update started: dpl_admin_update_10000
> >  [warning] Missing file with ID 1. ImageItem.php:331
> >  [notice] Retrieved password hash for user 1
> > Reset username and password for user 1
> > Removed roles local_administrator, editor, mediator for user 1
> > Created new user 9 with local administrator role
> > Transferred password hash from user 1 to new user 9
> > Updated owner for 78 file entities
> > Updated owner for 59 media entities
> > Updated owner for 96 node entities
> > Updated owner for 3 eventseries entities
> > Updated owner for 3 eventinstance entities
> > Deleted existing sessions for user 1
> > Released all content locks for user 1
> >  [notice] Update completed: dpl_admin_update_10000
> >  [notice] Message: Successfully updated 1 instance statuses. Skipped 0 instances due to status
> > or workflow mismatch with series.
```

###### User 1 before

<img width="1392" alt="billede" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/4d4657a6-c684-4270-bc20-60307e06b597"> 

###### User 1 after

<img width="1392" alt="billede" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/7e1748da-41a6-47cb-a135-4b98aeb3bba1">

###### New local admin after

<img width="1392" alt="billede" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/abb43dd0-e164-4c75-b424-2f478cb5d4cb">

###### User list before

<img width="1392" alt="billede" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/d5ca10dd-0a49-487e-bb93-158ddaac4f19">

###### User list after

<img width="1392" alt="billede" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/f10733fd-a257-486a-bf1c-83eb178e4d6e">

###### Content list before

<img width="1348" alt="billede" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/acbbce53-54f8-41cc-85b4-1bf2d3e81087">

###### Content list after

<img width="1392" alt="billede" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/ddc86e83-1cb0-4466-bb7b-6236195f4c4a">

(Note that all content previously owned by admin will be updated)


#### Additional comments or questions

I have tested transfer of passwords using the following procedure:

1. Restore a site from backup
2. Login locally as user 1 using `drush uli` 
3. Note the user name for user 1
4. Change the password of user 1 to `test`
5. Log out
6. Run the update hooks using `drush deploy`
7. Log in using the original user name and new password for user 1 
8. See that I am logged in as the new user

It is not possible to see the changes to event, media or file ownership as this is not listed in the UI of these.