### PR TITLE
Don't show expired or unpublished events in filtered events paragraph DDFFORM-796

### DIFF
--- a/config/sync/views.view.filtered_event_list.yml
+++ b/config/sync/views.view.filtered_event_list.yml
@@ -6,6 +6,7 @@ dependencies:
     - search_api.index.events
   module:
     - search_api
+    - user
 id: filtered_event_list
 label: 'Filtered events'
 module: views
@@ -105,8 +106,9 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: none
-        options: {  }
+        type: perm
+        options:
+          perm: 'access content'
       cache:
         type: none
         options: {  }
@@ -219,7 +221,94 @@ display:
           validate_options: {  }
           break_phrase: true
           not: false
-      filters: {  }
+      filters:
+        end_value:
+          id: end_value
+          table: search_api_index_events
+          field: end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_date
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: search_api_index_events
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -249,6 +338,7 @@ display:
       contexts:
         - 'languages:language_interface'
         - url
+        - user.permissions
       tags:
         - 'config:search_api.index.events'
         - 'search_api_list:events'


### PR DESCRIPTION
A bit hard to test, cause lagoon refuses to create an environment, but the title and the code is pretty straight forward:

Add the same kind of filters that we have on the /events view.

https://reload.atlassian.net/browse/DDFFORM-796