### PR TITLE
Add permission for `administer maintenance mode` + Add `config_perms`  / Custom Permissions Module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
         "drupal/config_filter": "^2.6",
         "drupal/config_ignore": "^3",
         "drupal/config_ignore_auto": "^3",
+        "drupal/config_perms": "^2.1",
         "drupal/config_translation_po": "^1.0",
         "drupal/content_lock": "^2.3",
         "drupal/cookieinformation": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc1323d5f135eaef38c3052276cd9c57",
+    "content-hash": "6c58aa470f72b6457a033c48a0857460",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2678,6 +2678,82 @@
             "homepage": "https://www.drupal.org/project/config_ignore_auto",
             "support": {
                 "source": "https://git.drupalcode.org/project/config_ignore_auto"
+            }
+        },
+        {
+            "name": "drupal/config_perms",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_perms.git",
+                "reference": "8.x-2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_perms-8.x-2.1.zip",
+                "reference": "8.x-2.1",
+                "shasum": "06bc0d6587fba76149b4de7ccc32f6c6b8bc382a"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.1",
+                    "datestamp": "1685589568",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "benellefimostfa",
+                    "homepage": "https://www.drupal.org/user/3092403"
+                },
+                {
+                    "name": "Docc",
+                    "homepage": "https://www.drupal.org/user/310132"
+                },
+                {
+                    "name": "gnuget",
+                    "homepage": "https://www.drupal.org/user/992990"
+                },
+                {
+                    "name": "Kristen Pol",
+                    "homepage": "https://www.drupal.org/user/8389"
+                },
+                {
+                    "name": "lelkneralfaro",
+                    "homepage": "https://www.drupal.org/user/3577260"
+                },
+                {
+                    "name": "MegaKeegMan",
+                    "homepage": "https://www.drupal.org/user/3620027"
+                },
+                {
+                    "name": "mlncn",
+                    "homepage": "https://www.drupal.org/user/64383"
+                },
+                {
+                    "name": "mrthumpz",
+                    "homepage": "https://www.drupal.org/user/266351"
+                }
+            ],
+            "description": "Allows additional permissions to be created and managed through an administration form.",
+            "homepage": "http://drupal.org/project/config_perms",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/config_perms",
+                "issues": "http://drupal.org/project/issues/config_perms"
             }
         },
         {

--- a/config/sync/config_perms.custom_perms_entity.administer_maintenance_mode.yml
+++ b/config/sync/config_perms.custom_perms_entity.administer_maintenance_mode.yml
@@ -1,0 +1,7 @@
+uuid: e813276f-23f5-4f43-aae5-a35977bc2ef3
+langcode: en
+status: true
+dependencies: {  }
+id: administer_maintenance_mode
+label: 'Administer maintenance mode'
+route: system.site_maintenance_mode

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -16,6 +16,7 @@ module:
   config_filter: 0
   config_ignore: 0
   config_ignore_auto: 0
+  config_perms: 0
   config_translation: 0
   config_translation_po: 0
   content_lock: 0

--- a/config/sync/entity_clone.cloneable_entities.yml
+++ b/config/sync/entity_clone.cloneable_entities.yml
@@ -3,3 +3,4 @@ cloneable_entities:
   - path_alias
   - redirect
   - paragraph
+  - custom_perms_entity

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -23,6 +23,7 @@ dependencies:
   module:
     - administerusersbyrole
     - block
+    - config_perms
     - content_lock
     - cookieinformation
     - dpl_admin
@@ -63,6 +64,7 @@ label: Administrator
 weight: 2
 is_admin: null
 permissions:
+  - 'Administer maintenance mode'
   - 'access administration pages'
   - 'access any webform configuration'
   - 'access content overview'

--- a/web/modules/custom/dpl_admin/dpl_admin.install
+++ b/web/modules/custom/dpl_admin/dpl_admin.install
@@ -172,3 +172,18 @@ function dpl_admin_update_10001(array &$sandbox): string {
   }, $administrators);
   return implode("\n", $updates);
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * This update ensures that all sites are returned to normal state
+ * (not in maintenance mode) after limiting access to maintenance mode
+ * to only administrators.
+ *
+ * See https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1171
+ */
+function dpl_admin_update_10002(): string {
+  // Set all sites to normal mode.
+  \Drupal::state()->set('system.maintenance_mode', FALSE);
+  return 'All sites have been moved back to normal state.';
+}

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -21,6 +21,7 @@ use Drupal\drupal_typed\DrupalTyped;
 function dpl_update_install(): string {
   $messages[] = dpl_update_update_10001();
   $messages[] = dpl_update_update_10002();
+  $messages[] = dpl_update_update_10003();
 
   return implode('\r\n', $messages);
 }
@@ -39,6 +40,13 @@ function dpl_update_update_10001(): string {
  */
 function dpl_update_update_10002(): string {
   return _dpl_update_install_modules(['collation_fixer']);
+}
+
+/**
+ * Installing config_perms module.
+ */
+function dpl_update_update_10003(): string {
+  return _dpl_update_install_modules(['config_perms']);
 }
 
 /**


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-762

#### Description
This pull request adds a new `administer maintenance mode` permission using the `config_perms` ([Custom Permissions](https://www.drupal.org/project/config_perms)) module.

This restricts the maintenance mode settings to `admin` users only.


#### Test

Test on https://varnish.pr-1171.dpl-cms.dplplat01.dpl.reload.dk/

Log in as `super admin`, https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-1171/tasks/ and choose `generate login link (uli)` go to `/admin/config', find Development (Udvikling) and see that Maintenance Mode (Vedligeholdstilstand) is there.

Log in as `local_administrator`, go to https://varnish.pr-1171.dpl-cms.dplplat01.dpl.reload.dk/admin/config, find Development (Udvikling) and see that Maintenance Mode (Vedligeholdstilstand) is **not** there.


#### Screenshot of the result
<img width="1840" alt="Skærmbillede 2024-05-23 kl  14 06 40" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/3f409b5f-d881-47d4-8218-069d15ba8163">

<img width="1840" alt="Skærmbillede 2024-05-23 kl  14 08 03" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/37e39659-c793-4f52-9014-a6ab35f8fa45">
