### PR TITLE
Move pincode-section-description-text to be a global text parameter

### DIFF
--- a/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
+++ b/web/modules/custom/dpl_patron_reg/src/Plugin/Block/PatronRegistrationBlock.php
@@ -120,7 +120,6 @@ class PatronRegistrationBlock extends BlockBase implements ContainerFactoryPlugi
       'create-patron-invalid-ssn-body-text' => $this->t("This SSN is invalid", [], ['context' => 'Create patron']),
       'create-patron-invalid-ssn-header-text' => $this->t("Invalid SSN", [], ['context' => 'Create patron']),
       'patron-contact-name-label-text' => $this->t("Name", [], ['context' => 'Create patron']),
-      'pincode-section-description-text' => $this->t('Length of 4 characters', [], ['context' => 'Create patron']),
       'post-register-redirect-info-bottom-text' => $this->t("You will be sent to the Adgangsplatformen to log in again in @seconds seconds.", [], ['context' => 'Create patron']),
       'post-register-redirect-info-top-text' => $this->t("You are now registered as a user and need to log in again to be able to use the application.", [], ['context' => 'Create patron']),
       'post-register-redirect-button-text' => $this->t("Log in again", [], ['context' => 'Create patron']),

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -241,6 +241,7 @@ function dpl_react_apps_texts(): array {
     'patron-page-pincode-label' => t('New pin', [], ['context' => 'Global']),
     'patron-page-pincode-too-short-validation' => t('The pincode should be minimum @pincodeLengthMin and maximum @pincodeLengthMax characters long', [], ['context' => 'Global']),
     'patron-page-pincodes-not-the-same' => t('The pincodes are not the same', [], ['context' => 'Global']),
+    'pincode-section-description' => t('Length of 4 characters', [], ['context' => 'Global']),
     'publizon-audio-book' => t('Audiobook', [], ['context' => 'Global']),
     'publizon-ebook' => t('E-book', [], ['context' => 'Global']),
     'publizon-podcast' => t('Podcast', [], ['context' => 'Global']),


### PR DESCRIPTION
#### Link to issue
Log on systemadministration.

#### Description
Move the pincode-section-description-text translation from being a single app translation to being global.

#### Screenshot of the result
-

#### Additional comments or questions
-