### PR TITLE
Debug detection and logging of Form triggering element detection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -290,7 +290,8 @@
                 "2259567: Support SVG files for theme logo setting": "https://www.drupal.org/files/issues/2023-05-08/2259567-168.patch",
                 "296693: Restrict access to empty top level administration pages": "https://www.drupal.org/files/issues/2023-08-31/296693-10.1.x_0.patch",
                 "3035578: Add details for AJAX response errors": "https://www.drupal.org/files/issues/2023-07-24/3035578-26.patch",
-                "Always assume chmod succeeds": "patches/core-304fd8b-chmod-true.patch"
+                "Always assume chmod succeeds": "patches/core-304fd8b-chmod-true.patch",
+                "Debug Form triggering element detection": "patches/form-triggering-element-detection-paragraphs-ee.patch"
             },
             "drupal/date_range_formatter": {
                 "3309324: Fails when start and end date are identical": "https://www.drupal.org/files/issues/2023-12-22/date_range_formatter_3309324_1.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fff56dea27360f4375755b7f45bb0946",
+    "content-hash": "53efde585c78fda19c956051c045f7c4",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -4186,17 +4186,17 @@
         },
         {
             "name": "drupal/gin",
-            "version": "3.0.0-rc7",
+            "version": "3.0.0-rc10",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/gin.git",
-                "reference": "8.x-3.0-rc7"
+                "reference": "8.x-3.0-rc10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/gin-8.x-3.0-rc7.zip",
-                "reference": "8.x-3.0-rc7",
-                "shasum": "9f91862fc82ef8b0adbf34b26caa3c42d4f1f6b2"
+                "url": "https://ftp.drupal.org/files/projects/gin-8.x-3.0-rc10.zip",
+                "reference": "8.x-3.0-rc10",
+                "shasum": "f79fd895dd1f16c3af457bfaed5527f5b5bc752c"
             },
             "require": {
                 "drupal/core": "^9 || ^10",
@@ -4205,8 +4205,8 @@
             "type": "drupal-theme",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.0-rc7",
-                    "datestamp": "1697193234",
+                    "version": "8.x-3.0-rc10",
+                    "datestamp": "1712686345",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."

--- a/patches/form-triggering-element-detection-paragraphs-ee.patch
+++ b/patches/form-triggering-element-detection-paragraphs-ee.patch
@@ -1,0 +1,58 @@
+From 6c49a270b2b9979344c75268ddccdd4aa089b2fe Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kasper=20Garn=C3=A6s?= <kasperg@users.noreply.github.com>
+Date: Fri, 14 Jun 2024 13:19:30 +0200
+Subject: [PATCH] Debug detection and logging of Form triggering element
+ detection
+
+When editors select a paragraph to add to a page we are seeing
+unexpected behavior:
+
+1. Users see an error message: "Oops - something went wrong". This
+occurs because Drupal cannot determine the AJAX callback for the
+triggering element in FormAjaxResponseBuilder::buildResponse()
+2. The UI behaves as if a different button has been clicked by opening
+the edit form of an existing paragraph instead.
+
+This may occur because Drupal fails to detect the triggering element.
+In these situations Drupal will instead try to use the first button
+on the page.
+
+We do not know why this happens.
+
+One theory is that the #value of the clicked button differs e.g. due
+to translations.
+
+In this situation it should actually be sufficient to check for the
+triggering element name as these differ between different paragraph
+types. The value makes no difference in this regard.
+
+We cannot easily un/reset the #value for the element in the Paragraph
+Editor Enhancements module. Instead we try to work around the issue
+by only comparing the element name if the element looks like a
+Paragraphs Editor Enhancement button.
+
+To provide additional information we try to add more logging for
+situations where there is no match between element values.
+---
+ lib/Drupal/Core/Form/FormBuilder.php | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/Drupal/Core/Form/FormBuilder.php b/lib/Drupal/Core/Form/FormBuilder.php
+index d7c4bf9374..06e0e904e5 100644
+--- a/lib/Drupal/Core/Form/FormBuilder.php
++++ b/lib/Drupal/Core/Form/FormBuilder.php
+@@ -1344,8 +1344,10 @@ class FormBuilder implements FormBuilderInterface, FormValidatorInterface, FormS
+   protected function elementTriggeredScriptedSubmission($element, FormStateInterface &$form_state) {
+     $input = $form_state->getUserInput();
+     if (!empty($input['_triggering_element_name']) && $element['#name'] == $input['_triggering_element_name']) {
+-      if (empty($input['_triggering_element_value']) || $input['_triggering_element_value'] == $element['#value']) {
++      if (empty($input['_triggering_element_value']) || $input['_triggering_element_value'] == $element['#value'] || preg_match('/^field_paragraphs_.*_add_more$/', $input['_triggering_element_name'])) {
+         return TRUE;
++      } else {
++        \Drupal::logger('form_builder')->debug("Value for triggering element {$input['_triggering_element_name']} does not match. Expected: {$element['#value']}. Actual: {$input['_triggering_element_value']}");
+       }
+     }
+     return FALSE;
+-- 
+2.43.4
+


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-698

#### Description

When editors select a paragraph to add to a page we are seeing unexpected behavior:

1. Users see an error message: "Oops - something went wrong". This occurs because Drupal cannot determine the AJAX callback for the triggering element in FormAjaxResponseBuilder::buildResponse()
2. The UI behaves as if a different button has been clicked by opening the edit form of an existing paragraph instead.

This may occur because Drupal fails to detect the triggering element. In these situations Drupal will instead try to use the first button on the page.

We do not know why this happens.

One theory is that the #value of the clicked button differs e.g. due to translations.

In this situation it should actually be sufficient to check for the triggering element name as these differ between different paragraph types. The value makes no difference in this regard.

We cannot easily un/reset the #value for the element in the Paragraph Editor Enhancements module. Instead we try to work around the issue by only comparing the element name if the element looks like a Paragraphs Editor Enhancement button.

To provide additional information we try to add more logging for situations where there is no match between element values.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
