### PR TITLE
Re-export all example content, based on `develop`

### DIFF
--- a/web/modules/custom/dpl_example_breadcrumb/content/media/35166ac7-4b0e-4644-8a60-3f29f3c8ecbe.yml
+++ b/web/modules/custom/dpl_example_breadcrumb/content/media/35166ac7-4b0e-4644-8a60-3f29f3c8ecbe.yml
@@ -25,7 +25,7 @@ default:
     - tag: link
       attributes:
         rel: canonical
-        href: "http://dpl-cms.docker/user/login"
+        href: "/user/login"
   path:
     - alias: ""
       langcode: en

--- a/web/modules/custom/dpl_example_breadcrumb/content/node/2cf63f02-2b2e-4015-a0f9-e887a63c99e1.yml
+++ b/web/modules/custom/dpl_example_breadcrumb/content/node/2cf63f02-2b2e-4015-a0f9-e887a63c99e1.yml
@@ -7,7 +7,6 @@ _meta:
   depends:
     c57495b6-2b50-4558-b6ad-a50d24c5310c: file
     486b17a2-60e6-426d-a952-793fe24e391d: node
-    a6ad2b81-5337-4f46-be41-f1e6d4a201df: taxonomy_term
     35166ac7-4b0e-4644-8a60-3f29f3c8ecbe: media
 default:
   revision_uid:
@@ -40,13 +39,11 @@ default:
         name: title
         content: '"Bestseller" læseklubber | DPL CMS'
   path:
-    - alias: /laesefilialen/laeseklubber/genre/bestsellers
+    - alias: /laesefilialen/bestseller-laeseklubber
       langcode: und
       pathauto: 1
   field_branch:
     - entity: 486b17a2-60e6-426d-a952-793fe24e391d
-  field_breadcrumb_parent:
-    - entity: a6ad2b81-5337-4f46-be41-f1e6d4a201df
   field_display_titles:
     - value: true
   field_teaser_image:

--- a/web/modules/custom/dpl_example_breadcrumb/content/node/37992672-ca84-46dd-8418-c8620ed6348a.yml
+++ b/web/modules/custom/dpl_example_breadcrumb/content/node/37992672-ca84-46dd-8418-c8620ed6348a.yml
@@ -41,7 +41,7 @@ default:
         name: title
         content: "Læseklubber - efter genre | DPL CMS"
   path:
-    - alias: /laesefilialen/laeseklubber/genre
+    - alias: /laesefilialen/laeseklubber/laeseklubber-efter-genre
       langcode: und
       pathauto: 1
   field_branch:

--- a/web/modules/custom/dpl_example_breadcrumb/content/node/b0db20b5-da9c-4ac2-8272-6ad133ca66c3.yml
+++ b/web/modules/custom/dpl_example_breadcrumb/content/node/b0db20b5-da9c-4ac2-8272-6ad133ca66c3.yml
@@ -40,7 +40,7 @@ default:
         name: title
         content: '"DIY-projekter" læseklubber | DPL CMS'
   path:
-    - alias: /laesefilialen/laeseklubber/genre/diy-projekter
+    - alias: /laesefilialen/laeseklubber/genre/diy-projekter-laeseklubber
       langcode: und
       pathauto: 1
   field_branch:

--- a/web/modules/custom/dpl_example_breadcrumb/content/taxonomy_term/2929bb32-bbf4-4b5d-975b-7c24a3ae949b.yml
+++ b/web/modules/custom/dpl_example_breadcrumb/content/taxonomy_term/2929bb32-bbf4-4b5d-975b-7c24a3ae949b.yml
@@ -26,7 +26,7 @@ default:
     - tag: link
       attributes:
         rel: canonical
-        href: "http://dpl-cms.docker/taxonomy/term/21"
+        href: "/taxonomy/term/25"
   path:
     - alias: ""
       langcode: en

--- a/web/modules/custom/dpl_example_breadcrumb/content/taxonomy_term/316e6db1-8d4e-40f7-9d95-b12e1294735e.yml
+++ b/web/modules/custom/dpl_example_breadcrumb/content/taxonomy_term/316e6db1-8d4e-40f7-9d95-b12e1294735e.yml
@@ -26,7 +26,7 @@ default:
     - tag: link
       attributes:
         rel: canonical
-        href: "http://dpl-cms.docker/taxonomy/term/20"
+        href: "/taxonomy/term/24"
   path:
     - alias: ""
       langcode: en

--- a/web/modules/custom/dpl_example_breadcrumb/content/taxonomy_term/5d977ebc-8630-49f7-9d1d-8746e395f087.yml
+++ b/web/modules/custom/dpl_example_breadcrumb/content/taxonomy_term/5d977ebc-8630-49f7-9d1d-8746e395f087.yml
@@ -25,7 +25,7 @@ default:
     - tag: link
       attributes:
         rel: canonical
-        href: "http://dpl-cms.docker/taxonomy/term/18"
+        href: "/taxonomy/term/22"
   path:
     - alias: ""
       langcode: en

--- a/web/modules/custom/dpl_example_breadcrumb/content/taxonomy_term/a6ad2b81-5337-4f46-be41-f1e6d4a201df.yml
+++ b/web/modules/custom/dpl_example_breadcrumb/content/taxonomy_term/a6ad2b81-5337-4f46-be41-f1e6d4a201df.yml
@@ -26,7 +26,7 @@ default:
     - tag: link
       attributes:
         rel: canonical
-        href: "http://dpl-cms.docker/taxonomy/term/19"
+        href: "/taxonomy/term/23"
   path:
     - alias: ""
       langcode: en

--- a/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/2ce9d9b0-7f10-4a17-9a5e-383d36c1ed93.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    28602a8e-98eb-4905-9e13-a58782c2894d: eventinstance
+    58b29c10-0c9c-467a-b8a7-1292c2c69c6c: eventinstance
     dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0: node
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f: media
@@ -99,9 +99,14 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: /hovedbiblioteket/arrangementer/vi-anbefaler/juleballet-noddeknaekkeren-0
+      langcode: und
+      pathauto: 1
   event_instances:
     -
-      entity: 28602a8e-98eb-4905-9e13-a58782c2894d
+      entity: 58b29c10-0c9c-467a-b8a7-1292c2c69c6c
   field_branch:
     -
       entity: dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0

--- a/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/c8177097-1438-493e-8177-e8ef968cc133.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    e424f47d-6b01-443e-8a03-0d3b436e20d3: eventinstance
+    94abec00-1839-48a9-880a-df019700e34e: eventinstance
     852d781f-82c9-40ac-bc8d-d0cefe07706d: node
     f457c4c2-dc28-45cd-9b6e-fda4248d9d45: taxonomy_term
     618e176a-a45a-4c36-a197-664230aa0a34: media
@@ -107,9 +107,14 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: /bronshoj-bibliotek/arrangementer/design-teknologi/fernisering-moderne-dans-0
+      langcode: und
+      pathauto: 1
   event_instances:
     -
-      entity: e424f47d-6b01-443e-8a03-0d3b436e20d3
+      entity: 94abec00-1839-48a9-880a-df019700e34e
   field_branch:
     -
       entity: 852d781f-82c9-40ac-bc8d-d0cefe07706d

--- a/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/f6aafa27-a538-44a3-ae1f-02f8efbfb068.yml
@@ -5,30 +5,30 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    7188667e-7497-409d-abf9-e82d816c9076: eventinstance
-    c1294fb3-f662-4129-a8b9-a5660b48453f: eventinstance
-    b2be22d3-7757-4af5-ac0f-a1a525a3500b: eventinstance
-    60733077-2d35-4e85-a39b-6a2d5d6e7ead: eventinstance
-    762e792d-9aa7-4452-8481-ece67ce6be1a: eventinstance
-    c6810c6b-3fc9-45c3-af3b-6ae6f3d502ca: eventinstance
-    43ef335d-b3c7-4fe8-8ae0-597dfa04ad22: eventinstance
-    027f8b61-714d-4759-aa1a-0d6913b4e341: eventinstance
-    3abed85c-054a-4377-96e6-74f577ebe111: eventinstance
-    f6169b2d-31b7-458f-89ee-a71e0bd7093b: eventinstance
-    1d4ef0e6-5e48-47ed-b7ed-9beaaf40064b: eventinstance
-    9e98fbf1-8ef5-43e6-9fe7-c66f81f1cc87: eventinstance
-    4582ccc8-ae38-4d8b-937e-53a387eb8916: eventinstance
-    ee78427d-cc6b-4246-8e0e-47e3c7c58b0b: eventinstance
-    367ba067-e53c-4ae1-8b30-f829dfb94743: eventinstance
-    07edc291-5bb9-48e0-9a38-4df1ef284e67: eventinstance
-    7e010c14-6497-4b03-96d4-ae649de1c0fe: eventinstance
-    f35b1d12-9e12-4b15-a356-979485256141: eventinstance
-    28d04879-c8f8-49c1-8550-11e975a9284a: eventinstance
-    e4810e2b-69c4-4766-bebd-096d03544564: eventinstance
-    3c0e7d70-7735-47f1-a614-1e14bb099c8c: eventinstance
-    d2b924c4-77e9-4384-ac41-add5183c4bd3: eventinstance
-    d6ffefcc-90d8-486d-9af0-c4a7c8fbb144: eventinstance
-    12c564b3-f67f-4610-82d7-c4b65b882c16: eventinstance
+    524f6c64-fd09-42a7-9120-5c99cfa47faa: eventinstance
+    050b11bc-ad5b-4faf-9f9c-9bcb9c1f45d3: eventinstance
+    3b1f6a76-7b75-43df-91ec-ab59ceae1b15: eventinstance
+    b979c69b-c94e-4455-aff2-92eac9e7dc2a: eventinstance
+    0259b951-62c1-4dbf-bb29-665fd94b4b58: eventinstance
+    0cb8651d-d2a1-44de-ade1-2b0c3618d3cc: eventinstance
+    671fb5ae-4c9c-48c2-bc4d-4024221cbc54: eventinstance
+    1b6b6568-74f2-49e4-92fb-afbe4ed95241: eventinstance
+    324a2af3-762c-4436-a940-103489702c54: eventinstance
+    099e25b0-21ff-474b-a1d6-dc22c916b5d5: eventinstance
+    0cf31c8d-bd7c-4e1a-804b-9044ce155b86: eventinstance
+    065c9eb8-4aec-462d-9679-a419b5397595: eventinstance
+    a29b010f-edb9-4ce7-9f69-a2fcc75544f4: eventinstance
+    cfa6ed91-0eee-4478-9154-b7c228253938: eventinstance
+    38c506bf-f6a7-4b6b-9c9e-1bf016151fae: eventinstance
+    555fa119-50a8-49b0-993b-dbcc2d394a83: eventinstance
+    1f8ec00a-dd3b-4e3a-8c16-a21e765f241d: eventinstance
+    bfb59c03-87ba-4854-91d6-30e3a6800863: eventinstance
+    c7821031-008b-4d26-a677-6c4c21c556bb: eventinstance
+    3c800ddc-ad6e-4319-be62-f22f5df0505f: eventinstance
+    58f83d98-ab2a-48d2-b112-49f8faa9f948: eventinstance
+    595a08ae-52ea-44c3-ad0a-9923c60e2ef7: eventinstance
+    e489cacf-38b2-4344-bc8f-fd18210d4abf: eventinstance
+    8d363311-0743-4351-a956-60552ae96af8: eventinstance
     dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0: node
     0fa7245a-3434-4d96-9793-a1848a22d37a: taxonomy_term
     ca329ad9-5a1c-4f55-b8a9-a60843b66466: media
@@ -125,55 +125,60 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: /hovedbiblioteket/arrangementer/vi-anbefaler/fars-legestue
+      langcode: und
+      pathauto: 1
   event_instances:
     -
-      entity: 7188667e-7497-409d-abf9-e82d816c9076
+      entity: 524f6c64-fd09-42a7-9120-5c99cfa47faa
     -
-      entity: c1294fb3-f662-4129-a8b9-a5660b48453f
+      entity: 050b11bc-ad5b-4faf-9f9c-9bcb9c1f45d3
     -
-      entity: b2be22d3-7757-4af5-ac0f-a1a525a3500b
+      entity: 3b1f6a76-7b75-43df-91ec-ab59ceae1b15
     -
-      entity: 60733077-2d35-4e85-a39b-6a2d5d6e7ead
+      entity: b979c69b-c94e-4455-aff2-92eac9e7dc2a
     -
-      entity: 762e792d-9aa7-4452-8481-ece67ce6be1a
+      entity: 0259b951-62c1-4dbf-bb29-665fd94b4b58
     -
-      entity: c6810c6b-3fc9-45c3-af3b-6ae6f3d502ca
+      entity: 0cb8651d-d2a1-44de-ade1-2b0c3618d3cc
     -
-      entity: 43ef335d-b3c7-4fe8-8ae0-597dfa04ad22
+      entity: 671fb5ae-4c9c-48c2-bc4d-4024221cbc54
     -
-      entity: 027f8b61-714d-4759-aa1a-0d6913b4e341
+      entity: 1b6b6568-74f2-49e4-92fb-afbe4ed95241
     -
-      entity: 3abed85c-054a-4377-96e6-74f577ebe111
+      entity: 324a2af3-762c-4436-a940-103489702c54
     -
-      entity: f6169b2d-31b7-458f-89ee-a71e0bd7093b
+      entity: 099e25b0-21ff-474b-a1d6-dc22c916b5d5
     -
-      entity: 1d4ef0e6-5e48-47ed-b7ed-9beaaf40064b
+      entity: 0cf31c8d-bd7c-4e1a-804b-9044ce155b86
     -
-      entity: 9e98fbf1-8ef5-43e6-9fe7-c66f81f1cc87
+      entity: 065c9eb8-4aec-462d-9679-a419b5397595
     -
-      entity: 4582ccc8-ae38-4d8b-937e-53a387eb8916
+      entity: a29b010f-edb9-4ce7-9f69-a2fcc75544f4
     -
-      entity: ee78427d-cc6b-4246-8e0e-47e3c7c58b0b
+      entity: cfa6ed91-0eee-4478-9154-b7c228253938
     -
-      entity: 367ba067-e53c-4ae1-8b30-f829dfb94743
+      entity: 38c506bf-f6a7-4b6b-9c9e-1bf016151fae
     -
-      entity: 07edc291-5bb9-48e0-9a38-4df1ef284e67
+      entity: 555fa119-50a8-49b0-993b-dbcc2d394a83
     -
-      entity: 7e010c14-6497-4b03-96d4-ae649de1c0fe
+      entity: 1f8ec00a-dd3b-4e3a-8c16-a21e765f241d
     -
-      entity: f35b1d12-9e12-4b15-a356-979485256141
+      entity: bfb59c03-87ba-4854-91d6-30e3a6800863
     -
-      entity: 28d04879-c8f8-49c1-8550-11e975a9284a
+      entity: c7821031-008b-4d26-a677-6c4c21c556bb
     -
-      entity: e4810e2b-69c4-4766-bebd-096d03544564
+      entity: 3c800ddc-ad6e-4319-be62-f22f5df0505f
     -
-      entity: 3c0e7d70-7735-47f1-a614-1e14bb099c8c
+      entity: 58f83d98-ab2a-48d2-b112-49f8faa9f948
     -
-      entity: d2b924c4-77e9-4384-ac41-add5183c4bd3
+      entity: 595a08ae-52ea-44c3-ad0a-9923c60e2ef7
     -
-      entity: d6ffefcc-90d8-486d-9af0-c4a7c8fbb144
+      entity: e489cacf-38b2-4344-bc8f-fd18210d4abf
     -
-      entity: 12c564b3-f67f-4610-82d7-c4b65b882c16
+      entity: 8d363311-0743-4351-a956-60552ae96af8
   field_branch:
     -
       entity: dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0

--- a/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
+++ b/web/modules/custom/dpl_example_content/content/eventseries/fb8b4d62-de14-4620-9ca1-be60cab74a65.yml
@@ -5,7 +5,7 @@ _meta:
   bundle: default
   default_langcode: en
   depends:
-    fde19c73-3a38-4788-aa84-a376d3ee6cf6: eventinstance
+    18f82ae8-0925-4794-a068-0c6c5b2842b7: eventinstance
     e539b26b-2992-406b-accf-03e549522c0d: taxonomy_term
     d6d67fd2-775c-46e7-a1bf-6af46290a5c8: media
     4704c566-afc2-4131-ab81-3d636f2451bf: taxonomy_term
@@ -99,9 +99,14 @@ default:
       attributes:
         rel: canonical
         href: '/user/login'
+  path:
+    -
+      alias: /arrangementer/klima/genbrugsstof-fremfor-plastik-0
+      langcode: und
+      pathauto: 1
   event_instances:
     -
-      entity: fde19c73-3a38-4788-aa84-a376d3ee6cf6
+      entity: 18f82ae8-0925-4794-a068-0c6c5b2842b7
   field_categories:
     -
       entity: e539b26b-2992-406b-accf-03e549522c0d

--- a/web/modules/custom/dpl_example_content/content/media/618e176a-a45a-4c36-a197-664230aa0a34.yml
+++ b/web/modules/custom/dpl_example_content/content/media/618e176a-a45a-4c36-a197-664230aa0a34.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_byline:
     -
       value: 'Af Ahmad Odeh / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/65432ee1-43f1-4130-9565-5683467d4b5a.yml
+++ b/web/modules/custom/dpl_example_content/content/media/65432ee1-43f1-4130-9565-5683467d4b5a.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_byline:
     -
       value: 'Af Admad Odeh / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/7b9d1894-7f9a-4f96-a7dc-efa3af5fc902.yml
+++ b/web/modules/custom/dpl_example_content/content/media/7b9d1894-7f9a-4f96-a7dc-efa3af5fc902.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_media_image:
     -
       entity: 50b4d50b-9c75-4698-b803-a125b46daaac

--- a/web/modules/custom/dpl_example_content/content/media/a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f.yml
+++ b/web/modules/custom/dpl_example_content/content/media/a0176f8c-bb7e-4f5a-bf23-b48cd8bab05f.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_media_image:
     -
       entity: 24244298-ff4d-4662-bc7f-5b9aa529f89e

--- a/web/modules/custom/dpl_example_content/content/media/a6a77786-07db-48d8-98ff-3bda54f231bf.yml
+++ b/web/modules/custom/dpl_example_content/content/media/a6a77786-07db-48d8-98ff-3bda54f231bf.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_media_image:
     -
       entity: 7fb4d332-81ef-4dc0-af9a-dfcd29ecf367

--- a/web/modules/custom/dpl_example_content/content/media/aba3cea8-cee5-42c1-a152-e30c2ab135e2.yml
+++ b/web/modules/custom/dpl_example_content/content/media/aba3cea8-cee5-42c1-a152-e30c2ab135e2.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_byline:
     -
       value: 'Af Jilbert Ebrahimi / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/ca329ad9-5a1c-4f55-b8a9-a60843b66466.yml
+++ b/web/modules/custom/dpl_example_content/content/media/ca329ad9-5a1c-4f55-b8a9-a60843b66466.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_media_image:
     -
       entity: 4400c2b6-2158-4ddb-aa87-9279dcf77fb7

--- a/web/modules/custom/dpl_example_content/content/media/d6d67fd2-775c-46e7-a1bf-6af46290a5c8.yml
+++ b/web/modules/custom/dpl_example_content/content/media/d6d67fd2-775c-46e7-a1bf-6af46290a5c8.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_media_image:
     -
       entity: ed301960-e40f-42b5-9229-4ac20fd07a7e

--- a/web/modules/custom/dpl_example_content/content/media/d97a25fd-a6ae-48b9-9a1a-7aec5372688e.yml
+++ b/web/modules/custom/dpl_example_content/content/media/d97a25fd-a6ae-48b9-9a1a-7aec5372688e.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_byline:
     -
       value: 'Af Becca Tapert / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/dc33677f-8894-4717-b34b-d985f6ad875f.yml
+++ b/web/modules/custom/dpl_example_content/content/media/dc33677f-8894-4717-b34b-d985f6ad875f.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_media_file:
     -
       entity: 3403d0ba-cbdc-425d-93f4-6cdabb5378b1

--- a/web/modules/custom/dpl_example_content/content/media/e4ce7616-976d-43fc-aed2-a01c42b67db9.yml
+++ b/web/modules/custom/dpl_example_content/content/media/e4ce7616-976d-43fc-aed2-a01c42b67db9.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_media_image:
     -
       entity: 231326de-6d73-42c6-8ec3-5d2bbae9cb91

--- a/web/modules/custom/dpl_example_content/content/media/e8283d3c-968a-4e74-ae02-9f02b76bb839.yml
+++ b/web/modules/custom/dpl_example_content/content/media/e8283d3c-968a-4e74-ae02-9f02b76bb839.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_media_image:
     -
       entity: e00e1460-169e-468d-9835-d664f06d0969

--- a/web/modules/custom/dpl_example_content/content/media/eef50571-39dc-461a-96ff-b6b7180ade61.yml
+++ b/web/modules/custom/dpl_example_content/content/media/eef50571-39dc-461a-96ff-b6b7180ade61.yml
@@ -37,6 +37,7 @@ default:
     -
       alias: ''
       langcode: da
+      pathauto: 1
   field_byline:
     -
       value: 'Af Jon Tyson / Unsplash'

--- a/web/modules/custom/dpl_example_content/content/media/f0204f0b-1f63-4c76-bb67-e3f7489ee392.yml
+++ b/web/modules/custom/dpl_example_content/content/media/f0204f0b-1f63-4c76-bb67-e3f7489ee392.yml
@@ -35,6 +35,7 @@ default:
     -
       alias: ''
       langcode: en
+      pathauto: 1
   field_media_oembed_video:
     -
       value: 'https://www.youtube.com/watch?v=CmzKQ3PSrow'

--- a/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
+++ b/web/modules/custom/dpl_example_content/content/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1.yml
@@ -61,8 +61,9 @@ default:
         content: 'Jesper Stein vinder Læsernes Bogpris for Rampen | DPL CMS'
   path:
     -
-      alias: ''
-      langcode: da
+      alias: /artikler/netmedier/jesper-stein-vinder-laesernes-bogpris-rampen
+      langcode: und
+      pathauto: 1
   field_categories:
     -
       entity: 92033694-15ac-4d9e-b275-ddfd18e48d9f

--- a/web/modules/custom/dpl_example_content/content/node/480a6997-4ca2-4cc6-a8f2-61254401d044.yml
+++ b/web/modules/custom/dpl_example_content/content/node/480a6997-4ca2-4cc6-a8f2-61254401d044.yml
@@ -31,6 +31,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  entity_clone_template_active:
+    -
+      value: true
   entity_clone_template_image:
     -
       entity: e00e1460-169e-468d-9835-d664f06d0969
@@ -46,8 +49,9 @@ default:
         content: 'Det virtuelle bibliotek | DPL CMS'
   path:
     -
-      alias: ''
-      langcode: da
+      alias: /det-virtuelle-bibliotek
+      langcode: und
+      pathauto: 1
   field_address:
     -
       langcode: en

--- a/web/modules/custom/dpl_example_content/content/node/852d781f-82c9-40ac-bc8d-d0cefe07706d.yml
+++ b/web/modules/custom/dpl_example_content/content/node/852d781f-82c9-40ac-bc8d-d0cefe07706d.yml
@@ -49,8 +49,9 @@ default:
         content: 'Brønshøj Bibliotek | DPL CMS'
   path:
     -
-      alias: ''
-      langcode: da
+      alias: /bronshoj-bibliotek
+      langcode: und
+      pathauto: 1
   field_address:
     -
       langcode: da

--- a/web/modules/custom/dpl_example_content/content/node/982e0d87-f6b8-4b84-8de8-c8c8bcfef557.yml
+++ b/web/modules/custom/dpl_example_content/content/node/982e0d87-f6b8-4b84-8de8-c8c8bcfef557.yml
@@ -54,8 +54,9 @@ default:
         content: 'Bibliotekarerne anbefaler læsning til den mørke tid | DPL CMS'
   path:
     -
-      alias: ''
-      langcode: da
+      alias: /artikler/bibliotekarerne-anbefaler-laesning-til-den-morke-tid
+      langcode: und
+      pathauto: 1
   field_override_author:
     -
       value: 'Det Digitale Folkebibliotek'

--- a/web/modules/custom/dpl_example_content/content/node/9cfd15df-32b4-4af9-b2da-56b039b5bf6b.yml
+++ b/web/modules/custom/dpl_example_content/content/node/9cfd15df-32b4-4af9-b2da-56b039b5bf6b.yml
@@ -49,8 +49,9 @@ default:
         content: '3 gode til godnat 3-6 år | DPL CMS'
   path:
     -
-      alias: ''
-      langcode: da
+      alias: /artikler/3-gode-til-godnat-3-6-ar
+      langcode: und
+      pathauto: 1
   field_paragraphs:
     -
       entity:

--- a/web/modules/custom/dpl_example_content/content/node/dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0.yml
+++ b/web/modules/custom/dpl_example_content/content/node/dac275e4-9b8c-4959-a13a-6b9fdbc1f6b0.yml
@@ -32,6 +32,9 @@ default:
   revision_translation_affected:
     -
       value: true
+  entity_clone_template_active:
+    -
+      value: true
   entity_clone_template_image:
     -
       entity: e00e1460-169e-468d-9835-d664f06d0969
@@ -47,8 +50,9 @@ default:
         content: 'Hovedbiblioteket | DPL CMS'
   path:
     -
-      alias: ''
-      langcode: da
+      alias: /hovedbiblioteket
+      langcode: und
+      pathauto: 1
   field_address:
     -
       langcode: da
@@ -79,6 +83,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          revision_translation_affected:
+            -
+              value: true
           field_body:
             -
               value: '<p>Velkommen til et hus fuld af viden og oplevelser</p><p>Københavns Hovedbibliotek er et åbent hus som du kan bruge fra morgen til aften. Biblioteket er et levende sted med arrangementer, klubber og udstillinger, for børn og voksne. Sammen bliver vi klogere og inspirerer hinanden.</p>'

--- a/web/modules/custom/dpl_example_content/content/node/fd774222-4b22-4803-ae45-2d4e80d84fac.yml
+++ b/web/modules/custom/dpl_example_content/content/node/fd774222-4b22-4803-ae45-2d4e80d84fac.yml
@@ -58,8 +58,9 @@ default:
         content: 'Frontpage | DPL CMS'
   path:
     -
-      alias: ''
-      langcode: da
+      alias: /frontpage
+      langcode: und
+      pathauto: 1
   field_paragraphs:
     -
       entity:

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0502836d-0f7b-4b21-9371-c40ae9e01495.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/10'
+        href: '/taxonomy/term/17'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/0fa7245a-3434-4d96-9793-a1848a22d37a.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/13'
+        href: '/taxonomy/term/20'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/1006441f-bb39-43b5-8c08-1a79344abf8b.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/5'
+        href: '/taxonomy/term/12'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/190beb00-d5af-4c9a-be8d-65a646b37bbb.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/7'
+        href: '/taxonomy/term/14'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/4704c566-afc2-4131-ab81-3d636f2451bf.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/4704c566-afc2-4131-ab81-3d636f2451bf.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/12'
+        href: '/taxonomy/term/19'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/53133c2e-1023-43a9-baf2-64a5081eea0f.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/6'
+        href: '/taxonomy/term/13'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/725e0059-9c5d-4c4e-8e3d-6d8cf2042fa4.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/8'
+        href: '/taxonomy/term/15'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/807e6053-86ed-4dce-b6a9-a48b566b5910.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/3'
+        href: '/taxonomy/term/10'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/92033694-15ac-4d9e-b275-ddfd18e48d9f.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/4'
+        href: '/taxonomy/term/11'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/e539b26b-2992-406b-accf-03e549522c0d.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/e539b26b-2992-406b-accf-03e549522c0d.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/11'
+        href: '/taxonomy/term/18'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/ec76c707-898d-4dfd-8cd2-e258aef1d6dd.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/9'
+        href: '/taxonomy/term/16'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1

--- a/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
+++ b/web/modules/custom/dpl_example_content/content/taxonomy_term/f457c4c2-dc28-45cd-9b6e-fda4248d9d45.yml
@@ -30,8 +30,9 @@ default:
       tag: link
       attributes:
         rel: canonical
-        href: '/taxonomy/term/14'
+        href: '/taxonomy/term/21'
   path:
     -
       alias: ''
       langcode: da
+      pathauto: 1


### PR DESCRIPTION
Re-export all example content, based on `develop`

Apparantly, various fields have been updated, but the
updates have not been passed along to the example content.
This is the result of running the following commands on `develop`:

```
drush default-content:export-module dpl_example_content
drush default-content:export-module dpl_example_breadcrumb
```

And, then finally doing a search/replace to fix any links:

"http://dpl-cms.docker/" => "/"