### PR TITLE
DDFFORM 809

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -345,7 +345,8 @@
             },
             "drupal/recurring_events": {
                 "3178696: Make compatible with Scheduler": "https://git.drupalcode.org/project/recurring_events/-/merge_requests/86.patch",
-                "3416436: Avoid array conversion warning when daily events are disabled": "https://git.drupalcode.org/project/recurring_events/-/commit/832ae52f135dd3f205eb74acf2d3715fb443e759.patch"
+                "3416436: Avoid array conversion warning when daily events are disabled": "https://git.drupalcode.org/project/recurring_events/-/commit/832ae52f135dd3f205eb74acf2d3715fb443e759.patch",
+                "3451613: Start date of weekly reccurring event jumps incorrectly": "https://git.drupalcode.org/project/recurring_events/-/commit/581c53dd1b0b067a8b6454d76cc0187887f7b187.patch"
             },
             "drupal/theme_permission": {
                 "3105637: Edit, install and uninstall permission": "https://www.drupal.org/files/issues/2024-02-01/theme-permission-edit-install-uninstall-3105637-7.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c58aa470f72b6457a033c48a0857460",
+    "content-hash": "b6c3f8a77e88a76d6f2ee984d1a32815",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/content_lock.settings.yml
+++ b/config/sync/content_lock.settings.yml
@@ -12,12 +12,13 @@ types:
   path_alias: {  }
   eventseries:
     '*': '*'
-  eventinstance:
-    '*': '*'
+  eventinstance: {  }
   search_api_task: {  }
   taxonomy_term: {  }
   user: {  }
   paragraph: {  }
+  redirect: {  }
+  webform_submission: {  }
 types_translation_lock: {  }
 types_js_lock: {  }
 form_op_lock:
@@ -58,5 +59,11 @@ form_op_lock:
     mode: 0
     values: {  }
   paragraph:
+    mode: 0
+    values: {  }
+  redirect:
+    mode: 0
+    values: {  }
+  webform_submission:
     mode: 0
     values: {  }


### PR DESCRIPTION
- **Remove all content lock restrictions from eventinstances.**
- **Add (temporary?) patch to fix weekly_recurring event start_date determination.**

#### Link to issue

Jira: [DDFFORM-809](https://reload.atlassian.net/browse/DDFFORM-809)

drupal.org issue with the suggested fix: https://www.drupal.org/project/recurring_events/issues/3451613 


#### Description

The test for the recurring_events patch is failing on drupal. I think it is out of scope to fix that as part of this pr.

This PR aims to fix an issue when creating/editing eventseries: 

The problem: 
When creating or editing an eventseries using the weekly_recurring_events recur_type, an issue would occur where either 
- The first instance would for the selected day would not be created. This issue is related caused by a specific check in recurring_events module. 
- An error occured for the creation or editing of eventinstances that were in the state of being content-locked. 

Both issues/solutions are explained in the commits. 

As part of this PR, test that you can: 

- Create and afterwards editing both days/times for an eventseries using the recur_type of weekly_recurring_event, and that each edit/creation is succesfull in creating all the correct instances. 

-  Importantly: That this test is done using an admin language that is different than english. 


[DDFFORM-809]: https://reload.atlassian.net/browse/DDFFORM-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ