### PR TITLE
Fix broken header, when logged into admin interface.

### DIFF
--- a/web/modules/custom/dpl_admin/assets/dpl_frontend.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_frontend.css
@@ -25,6 +25,19 @@
   mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M5 13q-.425 0-.712-.288T4 12t.288-.712T5 11h6.6l5-5H15q-.425 0-.712-.288T14 5t.288-.712T15 4h4q.425 0 .713.288T20 5v4q0 .425-.288.713T19 10t-.712-.288T18 9V7.4l-5.025 5.025q-.275.275-.637.425t-.763.15zm10 7q-.425 0-.712-.288T14 19t.288-.712T15 18h1.6l-2.475-2.45q-.3-.3-.3-.712t.3-.713t.725-.3t.725.3L18 16.6V15q0-.425.288-.712T19 14t.713.288T20 15v4q0 .425-.288.713T19 20z"/></svg>') !important;
 }
 
+/*
+  The DPL header gets confused when the admin toolbar exists, and keeps being
+  placed in a wrong position.
+  We'll just completely disable the dynamic movement, when the toolbar is
+  visible.
+*/
+.toolbar-fixed {
+  .header,
+  .header[style] {
+    top: 0 !important;
+  }
+}
+
 /* Gin wants to hide the text of the secondary toolbar items way too early. */
 @media (min-width: 61em) {
   .toolbar-horizontal .gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab .toolbar-item {


### PR DESCRIPTION
<img width="931" alt="Screenshot 2024-06-10 at 09 21 45" src="https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/12376583/9606446b-7b44-42f3-89fa-f33f26f60276">

This is driving me insane. Here's a quickfix.