### PR TITLE
Add 'published' status condition for method `getRenderedReferencingNodes`

### DIFF
--- a/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
+++ b/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\node\NodeInterface;
 use Drupal\pathauto\AliasCleanerInterface;
 use Drupal\recurring_events\Entity\EventInstance;
 use Drupal\taxonomy\TermInterface;
@@ -443,6 +444,7 @@ class BreadcrumbHelper {
     $query = $node_storage->getQuery();
     $nids = $query
       ->condition($field_name, $breadcrumb_item->id())
+      ->condition('status', NodeInterface::PUBLISHED)
       ->accessCheck(TRUE)
       ->sort('title', 'ASC')
       ->execute();


### PR DESCRIPTION

DDFFORM-805

#### Link to issue

Jira: [DDFFORM-805](https://reload.atlassian.net/browse/DDFFORM-805)

#### Description

The paragraph breadcrumb_children was displaying links to pages/other content that was unpublished. This should ensure that the nodes referenced are published.


Test this by using the paragraph breadcrumb_children, and then unpublish/republish some of the children that are displayed. 

[DDFFORM-805]: https://reload.atlassian.net/browse/DDFFORM-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ