### PR TITLE
DDFFORM 520 material grid desc

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.material_grid_automatic.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.material_grid_automatic.default.yml
@@ -5,8 +5,11 @@ dependencies:
   config:
     - field.field.paragraph.material_grid_automatic.field_amount_of_materials
     - field.field.paragraph.material_grid_automatic.field_cql_search
+    - field.field.paragraph.material_grid_automatic.field_material_grid_description
     - field.field.paragraph.material_grid_automatic.field_material_grid_title
     - paragraphs.paragraphs_type.material_grid_automatic
+  module:
+    - dpl_fbi
 id: paragraph.material_grid_automatic.default
 targetEntityType: paragraph
 bundle: material_grid_automatic
@@ -14,16 +17,22 @@ mode: default
 content:
   field_amount_of_materials:
     type: options_select
-    weight: 1
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   field_cql_search:
-    type: string_textfield
-    weight: 2
+    type: cql_search_widget
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_material_grid_description:
+    type: string_textarea
+    weight: 1
     region: content
     settings:
-      size: 60
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
   field_material_grid_title:

--- a/config/sync/core.entity_form_display.paragraph.material_grid_manual.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.material_grid_manual.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.material_grid_manual.field_material_grid_description
     - field.field.paragraph.material_grid_manual.field_material_grid_title
     - field.field.paragraph.material_grid_manual.field_material_grid_work_ids
     - field.field.paragraph.material_grid_manual.field_work_id
@@ -14,6 +15,14 @@ targetEntityType: paragraph
 bundle: material_grid_manual
 mode: default
 content:
+  field_material_grid_description:
+    type: string_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_material_grid_title:
     type: string_textfield
     weight: 0

--- a/config/sync/core.entity_view_display.paragraph.material_grid_automatic.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.material_grid_automatic.default.yml
@@ -30,5 +30,4 @@ content:
     weight: 0
     region: content
 hidden:
-  field_cql_search: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.material_grid_automatic.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.material_grid_automatic.default.yml
@@ -5,9 +5,11 @@ dependencies:
   config:
     - field.field.paragraph.material_grid_automatic.field_amount_of_materials
     - field.field.paragraph.material_grid_automatic.field_cql_search
+    - field.field.paragraph.material_grid_automatic.field_material_grid_description
     - field.field.paragraph.material_grid_automatic.field_material_grid_title
     - paragraphs.paragraphs_type.material_grid_automatic
   module:
+    - dpl_fbi
     - options
 id: paragraph.material_grid_automatic.default
 targetEntityType: paragraph
@@ -16,6 +18,20 @@ mode: default
 content:
   field_amount_of_materials:
     type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_cql_search:
+    type: cql_search_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_material_grid_description:
+    type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.paragraph.material_grid_manual.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.material_grid_manual.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.material_grid_manual.field_material_grid_description
     - field.field.paragraph.material_grid_manual.field_material_grid_title
     - field.field.paragraph.material_grid_manual.field_material_grid_work_ids
     - field.field.paragraph.material_grid_manual.field_work_id
@@ -12,6 +13,13 @@ targetEntityType: paragraph
 bundle: material_grid_manual
 mode: default
 content:
+  field_material_grid_description:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_material_grid_title:
     type: string
     label: above

--- a/config/sync/field.field.paragraph.material_grid_automatic.field_material_grid_description.yml
+++ b/config/sync/field.field.paragraph.material_grid_automatic.field_material_grid_description.yml
@@ -1,0 +1,19 @@
+uuid: 012904c2-a21c-4b83-aabc-e053c7722c98
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_material_grid_description
+    - paragraphs.paragraphs_type.material_grid_automatic
+id: paragraph.material_grid_automatic.field_material_grid_description
+field_name: field_material_grid_description
+entity_type: paragraph
+bundle: material_grid_automatic
+label: 'Material grid description'
+description: 'This is the optional description for the material grid. <br />Leave blank if you do not want a description.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.paragraph.material_grid_manual.field_material_grid_description.yml
+++ b/config/sync/field.field.paragraph.material_grid_manual.field_material_grid_description.yml
@@ -1,0 +1,19 @@
+uuid: cebef7f0-a8b8-41d7-92cd-05e055cc792d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_material_grid_description
+    - paragraphs.paragraphs_type.material_grid_manual
+id: paragraph.material_grid_manual.field_material_grid_description
+field_name: field_material_grid_description
+entity_type: paragraph
+bundle: material_grid_manual
+label: 'Material grid description'
+description: 'This is the optional description for the material grid. <br />Leave blank if you do not want a description.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.storage.paragraph.field_material_grid_description.yml
+++ b/config/sync/field.storage.paragraph.field_material_grid_description.yml
@@ -1,0 +1,19 @@
+uuid: b4bd5a5f-b0bf-496f-9d6f-19148b72d4fa
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_material_grid_description
+field_name: field_material_grid_description
+entity_type: paragraph
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldFormatter/CqlSearchFormatter.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldFormatter/CqlSearchFormatter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\dpl_fbi\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementation of the 'cql_search_formatter' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "cql_search_formatter",
+ *   label = @Translation("CQL Search Formatter"),
+ *   field_types = {
+ *     "dpl_fbi_cql_search"
+ *   }
+ * )
+ */
+class CqlSearchFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $elements[$delta] = [
+        '#markup' => $item->value,
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldFormatter/WorkIdFormatter.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldFormatter/WorkIdFormatter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\dpl_fbi\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementation of the 'work_id_formatter' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "work_id_formatter",
+ *   label = @Translation("Work ID Formatter"),
+ *   field_types = {
+ *     "dpl_fbi_work_id"
+ *   }
+ * )
+ */
+class WorkIdFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $output = $this->buildOutput($item);
+      $elements[$delta] = [
+        '#markup' => $output,
+      ];
+    }
+
+    return $elements;
+  }
+
+  /**
+   * Builds the output for a single field item.
+   *
+   * @param \Drupal\Core\Field\FieldItemInterface $item
+   *   The field item.
+   *
+   * @return string
+   *   The rendered output.
+   */
+  protected function buildOutput($item) {
+    $value = $item->get('value')->getValue();
+    $material_type = $item->get('material_type')->getValue();
+    $output = $value;
+    if (!empty($material_type)) {
+      $output .= ' (' . $material_type . ')';
+    }
+    return $output;
+  }
+
+}

--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/CqlSearchWidget.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/CqlSearchWidget.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\dpl_fbi\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'cql_search_widget' widget.
+ *
+ * @FieldWidget(
+ *   id = "cql_search_widget",
+ *   label = @Translation("CQL Search Widget"),
+ *   field_types = {
+ *     "dpl_fbi_cql_search"
+ *   }
+ * )
+ */
+class CqlSearchWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element['value'] = [
+      '#type' => 'textfield',
+      '#default_value' => $items[$delta]->value ?? '',
+      '#maxlength' => 16000,
+      '#title' => $this->t('CQL Search String'),
+      '#placeholder' => $this->t('Enter CQL search string'),
+      '#description' => $this->t('CQL search string field. Perform an advanced search and copy/paste the string to this field.'),
+    ];
+
+    return $element;
+  }
+
+}

--- a/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
+++ b/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
@@ -227,12 +227,16 @@ function dpl_paragraphs_preprocess_paragraph__material_grid_automatic(array &$va
     return;
   }
 
-  if (!$paragraph->hasField('field_amount_of_materials') || !$paragraph->hasField('field_material_grid_title') || !$paragraph->hasField('field_cql_search')) {
+  if (!$paragraph->hasField('field_amount_of_materials') ||
+    !$paragraph->hasField('field_material_grid_title') ||
+    !$paragraph->hasField('field_material_grid_description') ||
+    !$paragraph->hasField('field_cql_search')) {
     return;
   }
 
   // Extract field values.
   $material_grid_title = $paragraph->get('field_material_grid_title')->getString();
+  $material_grid_description = $paragraph->get('field_material_grid_description')->getString();
   $cql = $paragraph->get('field_cql_search')->getString();
   $selected_amount_of_materials_for_display = (int) $paragraph->get('field_amount_of_materials')->getString();
 
@@ -248,6 +252,7 @@ function dpl_paragraphs_preprocess_paragraph__material_grid_automatic(array &$va
     '#name' => 'material-grid-automatic',
     '#data' => [
       'title' => $material_grid_title,
+      'description' => $material_grid_description,
       'cql' => $cql,
       'selected-amount-of-materials-for-display' => $selected_amount_of_materials_for_display,
       'button-text' => t('Show all', [], ['context' => 'Material Grid']),
@@ -273,12 +278,16 @@ function dpl_paragraphs_preprocess_paragraph__material_grid_manual(array &$varia
 
   $paragraph = $variables['paragraph'] ?? NULL;
 
-  if (!($paragraph instanceof ParagraphInterface)  || !$paragraph->hasField('field_material_grid_title') || !$paragraph->hasField('field_material_grid_work_ids')) {
+  if (!($paragraph instanceof ParagraphInterface)  ||
+    !$paragraph->hasField('field_material_grid_title') ||
+    !$paragraph->hasField('field_material_grid_description') ||
+    !$paragraph->hasField('field_material_grid_work_ids')) {
     return;
   }
 
   // Extract field values.
   $material_grid_title = $paragraph->get('field_material_grid_title')->getString();
+  $material_grid_description = $paragraph->get('field_material_grid_description')->getString();
   $materials = [];
 
   if (!$paragraph->get('field_material_grid_work_ids')->isEmpty()) {
@@ -306,6 +315,7 @@ function dpl_paragraphs_preprocess_paragraph__material_grid_manual(array &$varia
     '#data' => [
       'materials' => $materials,
       'title' => $material_grid_title,
+      'description' => $material_grid_description,
       'button-text' => t('Show all', [], ['context' => 'Material Grid']),
       'blacklisted-search-branches-config' => $blacklistedSearchBranchesConfig,
       'branches-config' => $branchesConfig,


### PR DESCRIPTION

#### Link to issue
Jira link : [DDFFORM-520](https://reload.atlassian.net/browse/DDFFORM-520)

React pr: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1238
Design system pr: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/644

#### Description

This PR updates the material grid automatic and manual with a new field for a description. 

Additionally, this PR also adds a formatter and widget for the CQLSearchStringField, and a formatter for the work_id field. This should have been done previously and is necessary to correctly move the fields around. 

#### Screenshot of the result

backend:
![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/3b58cbea-50f5-41fd-8d6b-6758367c01bc)

Frontend:
![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/a4923236-f2b0-4d68-93b9-5d78cdd91941)


#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.


[DDFFORM-520]: https://reload.atlassian.net/browse/DDFFORM-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ