### PR TITLE
Add permission for uploading modules for administrator role (webmaster admin)

### DIFF
--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -106,6 +106,7 @@ permissions:
   - 'administer orphaned events entities'
   - 'administer redirects'
   - 'administer site configuration'
+  - 'administer software updates'
   - 'administer themes'
   - 'administer themes novel'
   - 'administer url proxy configuration'


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-644

#### Description

This PR was originally created to test if it is possible to upload modules in a Lagoon environment.
It is possible.
And found out that I needed to add a permission to the "administrator" role of the site in order for administrators to be able to access the upload section of Drupal admin.
Since administrators are the role used for admins on websmaster sites that particular permission should only be added to the "administrator" role.
