### PR TITLE
DDFLSBP-630-fix-reservations-configuration-issue

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -16,7 +16,7 @@ ignored_config_entities:
   - dpl_patron_reg.settings
   - dpl_publizon.settings
   - dpl_recommender.settings
-  - dpl_reservation_list.settings
+  - dpl_reservations.settings
   - dpl_url_proxy.settings
   - novel.settings
   - openid_connect.settings.adgangsplatformen

--- a/web/modules/custom/dpl_reservations/dpl_reservations.install
+++ b/web/modules/custom/dpl_reservations/dpl_reservations.install
@@ -6,9 +6,9 @@
  */
 
 /**
- * Implements hook_update_N().
+ * Migrate dpl_reservation_list configuration to dpl_reservations.
  */
-function dpl_reservations_update_9001(): void {
+function dpl_reservations_update_9001(): string {
   $config_factory = \Drupal::configFactory();
   $dpl_reservations_old_config_key = 'dpl_reservation_list.settings';
   $dpl_reservations_new_config_key = 'dpl_reservations.settings';
@@ -18,8 +18,7 @@ function dpl_reservations_update_9001(): void {
   // Check if the old configuration exists. If the old configuration
   // does not exist, we do not need to update anything.
   if ($dpl_reservations_old_configuration->isNew()) {
-    \Drupal::messenger()->addMessage('Nothing to update. Exiting update hook.');
-    return;
+    return 'Nothing to update. Exiting update hook.';
   }
 
   // We add the new dpl_reservations.settings to config_ignore.settings
@@ -34,5 +33,5 @@ function dpl_reservations_update_9001(): void {
   $dpl_reservations_old_config_data = $dpl_reservations_old_configuration->get();
   $config_factory->getEditable($dpl_reservations_new_config_key)->setData($dpl_reservations_old_config_data)->save();
   $config_factory->getEditable($dpl_reservations_old_config_key)->delete();
-  \Drupal::messenger()->addMessage('dpl_reservation_list configuration migrated to dpl_reservations.');
+  return 'dpl_reservation_list configuration migrated to dpl_reservations.';
 }

--- a/web/modules/custom/dpl_reservations/dpl_reservations.install
+++ b/web/modules/custom/dpl_reservations/dpl_reservations.install
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * DPL reservations install file.
+ */
+
+/**
+ * Implements hook_update_N().
+ */
+function dpl_reservations_update_9001(): void {
+  $config_factory = \Drupal::configFactory();
+  $dpl_reservations_old_config_key = 'dpl_reservation_list.settings';
+  $dpl_reservations_new_config_key = 'dpl_reservations.settings';
+  $config_ignore_config_key = 'config_ignore.settings';
+  $dpl_reservations_old_configuration = $config_factory->get($dpl_reservations_old_config_key);
+
+  // Check if the old configuration exists. If the old configuration
+  // does not exist, we do not need to update anything.
+  if ($dpl_reservations_old_configuration->isNew()) {
+    \Drupal::messenger()->addMessage('Nothing to update. Exiting update hook.');
+    return;
+  }
+
+  // We add the new dpl_reservations.settings to config_ignore.settings
+  // as the settings will otherwise risk being deleted by drush deploy.
+  $config_ignore_settings = $config_factory->getEditable($config_ignore_config_key);
+  $ignored_configs = $config_ignore_settings->get('ignored_config_entities');
+  $ignored_configs[] = $dpl_reservations_new_config_key;
+  $config_ignore_settings->set('ignored_config_entities', $ignored_configs)->save();
+
+  // We copy the old configuration to the new configuration key
+  // so we do not lose already added configuration.
+  $dpl_reservations_old_config_data = $dpl_reservations_old_configuration->get();
+  $config_factory->getEditable($dpl_reservations_new_config_key)->setData($dpl_reservations_old_config_data)->save();
+  $config_factory->getEditable($dpl_reservations_old_config_key)->delete();
+  \Drupal::messenger()->addMessage('dpl_reservation_list configuration migrated to dpl_reservations.');
+}

--- a/web/modules/custom/dpl_reservations/src/DplReservationsSettings.php
+++ b/web/modules/custom/dpl_reservations/src/DplReservationsSettings.php
@@ -15,7 +15,7 @@ class DplReservationsSettings extends DplReactConfigBase {
    * Gets the configuration key for reservation settings.
    */
   public function getConfigKey(): string {
-    return 'dpl_reservation_list.settings';
+    return 'dpl_reservations.settings';
   }
 
   /**


### PR DESCRIPTION
### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-630

### Description
This PR updates the configuration key to match the module dpl_reservations.
Changed from dpl_reservation_list.settings to dpl_reservations.settings

Futhermore it adds an update hook that makes sure to migrate existing configuration from dpl_reservation_list.settings into the correct dpl_reservations.settings configuration.

After migrating the configuration, we delete the old configuration.