### PR TITLE
Disable cookieinformation consent popup temporarily

### DIFF
--- a/config/sync/cookieinformation.settings.yml
+++ b/config/sync/cookieinformation.settings.yml
@@ -1,4 +1,4 @@
-enable_popup: true
+enable_popup: false
 google_consent_mode: ''
 block_iframes: false
 block_iframes_category: functional


### PR DESCRIPTION
Disable cookieinformation consent popup temporarily. We will enable it again when the rest of the cookieinformation implementation is ready to be deployed.

#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-650

#### Description

This PR disables the cookieinformation consent popup. This is done as we haven't finished the rest of the cookieinformation implementation and we only want to enable it when it is ready.

#### Additional comments or questions

A new task should be created to make sure that we enable the cookie consent popup again when it is ready.