### PR TITLE
Disable config-ignore-auto on local development machines.

### DIFF
--- a/assets/development.settings.php
+++ b/assets/development.settings.php
@@ -2,10 +2,3 @@
 
 # Enable verbose error reporting.
 $config['system.logging']['error_level'] = 'verbose';
-
-// Disable the "config auto ignore" module on local development.
-// When config_ignore_auto is enabled, it means that saving config-forms will
-// add the saved changes as 'ignored', and won't be overriden on next deploy.
-// This is a problem for development, as we obviously want to be able to
-// "cex" and "cim" our updates.
-$config['config_ignore_auto.settings']['status'] = FALSE;

--- a/assets/local.settings.php
+++ b/assets/local.settings.php
@@ -9,3 +9,10 @@ $config['system.performance']['js']['preprocess'] = FALSE;
 
 # Disable caching.
 $settings['cache']['default'] = 'cache.backend.null';
+
+// Disable the "config auto ignore" module on local development.
+// When config_ignore_auto is enabled, it means that saving config-forms will
+// add the saved changes as 'ignored', and won't be overriden on next deploy.
+// This is a problem for development, as we obviously want to be able to
+// "cex" and "cim" our updates.
+$config['config_ignore_auto.settings']['status'] = FALSE;


### PR DESCRIPTION
This was already done in development.settings.php but apparantly this is not the right file for local development.

This means that as a developer, you cannot export your config at the moment.

When config_ignore_auto is enabled, it means that saving config-forms will add the saved changes as 'ignored', and won't be overriden on next deploy. This is a problem for development, as we obviously want to be able to "cex" and "cim" our updates.
