### PR TITLE
Change event `Description` label to `Subtitle`

### DIFF
--- a/config/sync/field.field.eventinstance.default.field_description.yml
+++ b/config/sync/field.field.eventinstance.default.field_description.yml
@@ -9,7 +9,7 @@ id: eventinstance.default.field_description
 field_name: field_description
 entity_type: eventinstance
 bundle: default
-label: Description
+label: Subtitle
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.eventseries.default.field_description.yml
+++ b/config/sync/field.field.eventseries.default.field_description.yml
@@ -9,7 +9,7 @@ id: eventseries.default.field_description
 field_name: field_description
 entity_type: eventseries
 bundle: default
-label: Description
+label: Subtitle
 description: ''
 required: true
 translatable: false


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-504


#### Description

The `Description` field was confusing for users as it was meant as a lead paragraph instead of the actual description. This pull request updates the label of the `Description` field to `Subtitle` to provide clarity to users.

The fields/machine names remain unchanged, as it is still appropriate.

#### Screenshot of the result

<img width="1694" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/9374b1d2-635f-4a16-88f8-9ee87c25d583">
