### PR TITLE
Allow authenticated patrons to retrieve opening hours from API

### DIFF
--- a/config/sync/rest.resource.dpl_opening_hours_list.yml
+++ b/config/sync/rest.resource.dpl_opening_hours_list.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - dpl_login
     - dpl_opening_hours
     - serialization
     - user
@@ -15,4 +16,5 @@ configuration:
   formats:
     - json
   authentication:
+    - dpl_login_user_token
     - cookie


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-799

#### Description

Currently when a user who is authenticated as a patron tries to view the opening hours for a brach the API request to retrieve the opening hours is denied with a HTTP 403 response code and message: "The used authentication method is not allowed on this route."

This happens because the React component by default provides a bearer token for API requests if it exists. This maps to an authentication method, dpl_login_user_token, which is currently not enabled for the REST resource.

This API request does not require any form of authentication but we cannot easily avoid sending tokens for this request or allow access as the resource allows anonymous access.

To fix this we add the authentication method to the REST resource.

#### Screenshot of the result

Before:

![Monosnap Hovedbiblioteket | DPL CMS — Privat browsing 2024-06-10 08-44-37](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/64ae0067-315e-4de9-af1e-6092607f7013)
![Monosnap Details | DPL CMS | Logged in 2024-06-10 08-45-14](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/2a601c72-9cc4-456c-adda-31e2065f194b)

After:
![Monosnap Hovedbiblioteket | DPL CMS — Privat browsing 2024-06-10 08-45-48](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/73966/28df0cfd-95dd-469e-ad61-4557f5ea6e1a)

#### Additional comments or questions

