### PR TITLE
Restructure heading tree structure

### DIFF
--- a/web/themes/custom/novel/templates/components/footer-accordions.html.twig
+++ b/web/themes/custom/novel/templates/components/footer-accordions.html.twig
@@ -4,12 +4,12 @@
     {% for item in settings.footer_items %}
         {% set startsOpen = loop.index == 1 %}
         <li class="footer-accordion">
-            <h3 class="footer-accordion__header footer__title">
+            <h2 class="footer-accordion__header footer__title">
                 <button class="footer-accordion__header-button" aria-expanded="{{ startsOpen ? 'true' : 'false' }}" data-footer-accordion-trigger>
                     {{ item.name }}
                     <img class="footer-accordion__header-button__arrow" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-triangle.svg" alt="">
                 </button>
-            </h3>
+            </h2>
 
             <div class="footer__content {{ startsOpen ? '' : 'footer__content--hidden' }}">
                 {{ item.content.value|raw }}

--- a/web/themes/custom/novel/templates/components/footer-columns.html.twig
+++ b/web/themes/custom/novel/templates/components/footer-columns.html.twig
@@ -1,7 +1,7 @@
 <ul class="footer-columns">
     {% for item in settings.footer_items %}
         <li class="footer-column">
-            <h3 class="footer__title">{{ item.name }}</h3>
+            <h2 class="footer__title">{{ item.name }}</h2>
             <div class="footer__content">
                 {{ item.content.value|raw }}
             </div>

--- a/web/themes/custom/novel/templates/components/nav-spot.html.twig
+++ b/web/themes/custom/novel/templates/components/nav-spot.html.twig
@@ -19,7 +19,7 @@
     </figure>
 
     <div class="nav-spot__text">
-      <h1 class="nav-spot__title">{{ title }}</h1>
+      <h2 class="nav-spot__title">{{ title }}</h2>
 
       {% if subtitle %}
         <p class="nav-spot__subtitle">{{ subtitle }}</p>

--- a/web/themes/custom/novel/templates/components/nav-teaser.html.twig
+++ b/web/themes/custom/novel/templates/components/nav-teaser.html.twig
@@ -1,6 +1,6 @@
 <article {{ attributes.addClass('nav-teaser') }}>
   <a href="{{ url }}">
-    <h1 class="nav-teaser__title">{{ title }}</h1>
+    <h3 class="nav-teaser__title">{{ title }}</h3>
 
     {% if subtitle %}
       <p class="nav-teaser__subtitle">{{ subtitle }}</p>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-563

#### Reflecting changes in the design system
https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/635

#### Description

This pull request restructures the heading tree structure

This is important for accessibility and screen readers.


#### Test links

https://varnish.pr-1154.dpl-cms.dplplat01.dpl.reload.dk/laesefilialen/laeseklubber/genre/diy-projekter-laeseklubber 
https://varnish.pr-1154.dpl-cms.dplplat01.dpl.reload.dk/frontpage

I use this Chrome extension:

https://chromewebstore.google.com/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi


#### Screenshot of the result
<img width="1840" alt="Skærmbillede 2024-05-16 kl  11 49 09" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/570fe7e8-fb3e-47c4-adc0-c9f30e3df841">

<img width="1840" alt="Skærmbillede 2024-05-16 kl  11 48 57" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/8661c482-42b0-437f-9fbc-830efd82322a">
