### PR TITLE
Set `Event` series time intervals to 15 minutes

### DIFF
--- a/config/sync/recurring_events.eventseries.config.yml
+++ b/config/sync/recurring_events.eventseries.config.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: HuNc0wdz6BZa5IceY8HDpVfwTwqvp1rpRQeuS5szwSo
-interval: 30
+interval: 15
 min_time: '08:00am'
 max_time: '11:45pm'
 date_format: 'd/m/y - H:i'


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-789


#### Description

This pull request is changing the `Event` series time intervals to 15 minutes. By making this change, we ensure that consecutive events can now start and end at precise 15-minute intervals (e.g., 10:00, 10:15, 10:45, 11:00).


#### Test 
http://varnish.pr-1173.dpl-cms.dplplat01.dpl.reload.dk/events/add/default

#### Screenshot of the result
<img width="1726" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/18553104-e996-4cf3-811a-2b3ff8171442">
