### PR TITLE
Update Event API, to supply and recieve all external data.

### DIFF
--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_external_admin_link
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -40,7 +41,7 @@ third_party_settings:
       label: 'Teaser card'
       region: content
       parent_name: ''
-      weight: 14
+      weight: 12
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -57,7 +58,7 @@ third_party_settings:
       label: Tagging
       region: content
       parent_name: ''
-      weight: 15
+      weight: 13
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -71,10 +72,11 @@ third_party_settings:
       children:
         - field_event_image
         - field_event_state
+        - field_external_admin_link
       label: 'Event details'
       region: content
       parent_name: ''
-      weight: 13
+      weight: 11
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -125,7 +127,7 @@ content:
     third_party_settings: {  }
   field_event_address:
     type: address_default
-    weight: 6
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -140,7 +142,7 @@ content:
         show_edit: '1'
   field_event_link:
     type: link_default
-    weight: 7
+    weight: 5
     region: content
     settings:
       placeholder_url: ''
@@ -148,7 +150,7 @@ content:
     third_party_settings: {  }
   field_event_paragraphs:
     type: paragraphs
-    weight: 12
+    weight: 10
     region: content
     settings:
       title: Paragraph
@@ -176,7 +178,7 @@ content:
           dialog_style: tiles
   field_event_partners:
     type: string_textfield
-    weight: 10
+    weight: 8
     region: content
     settings:
       size: 60
@@ -184,7 +186,7 @@ content:
     third_party_settings: {  }
   field_event_place:
     type: string_textfield
-    weight: 9
+    weight: 7
     region: content
     settings:
       size: 60
@@ -204,6 +206,14 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_external_admin_link:
+    type: link_default
+    weight: 7
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
     third_party_settings: {  }
   field_tags:
     type: select2_entity_reference
@@ -234,7 +244,7 @@ content:
     third_party_settings: {  }
   field_ticket_categories:
     type: paragraphs
-    weight: 8
+    weight: 6
     region: content
     settings:
       title: Paragraph
@@ -262,13 +272,13 @@ content:
           dialog_style: tiles
   path:
     type: path
-    weight: 30
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 11
+    weight: 9
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_external_admin_link
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -122,6 +123,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_event_title: true
+  field_external_admin_link: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_external_admin_link
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -198,6 +199,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_event_title: true
+  field_external_admin_link: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_external_admin_link
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -186,6 +187,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_event_title: true
+  field_external_admin_link: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_external_admin_link
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -179,6 +180,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_event_title: true
+  field_external_admin_link: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser_stacked_parent.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser_stacked_parent.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_external_admin_link
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -186,6 +187,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_event_title: true
+  field_external_admin_link: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_external_admin_link
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -93,6 +94,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_event_title: true
+  field_external_admin_link: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_external_admin_link
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -86,6 +87,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_event_title: true
+  field_external_admin_link: true
   field_tags: true
   field_teaser_image: true
   field_ticket_categories: true

--- a/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_place
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
+    - field.field.eventinstance.default.field_external_admin_link
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -105,6 +106,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_event_title: true
+  field_external_admin_link: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/field.field.eventinstance.default.field_external_admin_link.yml
+++ b/config/sync/field.field.eventinstance.default.field_external_admin_link.yml
@@ -1,0 +1,23 @@
+uuid: 06d1537d-2f6f-455a-9b23-21f628d4273b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventinstance.field_external_admin_link
+    - recurring_events.eventinstance_type.default
+  module:
+    - link
+id: eventinstance.default.field_external_admin_link
+field_name: field_external_admin_link
+entity_type: eventinstance
+bundle: default
+label: 'External admin link'
+description: 'External systems, such as event management systems, are able to set a value that points to where you can edit the content in their system.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/config/sync/field.storage.eventinstance.field_external_admin_link.yml
+++ b/config/sync/field.storage.eventinstance.field_external_admin_link.yml
@@ -1,0 +1,19 @@
+uuid: e26cf97b-07b1-4e98-9008-88d6e06b157c
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - recurring_events
+id: eventinstance.field_external_admin_link
+field_name: field_external_admin_link
+entity_type: eventinstance
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventResource.php
+++ b/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventResource.php
@@ -116,9 +116,10 @@ final class EventResource extends EventResourceBase {
     $state = $request_data->getState();
     $external_data = $request_data->getExternalData();
 
-    // Only override the URL(s), if external data is set.
+    // Only override external data, if external data is set.
     if ($external_data instanceof EventPATCHRequestExternalData) {
       $event_instance->set('field_event_link', $external_data->getUrl());
+      $event_instance->set('field_external_admin_link', $external_data->getAdminUrl());
     }
 
     $event_instance->set('field_event_state', $state);

--- a/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
+++ b/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dpl_event\Services;
 
+use DanskernesDigitaleBibliotek\CMS\Api\Model\EventPATCHRequestExternalData;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInner;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerAddress;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerDateTime;
@@ -73,9 +74,20 @@ class EventRestMapper {
       'createdAt' => $this->getDateField('created'),
       'updatedAt' => $this->getDateField('changed'),
       'dateTime' => $this->getDate(),
+      'externalData' => $this->getExternalData(),
       'series' => new EventsGET200ResponseInnerSeries([
         'uuid' => $this->event->getEventSeries()->uuid(),
       ]),
+    ]);
+  }
+
+  /**
+   * Getting the external data, supplied by third party PATCH.
+   */
+  private function getExternalData(): EventPATCHRequestExternalData {
+    return new EventPATCHRequestExternalData([
+      'adminUrl' => $this->getValue('field_external_admin_link'),
+      'url' => $this->getValue('event_link'),
     ]);
   }
 


### PR DESCRIPTION
Add new 'field_external_admin_link' to eventinstances. DDFFORM-797

It is on purpose that it is not set up on the series and that there is
no inheritance:
Third parties only have access to edit/see instances.

----

Update event PATCH, to also add admin link. DDFFORM-797

----

Also supply external data with GET:/Events API. DDFFORM-797

https://reload.atlassian.net/browse/DDFFORM-797