### PR TITLE
DDFLSBP-665 - Enable confirmation message configuration

### DIFF
--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -25,6 +25,7 @@ dependencies:
     - dpl_admin
     - dpl_footer
     - dpl_opening_hours
+    - dpl_webform
     - entity_clone
     - file
     - filter
@@ -58,6 +59,7 @@ permissions:
   - 'access webform overview'
   - 'add eventseries entity'
   - 'add new links to main menu'
+  - 'administer advanced webform confirmation settings'
   - 'administer dpl_footer settings'
   - 'administer menu'
   - 'administer nodes'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -30,6 +30,7 @@ dependencies:
     - dpl_mapp
     - dpl_opening_hours
     - dpl_url_proxy
+    - dpl_webform
     - entity_clone
     - file
     - filter
@@ -73,6 +74,7 @@ permissions:
   - 'add eventseries entity'
   - 'add new links to admin menu'
   - 'add new links to main menu'
+  - 'administer advanced webform confirmation settings'
   - 'administer dpl_footer settings'
   - 'administer dpl_mapp configuration'
   - 'administer instant loan configuration'

--- a/web/modules/custom/dpl_webform/dpl_webform.module
+++ b/web/modules/custom/dpl_webform/dpl_webform.module
@@ -16,6 +16,11 @@ function dpl_webform_webform_create(Webform $webform): void {
   // Therefore we disable saving of results for all new webforms.
   $webform->setSetting('results_disabled', TRUE);
   $webform->setSetting('results_disabled_ignore', TRUE);
+
+  // We want to set a new "default_value" to the "confirmation_type" setting.
+  // If we do not set this, the editors will have to manually change it when
+  // creating a new webform.
+  $webform->setSetting('confirmation_type', 'message');
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-665

#### Description

This PR makes it possible for users with the roles 'local_administrator' and 'editor' to change how confirmation messages should be shown by giving the roles the correct permission. 

We also change the default confirmation type to be 'message', which means that the confirmation message will be shown on the same page as the webform. 
