### PR TITLE
Update card image styles, to respect focal point.

### DIFF
--- a/config/sync/image.style.card_large.yml
+++ b/config/sync/image.style.card_large.yml
@@ -13,13 +13,5 @@ effects:
     weight: -10
     data:
       width: 551
-      height: 551
-      crop_type: focal_point
-  6fb9e0dc-cb84-4e15-ba24-7387618e636d:
-    uuid: 6fb9e0dc-cb84-4e15-ba24-7387618e636d
-    id: image_scale_and_crop
-    weight: -9
-    data:
-      width: 551
       height: 312
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.card_medium.yml
+++ b/config/sync/image.style.card_medium.yml
@@ -5,7 +5,7 @@ dependencies:
   module:
     - focal_point
 name: card_medium
-label: 'Card - Medium - 321:426'
+label: 'Card - Medium - 551×731'
 effects:
   744cf13a-8bbe-48fb-bb3d-b0eb15a69472:
     uuid: 744cf13a-8bbe-48fb-bb3d-b0eb15a69472
@@ -13,13 +13,5 @@ effects:
     weight: -10
     data:
       width: 551
-      height: 551
+      height: 731
       crop_type: focal_point
-  d67bdd4c-783b-4750-85a3-c831f00ba8c7:
-    uuid: d67bdd4c-783b-4750-85a3-c831f00ba8c7
-    id: image_scale_and_crop
-    weight: -9
-    data:
-      width: 321
-      height: 426
-      anchor: center-center

--- a/web/themes/custom/novel/templates/fields/field--media--field-media-image--card.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--media--field-media-image--card.html.twig
@@ -1,0 +1,22 @@
+{% set alternative_image_styles = {'large': 'card_large', 'medium': 'card_medium'} %}
+{% set item = items.0 %}
+
+<div {{ attributes.addClass('image-credited__image') }}>
+  {#
+    We want to render some override images, that CSS takes care of displaying if relevant.
+    This is necessary, as the cards have different image styles.
+  #}
+  {% for image_style_name, image_style in alternative_image_styles %}
+    {% set uri = item.content['#item'].entity.getFileUri() %}
+    {% set url = uri|image_style(image_style) %}
+
+    {% if url %}
+      <div  class="card__override-images" data-card-style="{{ image_style_name }}"
+        style="display: none; background-image: url('{{ uri|image_style(image_style) }}')"></div>
+    {% endif %}
+
+  {% endfor %}
+
+  {# Render the default, fallback image. #}
+  {{ item.content }}
+</div>


### PR DESCRIPTION
Up until now, large and medium card image styles have been using a fake focal point - e.g., in the actual template, we only use the 'x large' image style.
This is because the size is decided by CSS.

This commit includes an update from the design system, that allows us to send along alternatively-cropped image styles, that CSS takes care of displaying when relevant.

DDFFORM-667

https://reload.atlassian.net/browse/DDFFORM-667