### PR TITLE
Refactor preprocess for displaying upcoming events on series.

### DIFF
--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -17,6 +17,7 @@ use Drupal\dpl_event\Workflows\UnpublishSchedule;
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\recurring_events\Entity\EventInstance;
 use Drupal\recurring_events\Entity\EventSeries;
+use Safe\DateTime;
 
 /**
  * Implements hook_cron_job_scheduler_info().
@@ -186,18 +187,30 @@ function dpl_event_preprocess_eventseries(array &$variables): void {
     return;
   }
 
-  // Load event instances related to this series and prepare them for rendering.
+  // Load event instances & filter out past events.
   $eventinstances_in_series = $event_series->get('event_instances')->referencedEntities();
+  $current_date = (new DateTime())->setTime(0, 0, 0);
 
+  $eventinstances_in_series_filtered = array_filter($eventinstances_in_series, function ($eventInstance) use ($current_date) {
+    $event_start_date = new DateTime($eventInstance->get('date')->start_date);
+    return $event_start_date >= $current_date;
+  });
+
+  $eventinstances_in_series_filtered = array_values($eventinstances_in_series_filtered);
+
+  $viewBuilder = \Drupal::entityTypeManager()->getViewBuilder('eventinstance');
   $variables['event_instances'] = [];
-  foreach ($eventinstances_in_series as $index => $eventInstance) {
+  foreach ($eventinstances_in_series_filtered as $index => $eventInstance) {
     $viewMode = $index === 0 ? 'list_teaser_stacked_parent' : 'stacked_event';
-
-    $renderable_instances = \Drupal::entityTypeManager()
-      ->getViewBuilder('eventinstance')->view($eventInstance, $viewMode);
-
-    $variables['event_instances'][] = $renderable_instances;
+    $renderable_instance = $viewBuilder->view($eventInstance, $viewMode);
+    $variables['event_instances'][] = $renderable_instance;
   }
+
+  // Add cache tags and 12-hours max-age fallback.
+  $variables['#cache'] = [
+    '#max-age' => (60 * 60 * 12),
+    '#tags' => ['eventinstance_list', 'eventseries_list'],
+  ];
 }
 
 /**


### PR DESCRIPTION
This commit ensures that only event instances that are happening `today` and onwards are displayed  as upcoming events. Before it was displayed everything in the series regardless of whether the date had passed.

DDFFORM-846

#### Link to issue

[DDFFORM-846](https://reload.atlassian.net/browse/DDFFORM-846)

#### Description

On an eventseries page, only event instances that happen from the current day and onwards should be displayed. This was not the case before . 

Test: 

Create an eventseries with 1-2 dates that have already occured, and 1-2 that have not yet occured. Confirm tha the 1-2 dates that have already occured are not displayed. 

[DDFFORM-846]: https://reload.atlassian.net/browse/DDFFORM-846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ