### PR TITLE
Add update hook to dpl_webform module that adds a new entry in config_ignore

### DIFF
--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -8,7 +8,7 @@
 /**
  * Implements hook_update_N().
  */
-function dpl_webform_update_10003(): void {
+function dpl_webform_update_10000(): string {
   $config_factory = \Drupal::configFactory();
   $config_ignore_config_key = 'config_ignore.settings';
 
@@ -19,5 +19,5 @@ function dpl_webform_update_10003(): void {
   $ignored_configs = $config_ignore_settings->get('ignored_config_entities');
   $ignored_configs[] = 'webform.webform.*';
   $config_ignore_settings->set('ignored_config_entities', $ignored_configs)->save();
-  \Drupal::messenger()->addMessage('webform.webform.* is added to ignored configs.');
+  return 'webform.webform.* is added to ignored configs.';
 }

--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -8,26 +8,16 @@
 /**
  * Implements hook_update_N().
  */
-function dpl_webform_update_10001(): void {
-
+function dpl_webform_update_10003(): void {
   $config_factory = \Drupal::configFactory();
   $config_ignore_config_key = 'config_ignore.settings';
 
-  // Get the current config_ignore settings.
+  // We add the new webform.webform.* to config_ignore.settings
+  // as the settings will otherwise risk being deleted by when
+  // drush deploy is running confiugraiton import.
   $config_ignore_settings = $config_factory->getEditable($config_ignore_config_key);
-
-  // Get the ignored configurations.
   $ignored_configs = $config_ignore_settings->get('ignored_config_entities');
-
-  // Check if the configuration is already being ignored.
-  if (array_key_exists('webform.webform.*', $ignored_configs)) {
-    \Drupal::messenger()->addMessage('webform.webform.* already exists in ignored configs. Exiting update hook.');
-    return;
-  }
-
-  // Save the updated config_ignore settings.
   $ignored_configs[] = 'webform.webform.*';
   $config_ignore_settings->set('ignored_config_entities', $ignored_configs)->save();
-
   \Drupal::messenger()->addMessage('webform.webform.* is added to ignored configs.');
 }

--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -14,7 +14,7 @@ function dpl_webform_update_10000(): string {
 
   // We add the new webform.webform.* to config_ignore.settings
   // as the settings will otherwise risk being deleted by when
-  // drush deploy is running confiugraiton import.
+  // drush deploy is running configuration import.
   $config_ignore_settings = $config_factory->getEditable($config_ignore_config_key);
   $ignored_configs = $config_ignore_settings->get('ignored_config_entities');
   $ignored_configs[] = 'webform.webform.*';

--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * DPL webform install file.
+ */
+
+/**
+ * Implements hook_update_N().
+ */
+function dpl_webform_update_10001(): void {
+
+  $config_factory = \Drupal::configFactory();
+  $config_ignore_config_key = 'config_ignore.settings';
+
+  // Get the current config_ignore settings.
+  $config_ignore_settings = $config_factory->getEditable($config_ignore_config_key);
+
+  // Get the ignored configurations.
+  $ignored_configs = $config_ignore_settings->get('ignored_config_entities');
+
+  // Check if the configuration is already being ignored.
+  if (array_key_exists('webform.webform.*', $ignored_configs)) {
+    \Drupal::messenger()->addMessage('webform.webform.* already exists in ignored configs. Exiting update hook.');
+    return;
+  }
+
+  // Save the updated config_ignore settings.
+  $ignored_configs[] = 'webform.webform.*';
+  $config_ignore_settings->set('ignored_config_entities', $ignored_configs)->save();
+
+  \Drupal::messenger()->addMessage('webform.webform.* is added to ignored configs.');
+}

--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -6,7 +6,7 @@
  */
 
 /**
- * Implements hook_update_N().
+ * Add all webforms to config ignore.
  */
 function dpl_webform_update_10000(): string {
   $config_factory = \Drupal::configFactory();


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-645

#### Description

Added update hook to dpl_webform that makes sure to add an entry to config_ignore.settings.yml. The entry added is 'webform.webform.*'. This will make sure that the ignoring of webform configuration is in place before we run the drush deploy command, and thus we make sure that created webforms is not deleted when deploying.
