### PR TITLE
Use platform bots access token

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -108,7 +108,7 @@ jobs:
           --body "${{ format('This is an automated PR for {0}:{1}', env.PACKAGE, env.PR_BRANCH) }}"
         if: ${{ steps.create_branch.outcome == 'success' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CMS_PR_CREATION_PAT }}
 
       - name: Adding summary
         run: |


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-643

#### Description

In order to make sure that the PR checks are running when the PR has been created.
According to this
[post](https://github.com/orgs/community/discussions/25602#discussioncomment-3248432) it should be solved with adding a PAT with the right permissions.

