### PR TITLE
DDFLSBP-650 - Add cookie information module and configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
         "drupal/config_ignore": "^2.4",
         "drupal/config_translation_po": "^1.0",
         "drupal/content_lock": "^2.3",
+        "drupal/cookieinformation": "^2.1",
         "drupal/core-composer-scaffold": "~10.1.7",
         "drupal/core-project-message": "~10.1.7",
         "drupal/core-recommended": "~10.1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91a46fb9a94398dce4910df921cdf2db",
+    "content-hash": "de74cbf981d72bfd0c838c1a6a5e9a33",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/composer.lock
+++ b/composer.lock
@@ -2756,17 +2756,17 @@
         },
         {
             "name": "drupal/cookieinformation",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/cookieinformation.git",
-                "reference": "2.1.1"
+                "reference": "2.1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/cookieinformation-2.1.1.zip",
-                "reference": "2.1.1",
-                "shasum": "397efbf08e4b8a1b333cbe655064d4ce4931c619"
+                "url": "https://ftp.drupal.org/files/projects/cookieinformation-2.1.2.zip",
+                "reference": "2.1.2",
+                "shasum": "53c513a70a6833fe9c8a761755d283005ea38e6d"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10"
@@ -2774,8 +2774,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.1.1",
-                    "datestamp": "1712559065",
+                    "version": "2.1.2",
+                    "datestamp": "1716895717",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "430f87dbbfc98fd3e8c820124b796d85",
+    "content-hash": "91a46fb9a94398dce4910df921cdf2db",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2752,6 +2752,58 @@
             "homepage": "https://www.drupal.org/project/content_lock",
             "support": {
                 "source": "https://git.drupalcode.org/project/content_lock"
+            }
+        },
+        {
+            "name": "drupal/cookieinformation",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/cookieinformation.git",
+                "reference": "2.1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/cookieinformation-2.1.1.zip",
+                "reference": "2.1.1",
+                "shasum": "397efbf08e4b8a1b333cbe655064d4ce4931c619"
+            },
+            "require": {
+                "drupal/core": "^9.3 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.1.1",
+                    "datestamp": "1712559065",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "beltofte",
+                    "homepage": "https://www.drupal.org/user/151799"
+                },
+                {
+                    "name": "HeikkiY",
+                    "homepage": "https://www.drupal.org/user/3442607"
+                },
+                {
+                    "name": "kekkis",
+                    "homepage": "https://www.drupal.org/user/813328"
+                }
+            ],
+            "description": "Integration cookie consent popup from Cookieinformation.com.",
+            "homepage": "https://www.drupal.org/project/cookieinformation",
+            "support": {
+                "source": "https://git.drupalcode.org/project/cookieinformation"
             }
         },
         {

--- a/config/sync/cookieinformation.settings.yml
+++ b/config/sync/cookieinformation.settings.yml
@@ -1,0 +1,8 @@
+enable_popup: true
+google_consent_mode: ''
+block_iframes: false
+block_iframes_category: functional
+enable_iab: false
+exclude_paths: ''
+exclude_admin: true
+exclude_uid_1: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -17,6 +17,7 @@ module:
   config_translation: 0
   config_translation_po: 0
   content_lock: 0
+  cookieinformation: 0
   crop: 0
   date_range_formatter: 0
   datetime: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -24,6 +24,7 @@ dependencies:
     - administerusersbyrole
     - block
     - content_lock
+    - cookieinformation
     - dpl_admin
     - dpl_cache_settings
     - dpl_footer
@@ -92,6 +93,7 @@ permissions:
   - 'administer advanced webform handler settings'
   - 'administer advanced webform submission settings'
   - 'administer blocks'
+  - 'administer cookie information settings'
   - 'administer dpl_footer settings'
   - 'administer dpl_mapp configuration'
   - 'administer filters'
@@ -174,6 +176,7 @@ permissions:
   - 'delete terms in categories'
   - 'delete terms in tags'
   - 'delete terms in webform_email_categories'
+  - 'disable cookie information consent'
   - 'dpl admin access pages'
   - 'edit admin menu'
   - 'edit any article content'


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-650

#### Description

This PR adds the cookieinformation module as well as its configuration.

The following configuration has been added:
- Enable cookieinformation module.
- Enable cookieinformation 'consent popup'.
- Exclude 'consent popup' on admin pages.
- Exclude 'consent popup' for UID 1 (super admin).

#### Screenshot of the result

Image showing the cookie consent popup:
![Screenshot 2024-05-29 at 09 30 18](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/6142323/e19628e6-9cd6-4227-8d47-3533c6848a23)

#### Additional comments or questions

Cookie information dashboard setup:
This PR only handles the implementation of the cookieinformation contrib module and its configuration. Before the cookieinformation module works properly, it also needs to be setup in the cookieinformation dashboard. 
As the old librarie sites also uses cookieinformation, the cookieinformation dashboard configuration should already be in place for live sites. 
To test the cookieinformation module, we have also added 'dapple-cms.docker' to the list of dev environment domains in cookieinformation dashboard. 

Styling overrides:
When comparing the styling of the cookieinformation consent popup with how it looks on the existing sites, it looks like both versions have some overwrites some part of the default styling. We have asked the client about this, and will create another PR, if we need to change the styling of the content popup.
