### PR TITLE
Replace hashing of openid_connect authmap sub ident

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -58,6 +58,9 @@ parameters:
       path: web/modules/custom/dpl_po/src/Services/CtpConfigManager.php
     # Drupal field widget formElement() method has parameters and return type which we cannot provide more detailed typing of.
     - '#Method Drupal\\.*\\Plugin\\Field\\FieldWidget\\.*::formElement\(\) .* no value type specified in iterable type array\.#'
+    -
+      message: "#Variable .* might not be defined#"
+      path: web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
   scanFiles:
     # Needed to make locale_translation_batch_fetch_finished() discoverable.
     - web/core/modules/locale/locale.batch.inc

--- a/web/modules/custom/dpl_login/dpl_login.module
+++ b/web/modules/custom/dpl_login/dpl_login.module
@@ -13,7 +13,6 @@ use DanskernesDigitaleBibliotek\FBS\Model\BlockStatus;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Site\Settings;
 use Drupal\dpl_fbs\Patron\BlockedReason;
 use Drupal\dpl_login\AccessToken;
 use Drupal\dpl_login\DplLoginInterface;
@@ -22,8 +21,6 @@ use Drupal\dpl_login\UserTokensProviderInterface;
 use Drupal\user\UserInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
-
-use function Safe\sprintf as sprintf;
 
 /**
  * Implements hook_openid_connect_userinfo_alter().
@@ -36,25 +33,11 @@ use function Safe\sprintf as sprintf;
  * @throws Exception
  */
 function dpl_login_openid_connect_userinfo_alter(array &$userinfo, array $context): void {
-
-  // If we cannot resolve both cpr and uniqueId we cannot continue.
-  if (!$cpr = $userinfo['attributes']['cpr'] ?? FALSE) {
-    if (!$uniqueId = $userinfo['attributes']['uniqueId'] ?? FALSE) {
-      throw new \Exception('Unable to identify user. Both CPR and uniqueId are missing.');
-    }
-  }
-
-  $id = $cpr ?: $uniqueId;
-
-  $id_hash = crypt($id, Settings::getHashSalt());
-
-  $name = uniqid();
-  // Drupal needs an email. We set a unique one to apply to that rule.
-  $userinfo['email'] = sprintf('%s@dpl-cms.invalid', $name);
-  // Drupal needs a username. We use the unique id to apply to that rule.
-  $userinfo['name'] = $name;
-  // openid_connect module needs the sub for creating the auth map.
-  $userinfo['sub'] = $id_hash;
+  $service = \Drupal::service('dpl_login.openid_user_info');
+  $userinfo = array_merge(
+    $userinfo,
+    $service->getOpenIdUserInfoFromAdgangsplatformenUserInfoResponse($userinfo)
+  );
 }
 
 /**

--- a/web/modules/custom/dpl_login/dpl_login.services.yml
+++ b/web/modules/custom/dpl_login/dpl_login.services.yml
@@ -46,3 +46,6 @@ services:
   dpl_login.adgangsplatformen.config:
     class: Drupal\dpl_login\Adgangsplatformen\Config
     arguments: ["@config.factory"]
+  dpl_login.openid_user_info:
+    class: Drupal\dpl_login\OpenIdUserInfoService
+    arguments: ["@settings"]

--- a/web/modules/custom/dpl_login/src/AuthorizationIdType.php
+++ b/web/modules/custom/dpl_login/src/AuthorizationIdType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\dpl_login;
+
+/**
+ * Authorization id types enum.
+ *
+ * Used to distinguish between different identifiers.
+ */
+enum AuthorizationIdType: string {
+  case CPR = 'cpr';
+  case UNIQUE_ID = 'unique_id';
+}

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\dpl_login;
+
+use Drupal\Core\Site\Settings;
+
+/**
+ * Access Token.
+ */
+class OpenIdUserInfoService {
+
+  /**
+   *
+   */
+  public function __construct(
+    private Settings $settings
+  ) {}
+
+  /**
+   *
+   */
+  public function getOpenIdUserInfoFromAdgangsplatformenUserInfoResponse(array $response): array {
+    $name = uniqid();
+    // Drupal needs an email. We set a unique one to apply to that rule.
+    $userinfo['email'] = sprintf('%s@dpl-cms.invalid', $name);
+    // Drupal needs a username. We use the unique id to apply to that rule.
+    $userinfo['name'] = $name;
+    // openid_connect module needs the sub for creating the auth map.
+    $userinfo['sub'] = $this->getSubHashFromUserInfo($response);
+
+    return $userinfo;
+  }
+
+  /**
+   *
+   */
+  public function getSubHashFromUserInfo(array $userinfo): string {
+    if (!$cpr = $userinfo['attributes']['cpr'] ?? FALSE) {
+      if (!$uniqueId = $userinfo['attributes']['uniqueId'] ?? FALSE) {
+        throw new \Exception('Unable to identify user. Both CPR and uniqueId are missing.');
+      }
+    }
+
+    $id = $cpr ?: $uniqueId;
+    return $this->hashIdentifier($id);
+  }
+
+  /**
+   *
+   */
+  public function hashIdentifier(string $identifier): string {
+    return crypt($identifier, $this->settings::getHashSalt());
+  }
+
+}

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -61,7 +61,7 @@ class OpenIdUserInfoService {
    * @param mixed[] $userinfo
    *   The userinfo from the adgangsplatformen userinfo endpoint.
    *
-   * @return mixed[]
+   * @return array{"id": string, "type": AuthorizationIdType}
    *   The identifier data: Raw id and type of id.
    */
   public function getIdentifierDataFromUserInfo(array $userinfo): array {

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -26,7 +26,7 @@ class OpenIdUserInfoService {
     // Drupal needs a username. We use the unique id to apply to that rule.
     $userinfo['name'] = $name;
     // openid_connect module needs the sub for creating the auth map.
-    $userinfo['sub'] = $this->getSubHashFromUserInfo($response);
+    $userinfo['sub'] = $this->getSubIdFromUserInfo($response);
 
     return $userinfo;
   }
@@ -34,8 +34,20 @@ class OpenIdUserInfoService {
   /**
    *
    */
-  public function getSubHashFromUserInfo(array $userinfo): string {
-    return $this->hashIdentifier($this->getIdentifierDataFromUserInfo($userinfo)['id']);
+  public function getSubIdFromUserInfo(array $userinfo): ?string {
+    $identifier_data = $this->getIdentifierDataFromUserInfo($userinfo);
+
+    switch ($identifier_data['type']) {
+      case AuthorizationIdType::CPR:
+        return $this->hashIdentifier($identifier_data['id']);
+
+      // We use the unique id as is. DBC says we can trust the uniquenes of it.
+      case AuthorizationIdType::UNIQUE_ID:
+        return $identifier_data['id'];
+
+      default:
+        return NULL;
+    }
   }
 
   /**

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -7,7 +7,9 @@ use Drupal\Core\Site\Settings;
 use function Safe\sprintf;
 
 /**
- * Access Token.
+ * OpenIdUserInfoService.
+ *
+ * Used for handling the userinfo from the adgangsplatformen userinfo endpoint.
  */
 class OpenIdUserInfoService {
 

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -91,7 +91,11 @@ class OpenIdUserInfoService {
   }
 
   /**
-   * Hash the identifier.
+   * We need a unique identifier for the openid_connect authmap.
+   *
+   * Since we cannot use the CPR or uniqueId directly as the identifier
+   * we hash it with a salt. That way we can still identify the user
+   * but the actual identifier is not stored in the database.
    *
    * @param string $identifier
    *   The identifier to hash.

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -4,6 +4,8 @@ namespace Drupal\dpl_login;
 
 use Drupal\Core\Site\Settings;
 
+use function Safe\sprintf;
+
 /**
  * Access Token.
  */

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -78,7 +78,7 @@ class OpenIdUserInfoService {
    *
    */
   public function hashIdentifier(string $identifier): string {
-    return crypt($identifier, $this->settings::getHashSalt());
+    return crypt($identifier, sprintf('$5$%s', $this->settings::getHashSalt()));
   }
 
 }

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -34,20 +34,9 @@ class OpenIdUserInfoService {
   /**
    *
    */
-  public function getSubIdFromUserInfo(array $userinfo): ?string {
+  public function getSubIdFromUserInfo(array $userinfo): string {
     $identifier_data = $this->getIdentifierDataFromUserInfo($userinfo);
-
-    switch ($identifier_data['type']) {
-      case AuthorizationIdType::CPR:
-        return $this->hashIdentifier($identifier_data['id']);
-
-      // We use the unique id as is. DBC says we can trust the uniquenes of it.
-      case AuthorizationIdType::UNIQUE_ID:
-        return $identifier_data['id'];
-
-      default:
-        return NULL;
-    }
+    return $this->hashIdentifier($identifier_data['id']);
   }
 
   /**

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -104,7 +104,7 @@ class OpenIdUserInfoService {
    *   The hashed identifier.
    */
   public function hashIdentifier(string $identifier): string {
-    return crypt($identifier, sprintf('$5$%s', $this->settings::getHashSalt()));
+    return hash_hmac('sha256', $identifier, $this->settings::getHashSalt());
   }
 
 }

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -26,7 +26,7 @@ class OpenIdUserInfoService {
    * @param mixed[] $response
    *   The response from the userinfo endpoint.
    *
-   * @return mixed[]
+   * @return array{'email': string, 'name': string, 'sub': string}
    *   The openid_connect user info.
    */
   public function getOpenIdUserInfoFromAdgangsplatformenUserInfoResponse(array $response): array {

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -12,14 +12,22 @@ use function Safe\sprintf;
 class OpenIdUserInfoService {
 
   /**
-   *
+   * Constructor.
    */
   public function __construct(
     private Settings $settings
   ) {}
 
   /**
+   * Get the user info from the response.
    *
+   * From the adgangsplatformen userinfo endpoint.
+   *
+   * @param mixed[] $response
+   *   The response from the userinfo endpoint.
+   *
+   * @return mixed[]
+   *   The openid_connect user info.
    */
   public function getOpenIdUserInfoFromAdgangsplatformenUserInfoResponse(array $response): array {
     $name = uniqid();
@@ -34,7 +42,13 @@ class OpenIdUserInfoService {
   }
 
   /**
+   * Get the hashed userinfo id.
    *
+   * @param mixed[] $userinfo
+   *   The userinfo from the adgangsplatformen userinfo endpoint.
+   *
+   * @return string
+   *   The hashed opemid_connect sub id.
    */
   public function getSubIdFromUserInfo(array $userinfo): string {
     $identifier_data = $this->getIdentifierDataFromUserInfo($userinfo);
@@ -42,11 +56,18 @@ class OpenIdUserInfoService {
   }
 
   /**
+   * Get the identifier data from the userinfo.
    *
+   * @param mixed[] $userinfo
+   *   The userinfo from the adgangsplatformen userinfo endpoint.
+   *
+   * @return mixed[]
+   *   The identifier data: Raw id and type of id.
    */
   public function getIdentifierDataFromUserInfo(array $userinfo): array {
     $cpr = $userinfo['attributes']['cpr'] ?? FALSE;
     $unique_id = $userinfo['attributes']['uniqueId'] ?? FALSE;
+    $id = $type = NULL;
 
     if (!$cpr && !$unique_id) {
       throw new \Exception('Unable to identify user. Both CPR and uniqueId are missing.');
@@ -66,7 +87,13 @@ class OpenIdUserInfoService {
   }
 
   /**
+   * Hash the identifier.
    *
+   * @param string $identifier
+   *   The identifier to hash.
+   *
+   * @return string
+   *   The hashed identifier.
    */
   public function hashIdentifier(string $identifier): string {
     return crypt($identifier, sprintf('$5$%s', $this->settings::getHashSalt()));

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -67,6 +67,10 @@ class OpenIdUserInfoService {
   public function getIdentifierDataFromUserInfo(array $userinfo): array {
     $cpr = $userinfo['attributes']['cpr'] ?? FALSE;
     $unique_id = $userinfo['attributes']['uniqueId'] ?? FALSE;
+    // This is added to make Phpstan happy.
+    // The fact that an exception is thrown if both are missing
+    // should make it impossible to end up with NULL values.
+    // But Phpstan does not understand that.
     $id = $type = NULL;
 
     if (!$cpr && !$unique_id) {

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -35,14 +35,31 @@ class OpenIdUserInfoService {
    *
    */
   public function getSubHashFromUserInfo(array $userinfo): string {
-    if (!$cpr = $userinfo['attributes']['cpr'] ?? FALSE) {
-      if (!$uniqueId = $userinfo['attributes']['uniqueId'] ?? FALSE) {
-        throw new \Exception('Unable to identify user. Both CPR and uniqueId are missing.');
-      }
+    return $this->hashIdentifier($this->getIdentifierDataFromUserInfo($userinfo)['id']);
+  }
+
+  /**
+   *
+   */
+  public function getIdentifierDataFromUserInfo(array $userinfo): array {
+    $cpr = $userinfo['attributes']['cpr'] ?? FALSE;
+    $unique_id = $userinfo['attributes']['uniqueId'] ?? FALSE;
+
+    if (!$cpr && !$unique_id) {
+      throw new \Exception('Unable to identify user. Both CPR and uniqueId are missing.');
     }
 
-    $id = $cpr ?: $uniqueId;
-    return $this->hashIdentifier($id);
+    if ($unique_id) {
+      $id = $unique_id;
+      $type = AuthorizationIdType::UNIQUE_ID;
+    }
+
+    if ($cpr) {
+      $id = $cpr;
+      $type = AuthorizationIdType::CPR;
+    }
+
+    return ['id' => $id, 'type' => $type];
   }
 
   /**

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
@@ -66,6 +66,17 @@ class OpenIdAuthMapTest extends UnitTestCase {
   /**
    *
    */
+  public function testThatHashedIdentifierIsReproducible() {
+    $service = new OpenIdUserInfoService($this->settings);
+    $id = '9d67c9fa-81d6-41ce-8b42-9d187b306fd9';
+    $hash1 = $service->hashIdentifier($id);
+    $hash2 = $service->hashIdentifier($id);
+    $this->assertEquals($hash1, $hash2);
+  }
+
+  /**
+   *
+   */
   public function cprHasPrecedenceOverUniqueIdData(): array {
     return [
       'cpr is getting hashed when both cpr and uniqueId are present' => [

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
@@ -31,9 +31,9 @@ class OpenIdAuthMapTest extends UnitTestCase {
    * @dataProvider cprHasPrecedenceOverUniqueIdData
    */
   public function testHashCreationThatCprHasPrecedenceOverUniqueid(array $userinfo, string $expected_sub_id, AuthorizationIdType $expected_id_type) {
-    $open_id_user_info_service = new OpenIdUserInfoService($this->settings);
-    $sub_id = $open_id_user_info_service->getSubIdFromUserInfo($userinfo);
-    $id_type = $open_id_user_info_service->getIdentifierDataFromUserInfo($userinfo)['type'];
+    $service = new OpenIdUserInfoService($this->settings);
+    $sub_id = $service->getSubIdFromUserInfo($userinfo);
+    $id_type = $service->getIdentifierDataFromUserInfo($userinfo)['type'];
 
     $this->assertEquals($expected_sub_id, $sub_id);
     $this->assertEquals($expected_id_type, $id_type);
@@ -43,23 +43,23 @@ class OpenIdAuthMapTest extends UnitTestCase {
    *
    */
   public function testThatGettingSubHashFromUserInfoThrowsAnExceptionIfBothCprAndUniqueIdAreMissing() {
-    $open_id_user_info_service = new OpenIdUserInfoService($this->settings);
+    $service = new OpenIdUserInfoService($this->settings);
     $userinfo = [
       'attributes' => [],
     ];
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Unable to identify user. Both CPR and uniqueId are missing.');
 
-    $open_id_user_info_service->getSubIdFromUserInfo($userinfo);
+    $service->getSubIdFromUserInfo($userinfo);
   }
 
   /**
    * @dataProvider weGetUniqueHashesNotMatterWhatData
    */
   public function testThatHashIdentifierReturnsAUniqueHash(string $id_1, string $id_2) {
-    $open_id_user_info_service = new OpenIdUserInfoService($this->settings);
-    $hash1 = $open_id_user_info_service->hashIdentifier($id_1);
-    $hash2 = $open_id_user_info_service->hashIdentifier($id_2);
+    $service = new OpenIdUserInfoService($this->settings);
+    $hash1 = $service->hashIdentifier($id_1);
+    $hash2 = $service->hashIdentifier($id_2);
     $this->assertNotEquals($hash1, $hash2);
   }
 

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
@@ -56,7 +56,7 @@ class OpenIdAuthMapTest extends UnitTestCase {
   /**
    * @dataProvider weGetUniqueHashesNotMatterWhatData
    */
-  public function testThatHashIdentifierReturnsAUniqueHash(string $id_1, string $id_2) {
+  public function testThatHashedCprsAreUnique(string $id_1, string $id_2) {
     $service = new OpenIdUserInfoService($this->settings);
     $hash1 = $service->hashIdentifier($id_1);
     $hash2 = $service->hashIdentifier($id_2);
@@ -75,7 +75,7 @@ class OpenIdAuthMapTest extends UnitTestCase {
             'uniqueId' => '9d67c9fa-81d6-41ce-8b42-9d187b306fd9',
           ],
         ],
-        'e32K92Yudky16',
+        '$5$e3b0c44298fc1c14$yd.tasg4wRielbUAUo.AKfcvYplJeAPfXvPBfKxaO47',
         AuthorizationIdType::CPR,
       ],
       'uniqueId is getting hashed when cpr is missing' => [
@@ -130,134 +130,6 @@ class OpenIdAuthMapTest extends UnitTestCase {
       'a pair of cpr that starts with the same nine characters' => [
         '1234567890',
         '1234567891',
-      ],
-      'a pair of cpr that are identical' => [
-        '1234567890',
-        '1234567890',
-      ],
-      'a pair of unique_ids that start with the same character' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e0aca8c3-5e36-42e0-b9e5-bd867e3b4599',
-      ],
-      'a pair of unique_ids that starts with the same two characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1aca8c3-5e36-42e0-b9e5-bd867e3b4599',
-      ],
-      'a pair of unique_ids that starts with the same three characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1aee469-527b-4025-9c55-2daa7a9fa172',
-      ],
-      'a pair of unique_ids that starts with the same four characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0d7c6-1dad-4372-89dd-d23d018c470b',
-      ],
-      'a pair of unique_ids that starts with the same five characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0e309-432e-48bd-914a-ab30cfcc2f6c',
-      ],
-      'a pair of unique_ids that starts with the same six characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0ecaf-2830-44da-aaa0-109d81aff5e4',
-      ],
-      'a pair of unique_ids that starts with the same seven characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0ecc5-90eb-4f5c-acb8-a457c38f0f02',
-      ],
-      'a pair of unique_ids that starts with the same nine characters (because of separator)' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-4b5b-418c-a6df-eafad2898e36',
-      ],
-      'a pair of unique_ids that starts withe the same ten characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-69cb-4a3c-b62b-3a9bccd75e54',
-      ],
-      'a pair of unique_ids that starts withe the same elleven characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6ac1-4cb5-be86-fae04806fe59',
-      ],
-      'a pair of unique_ids that starts withe the same twelve characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a81-4cb5-be86-fae04806fe59',
-      ],
-      'a pair of unique_ids that starts withe the same thirteen characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-1e9a-b38c-eed00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same sixteen characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-479a-b38c-eed00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same seventeen characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47aa-b38c-eed00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same nineteen characters (because of separator)' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-b38c-eed00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same twenty characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-838c-eed00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same twenty one characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-888c-eed00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same twenty two characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-eed00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same twenty three characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-8865-eed00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same twenty five characters (because of separator)' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ed00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same twenty six characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ad00a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same twenty seven characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ac90a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same twenty eight characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ac90a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same twenty nine characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ac91a66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same thirty characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ac91c66a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same thirty one characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ac91c16a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same thirty two characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ac91c10a2c3',
-      ],
-      'a pair of unique_ids that starts withe the same thirty three characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ac91c1042c3',
-      ],
-      'a pair of unique_ids that starts withe the same thirty four characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ac91c104fc3',
-      ],
-      'a pair of unique_ids that starts withe the same thirty five characters' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-886c-6ac91c104f23',
-      ],
-      'a pair of unique_ids that are identical' => [
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
-        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
       ],
     ];
   }

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
@@ -30,11 +30,12 @@ class OpenIdAuthMapTest extends UnitTestCase {
   /**
    * @dataProvider cprHasPrecedenceOverUniqueIdData
    */
-  public function testHashCreationThatCprHasPrecedenceOverUniqueid(array $userinfo, string $expected_hash, AuthorizationIdType $expected_id_type) {
+  public function testHashCreationThatCprHasPrecedenceOverUniqueid(array $userinfo, string $expected_sub_id, AuthorizationIdType $expected_id_type) {
     $open_id_user_info_service = new OpenIdUserInfoService($this->settings);
-    $hash = $open_id_user_info_service->getSubHashFromUserInfo($userinfo);
+    $sub_id = $open_id_user_info_service->getSubIdFromUserInfo($userinfo);
     $id_type = $open_id_user_info_service->getIdentifierDataFromUserInfo($userinfo)['type'];
-    $this->assertEquals($expected_hash, $hash);
+
+    $this->assertEquals($expected_sub_id, $sub_id);
     $this->assertEquals($expected_id_type, $id_type);
   }
 
@@ -49,7 +50,7 @@ class OpenIdAuthMapTest extends UnitTestCase {
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Unable to identify user. Both CPR and uniqueId are missing.');
 
-    $open_id_user_info_service->getSubHashFromUserInfo($userinfo);
+    $open_id_user_info_service->getSubIdFromUserInfo($userinfo);
   }
 
   /**
@@ -83,7 +84,7 @@ class OpenIdAuthMapTest extends UnitTestCase {
             'uniqueId' => '9d67c9fa-81d6-41ce-8b42-9d187b306fd9',
           ],
         ],
-        'e3ydd5oyGyQNc',
+        '9d67c9fa-81d6-41ce-8b42-9d187b306fd9',
         AuthorizationIdType::UNIQUE_ID,
       ],
     ];

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\dpl_login\Unit;
 
 use Drupal\Core\Site\Settings;
+use Drupal\dpl_login\AuthorizationIdType;
 use Drupal\dpl_login\OpenIdUserInfoService;
 use Drupal\Tests\UnitTestCase;
 
@@ -29,10 +30,12 @@ class OpenIdAuthMapTest extends UnitTestCase {
   /**
    * @dataProvider cprHasPrecedenceOverUniqueIdData
    */
-  public function testHashCreationThatCprHasPrecedenceOverUniqueid(array $userinfo, string $expected_hash) {
+  public function testHashCreationThatCprHasPrecedenceOverUniqueid(array $userinfo, string $expected_hash, AuthorizationIdType $expected_id_type) {
     $open_id_user_info_service = new OpenIdUserInfoService($this->settings);
     $hash = $open_id_user_info_service->getSubHashFromUserInfo($userinfo);
+    $id_type = $open_id_user_info_service->getIdentifierDataFromUserInfo($userinfo)['type'];
     $this->assertEquals($expected_hash, $hash);
+    $this->assertEquals($expected_id_type, $id_type);
   }
 
   /**
@@ -72,6 +75,7 @@ class OpenIdAuthMapTest extends UnitTestCase {
           ],
         ],
         'e32K92Yudky16',
+        AuthorizationIdType::CPR,
       ],
       'uniqueId is getting hashed when cpr is missing' => [
         [
@@ -80,6 +84,7 @@ class OpenIdAuthMapTest extends UnitTestCase {
           ],
         ],
         'e3ydd5oyGyQNc',
+        AuthorizationIdType::UNIQUE_ID,
       ],
     ];
   }

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Drupal\Tests\dpl_login\Unit;
+
+use Drupal\Core\Site\Settings;
+use Drupal\dpl_login\OpenIdUserInfoService;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Unit test for the Adgangsplatformen configuration.
+ *
+ * @covers \Drupal\dpl_login\Adgangsplatformen\Config
+ */
+class OpenIdAuthMapTest extends UnitTestCase {
+  private Settings $settings;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $settings = [];
+    $settings['hash_salt'] = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+    $this->settings = new Settings($settings);
+
+  }
+
+  /**
+   * @dataProvider cprHasPrecedenceOverUniqueIdData
+   */
+  public function testHashCreationThatCprHasPrecedenceOverUniqueid(array $userinfo, string $expected_hash) {
+    $open_id_user_info_service = new OpenIdUserInfoService($this->settings);
+    $hash = $open_id_user_info_service->getSubHashFromUserInfo($userinfo);
+    $this->assertEquals($expected_hash, $hash);
+  }
+
+  /**
+   *
+   */
+  public function testThatGettingSubHashFromUserInfoThrowsAnExceptionIfBothCprAndUniqueIdAreMissing() {
+    $open_id_user_info_service = new OpenIdUserInfoService($this->settings);
+    $userinfo = [
+      'attributes' => [],
+    ];
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('Unable to identify user. Both CPR and uniqueId are missing.');
+
+    $open_id_user_info_service->getSubHashFromUserInfo($userinfo);
+  }
+
+  /**
+   * @dataProvider weGetUniqueHashesNotMatterWhatData
+   */
+  public function testThatHashIdentifierReturnsAUniqueHash(string $id_1, string $id_2) {
+    $open_id_user_info_service = new OpenIdUserInfoService($this->settings);
+    $hash1 = $open_id_user_info_service->hashIdentifier($id_1);
+    $hash2 = $open_id_user_info_service->hashIdentifier($id_2);
+    $this->assertNotEquals($hash1, $hash2);
+  }
+
+  /**
+   *
+   */
+  public function cprHasPrecedenceOverUniqueIdData(): array {
+    return [
+      'cpr is getting hashed when both cpr and uniqueId are present' => [
+        [
+          'attributes' => [
+            'cpr' => '1234567890',
+            'uniqueId' => '9d67c9fa-81d6-41ce-8b42-9d187b306fd9',
+          ],
+        ],
+        'e32K92Yudky16',
+      ],
+      'uniqueId is getting hashed when cpr is missing' => [
+        [
+          'attributes' => [
+            'uniqueId' => '9d67c9fa-81d6-41ce-8b42-9d187b306fd9',
+          ],
+        ],
+        'e3ydd5oyGyQNc',
+      ],
+    ];
+  }
+
+  /**
+   *
+   */
+  public function weGetUniqueHashesNotMatterWhatData(): array {
+    return [
+      'a pair of cpr that starts with the same character' => [
+        '1234567890',
+        '1098765432',
+      ],
+      'a pair of cpr that starts with the same two characters' => [
+        '1234567890',
+        '1209876543',
+      ],
+      'a pair of cpr that starts with the same three characters' => [
+        '1234567890',
+        '1230987654',
+      ],
+      'a pair of cpr that starts with the same four characters' => [
+        '1234567890',
+        '1234098765',
+      ],
+      'a pair of cpr that starts with the same five characters' => [
+        '1234567890',
+        '1234509876',
+      ],
+      'a pair of cpr that starts with the same six characters' => [
+        '1234567890',
+        '1234560987',
+      ],
+      'a pair of cpr that starts with the same seven characters' => [
+        '1234567890',
+        '1234567098',
+      ],
+      'a pair of cpr that starts with the same eight characters' => [
+        '1234567890',
+        '1234567809',
+      ],
+      'a pair of cpr that starts with the same nine characters' => [
+        '1234567890',
+        '1234567891',
+      ],
+      'a pair of cpr that are identical' => [
+        '1234567890',
+        '1234567890',
+      ],
+      'a pair of unique_ids that start with the same character' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e0aca8c3-5e36-42e0-b9e5-bd867e3b4599',
+      ],
+      'a pair of unique_ids that starts with the same two characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1aca8c3-5e36-42e0-b9e5-bd867e3b4599',
+      ],
+      'a pair of unique_ids that starts with the same three characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1aee469-527b-4025-9c55-2daa7a9fa172',
+      ],
+      'a pair of unique_ids that starts with the same four characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0d7c6-1dad-4372-89dd-d23d018c470b',
+      ],
+      'a pair of unique_ids that starts with the same five characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0e309-432e-48bd-914a-ab30cfcc2f6c',
+      ],
+      'a pair of unique_ids that starts with the same six characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0ecaf-2830-44da-aaa0-109d81aff5e4',
+      ],
+      'a pair of unique_ids that starts with the same seven characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0ecc5-90eb-4f5c-acb8-a457c38f0f02',
+      ],
+      'a pair of unique_ids that starts with the same nine characters (because of separator)' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-4b5b-418c-a6df-eafad2898e36',
+      ],
+      'a pair of unique_ids that starts withe the same ten characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-69cb-4a3c-b62b-3a9bccd75e54',
+      ],
+      'a pair of unique_ids that starts withe the same elleven characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6ac1-4cb5-be86-fae04806fe59',
+      ],
+      'a pair of unique_ids that starts withe the same twelve characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a81-4cb5-be86-fae04806fe59',
+      ],
+      'a pair of unique_ids that starts withe the same thirteen characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-1e9a-b38c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same sixteen characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-479a-b38c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same seventeen characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47aa-b38c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same nineteen characters (because of separator)' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-b38c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-838c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty one characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-888c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty two characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty three characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-8865-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty five characters (because of separator)' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty six characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ad00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty seven characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac90a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty eight characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac90a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty nine characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty one characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c16a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty two characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c10a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty three characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c1042c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty four characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c104fc3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty five characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c104f23',
+      ],
+      'a pair of unique_ids that are identical' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
@@ -56,7 +56,7 @@ class OpenIdAuthMapTest extends UnitTestCase {
   /**
    * @dataProvider weGetUniqueHashesNotMatterWhatData
    */
-  public function testThatHashedCprsAreUnique(string $id_1, string $id_2) {
+  public function testThatHashedIdentifiersAreUnique(string $id_1, string $id_2) {
     $service = new OpenIdUserInfoService($this->settings);
     $hash1 = $service->hashIdentifier($id_1);
     $hash2 = $service->hashIdentifier($id_2);
@@ -84,7 +84,7 @@ class OpenIdAuthMapTest extends UnitTestCase {
             'uniqueId' => '9d67c9fa-81d6-41ce-8b42-9d187b306fd9',
           ],
         ],
-        '9d67c9fa-81d6-41ce-8b42-9d187b306fd9',
+        '$5$e3b0c44298fc1c14$Dj8wC1wNLslq2iqawXGyEEX.Rh0DD3QNQY7pxX/Hvx6',
         AuthorizationIdType::UNIQUE_ID,
       ],
     ];
@@ -130,6 +130,126 @@ class OpenIdAuthMapTest extends UnitTestCase {
       'a pair of cpr that starts with the same nine characters' => [
         '1234567890',
         '1234567891',
+      ],
+      'a pair of unique_ids that start with the same character' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e0aca8c3-5e36-42e0-b9e5-bd867e3b4599',
+      ],
+      'a pair of unique_ids that starts with the same two characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1aca8c3-5e36-42e0-b9e5-bd867e3b4599',
+      ],
+      'a pair of unique_ids that starts with the same three characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1aee469-527b-4025-9c55-2daa7a9fa172',
+      ],
+      'a pair of unique_ids that starts with the same four characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0d7c6-1dad-4372-89dd-d23d018c470b',
+      ],
+      'a pair of unique_ids that starts with the same five characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0e309-432e-48bd-914a-ab30cfcc2f6c',
+      ],
+      'a pair of unique_ids that starts with the same six characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0ecaf-2830-44da-aaa0-109d81aff5e4',
+      ],
+      'a pair of unique_ids that starts with the same seven characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0ecc5-90eb-4f5c-acb8-a457c38f0f02',
+      ],
+      'a pair of unique_ids that starts with the same nine characters (because of separator)' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-4b5b-418c-a6df-eafad2898e36',
+      ],
+      'a pair of unique_ids that starts withe the same ten characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-69cb-4a3c-b62b-3a9bccd75e54',
+      ],
+      'a pair of unique_ids that starts withe the same elleven characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6ac1-4cb5-be86-fae04806fe59',
+      ],
+      'a pair of unique_ids that starts withe the same twelve characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a81-4cb5-be86-fae04806fe59',
+      ],
+      'a pair of unique_ids that starts withe the same thirteen characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-1e9a-b38c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same sixteen characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-479a-b38c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same seventeen characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47aa-b38c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same nineteen characters (because of separator)' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-b38c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-838c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty one characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-888c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty two characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty three characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-8865-eed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty five characters (because of separator)' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ed00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty six characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ad00a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty seven characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac90a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty eight characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac90a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same twenty nine characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91a66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c66a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty one characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c16a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty two characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c10a2c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty three characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c1042c3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty four characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c104fc3',
+      ],
+      'a pair of unique_ids that starts withe the same thirty five characters' => [
+        'e1a0eccd-6a89-47ad-8865-6ac91c104f22',
+        'e1a0eccd-6a89-47ad-886c-6ac91c104f23',
       ],
     ];
   }

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdAuthMapTest.php
@@ -25,6 +25,14 @@ class OpenIdAuthMapTest extends UnitTestCase {
     $settings = [];
     $settings['hash_salt'] = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
     $this->settings = new Settings($settings);
+  }
+
+  /**
+   *
+   */
+  public static function setUpBeforeClass(): void {
+    parent::setUpBeforeClass();
+
     $builder = new MockBuilder();
     $builder->setNamespace('Drupal\dpl_login')
       ->setName("uniqid")

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
@@ -37,7 +37,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
    */
   public function testHashCreationThatCprHasPrecedenceOverUniqueid(array $userinfo, string $expected_sub_id, AuthorizationIdType $expected_id_type) {
     $service = new OpenIdUserInfoService($this->settings);
-    $sub_id = $service->getSubIdFromUserInfo($userinfo);
+    $sub_id = $service->getSubjectIdFromUserInfo($userinfo);
     $id_type = $service->getIdentifierDataFromUserInfo($userinfo)['type'];
 
     $this->assertEquals($expected_sub_id, $sub_id);
@@ -55,7 +55,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Unable to identify user. Both CPR and uniqueId are missing.');
 
-    $service->getSubIdFromUserInfo($userinfo);
+    $service->getSubjectIdFromUserInfo($userinfo);
   }
 
   /**

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
@@ -110,7 +110,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
     $this->assertEquals([
       'email' => '9999999999999@dpl-cms.invalid',
       'name' => '9999999999999',
-      'sub' => '$5$e3b0c44298fc1c14$yd.tasg4wRielbUAUo.AKfcvYplJeAPfXvPBfKxaO47',
+      'sub' => 'e2057a73dd0aa38c7fa4450a9a0561494cd4baa4a1b769d6f04deb3e3677379e',
     ], $userinfo);
 
     $mock->disable();
@@ -128,7 +128,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
             'uniqueId' => '9d67c9fa-81d6-41ce-8b42-9d187b306fd9',
           ],
         ],
-        '$5$e3b0c44298fc1c14$yd.tasg4wRielbUAUo.AKfcvYplJeAPfXvPBfKxaO47',
+        'e2057a73dd0aa38c7fa4450a9a0561494cd4baa4a1b769d6f04deb3e3677379e',
         AuthorizationIdType::CPR,
       ],
       'uniqueId is getting hashed when cpr is missing' => [
@@ -137,7 +137,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
             'uniqueId' => '9d67c9fa-81d6-41ce-8b42-9d187b306fd9',
           ],
         ],
-        '$5$e3b0c44298fc1c14$Dj8wC1wNLslq2iqawXGyEEX.Rh0DD3QNQY7pxX/Hvx6',
+        '70abf093ee19f055b16d35e494e3cc1c6a0f4bae36c6b07ae9ed0d7867bf1909',
         AuthorizationIdType::UNIQUE_ID,
       ],
     ];

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
@@ -28,24 +28,6 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
   }
 
   /**
-   *
-   */
-  public static function setUpBeforeClass(): void {
-    parent::setUpBeforeClass();
-
-    $builder = new MockBuilder();
-    $builder->setNamespace('Drupal\dpl_login')
-      ->setName("uniqid")
-      ->setFunction(
-                function () {
-                    return '9999999999999';
-                }
-            );
-    $mock = $builder->build();
-    $mock->enable();
-  }
-
-  /**
    * @dataProvider cprHasPrecedenceOverUniqueIdData
    */
   public function testHashCreationThatCprHasPrecedenceOverUniqueid(array $userinfo, string $expected_sub_id, AuthorizationIdType $expected_id_type) {
@@ -96,6 +78,20 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
    *
    */
   public function testThatWeGetExpectedUserInfoFromService() {
+    // getOpenIdUserInfoFromAdgangsplatformenUserInfoResponse uses uniqid()
+    // to generate a unique user name. We need to mock it to get a predictable
+    // result.
+    $builder = new MockBuilder();
+    $builder->setNamespace('Drupal\dpl_login')
+      ->setName("uniqid")
+      ->setFunction(
+                function () {
+                    return '9999999999999';
+                }
+            );
+    $mock = $builder->build();
+    $mock->enable();
+
     $service = new OpenIdUserInfoService($this->settings);
     $userinfo = $service->getOpenIdUserInfoFromAdgangsplatformenUserInfoResponse([
       'attributes' => [
@@ -109,6 +105,8 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
       'name' => '9999999999999',
       'sub' => '$5$e3b0c44298fc1c14$yd.tasg4wRielbUAUo.AKfcvYplJeAPfXvPBfKxaO47',
     ], $userinfo);
+
+    $mock->disable();
   }
 
   /**

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
@@ -13,7 +13,7 @@ use phpmock\MockBuilder;
  *
  * @covers \Drupal\dpl_login\Adgangsplatformen\Config
  */
-class OpenIdAuthMapTest extends UnitTestCase {
+class OpenIdUserInfoServiceTest extends UnitTestCase {
   private Settings $settings;
 
   /**

--- a/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
+++ b/web/modules/custom/dpl_login/tests/src/Unit/OpenIdUserInfoServiceTest.php
@@ -14,6 +14,9 @@ use phpmock\MockBuilder;
  * @covers \Drupal\dpl_login\Adgangsplatformen\Config
  */
 class OpenIdUserInfoServiceTest extends UnitTestCase {
+  /**
+   * Drupal settings.
+   */
   private Settings $settings;
 
   /**
@@ -28,6 +31,8 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
   }
 
   /**
+   * Test precedence of CPR over uniqueId.
+   *
    * @dataProvider cprHasPrecedenceOverUniqueIdData
    */
   public function testHashCreationThatCprHasPrecedenceOverUniqueid(array $userinfo, string $expected_sub_id, AuthorizationIdType $expected_id_type) {
@@ -40,7 +45,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
   }
 
   /**
-   *
+   * Test Exception if both CPR and uniqueId are missing.
    */
   public function testThatGettingSubHashFromUserInfoThrowsAnExceptionIfBothCprAndUniqueIdAreMissing() {
     $service = new OpenIdUserInfoService($this->settings);
@@ -54,6 +59,8 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
   }
 
   /**
+   * Test that hashed identifiers are unique.
+   *
    * @dataProvider weGetUniqueHashesNotMatterWhatData
    */
   public function testThatHashedIdentifiersAreUnique(string $id_1, string $id_2) {
@@ -64,7 +71,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
   }
 
   /**
-   *
+   * Test that hashed identifier is reproducible.
    */
   public function testThatHashedIdentifierIsReproducible() {
     $service = new OpenIdUserInfoService($this->settings);
@@ -75,7 +82,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
   }
 
   /**
-   *
+   * Test that we get expected user info from service.
    */
   public function testThatWeGetExpectedUserInfoFromService() {
     // getOpenIdUserInfoFromAdgangsplatformenUserInfoResponse uses uniqid()
@@ -110,7 +117,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
   }
 
   /**
-   *
+   * Data provider for testHashCreationThatCprHasPrecedenceOverUniqueid.
    */
   public function cprHasPrecedenceOverUniqueIdData(): array {
     return [
@@ -137,7 +144,7 @@ class OpenIdUserInfoServiceTest extends UnitTestCase {
   }
 
   /**
-   *
+   * Data provider for testThatHashedIdentifiersAreUnique.
    */
   public function weGetUniqueHashesNotMatterWhatData(): array {
     return [


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-664

#### Description

A bug was reported that one user was able to se another users data.
We traced down the issue and found out that our technique of hashing the user ident used in the openid_connect authmap was not working correctly. Several users could end up having the same ident and thereby sharing the same issued tokens.
This PR changes the hashing method and also contains tests that proves it works, opposed to the former solution.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
