### PR TITLE
Quick fix for opening hours Cypress test.

### DIFF
--- a/cypress/e2e/opening-hours-editor.cy.ts
+++ b/cypress/e2e/opening-hours-editor.cy.ts
@@ -535,7 +535,7 @@ describe("Opening hours editor", () => {
   };
   it("Can edit rest of opening hours series", () => {
     const editData: EditRestOfOpeningHoursSeriesType = {
-      editSeriesFromIndex: 2,
+      editSeriesFromIndex: 1,
       openingHourCategory: OpeningHourCategories.SelfService,
       originalTimeDuration: { start: "10:00", end: "16:00" },
       updatedTimeDuration: { start: "09:00", end: "15:00" },
@@ -581,7 +581,7 @@ describe("Opening hours editor", () => {
       openingHourCategory: OpeningHourCategories.WithService,
       timeDuration: { start: "10:00", end: "11:00" },
       endDate: oneMonthFromToday(),
-      editSeriesFromIndex: 2,
+      editSeriesFromIndex: 1,
     };
 
     createOpeningHoursSeries({


### PR DESCRIPTION
#### Description

Update test to select the second opening hour instead of the third due to dates like 27 May having only 2 visible opening hours in the month view.

I need to investigate Cypress test configuration to set a specific "current" date to prevent issues with special view days.






