### PR TITLE
Update mobile-menu toggle button to button element.

### DIFF
--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -7,19 +7,22 @@
         <nav class="header__menu-first" aria-label="Primary site navigation">
             <div>
                 <div class="header__menu-navigation-mobile">
-                    <div class="pagefold-parent--small header__menu-navigation-button header__button" id="header-sidebar-nav__toggle"
-                    aria-controls="sidebarNav"
-                    aria-expanded="false"
-                    role="button"
-                    tabIndex="0">
+                  <button
+                  class="header__menu-navigation-button header__button"
+                  id="header-sidebar-nav__toggle"
+                  aria-controls="sidebarNav"
+                  aria-expanded="false"
+                  >
+                    <div class="pagefold-parent--small
+                    header__menu-navigation-pagefold">
                         <div class="pagefold-triangle--small"></div>
                         <img width="20" height="14" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-menu.svg" alt="List of bookmarks"/>
                     </div>
-                    <div class="header__menu-navigation-logo">
-                       {{ logo }}
-                    </div>
+                  </button>
+                  <div class="header__menu-navigation-logo">
+                    {{ logo }}
+                  </div>
                 </div>
-
                 {{ drupal_menu('main') }}
             </div>
       {{ patron_menu }}


### PR DESCRIPTION


#### Link to issue
[DDFFORM-812](https://reload.atlassian.net/browse/DDFFORM-812)

design system pr: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/655

Design
#### Description

This PR updates the  HTML markup for the mobile-menu toggler to be a button, in order to let non-chromium based browers add their default focus styling. 

This commit is reflecthing the changes added to the design system [here](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/655/commits/adb857b3c8e86a0d21e060e66d28736244234236)


Please test that the button works and that a focus as added in non-chromium browsers. 

[DDFFORM-812]: https://reload.atlassian.net/browse/DDFFORM-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ