### PR TITLE
Re-introduce automatic paragraph logic via dpl_filtered_paragraphs. DDFFORM-861

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.card_grid_automatic.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.card_grid_automatic.default.yml
@@ -17,7 +17,6 @@ third_party_settings:
   field_group:
     group_filters:
       children:
-        - field_filter_cond_type
         - field_filter_tags
         - field_filter_categories
         - field_filter_branches
@@ -57,12 +56,6 @@ content:
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }
-  field_filter_cond_type:
-    type: options_buttons
-    weight: 14
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_filter_content_types:
     type: select2
     weight: 1
@@ -90,4 +83,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_filter_cond_type: true
   status: true

--- a/config/sync/core.entity_form_display.paragraph.content_slider_automatic.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.content_slider_automatic.default.yml
@@ -17,7 +17,6 @@ third_party_settings:
   field_group:
     group_filters:
       children:
-        - field_filter_cond_type
         - field_filter_tags
         - field_filter_categories
         - field_filter_branches
@@ -57,12 +56,6 @@ content:
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }
-  field_filter_cond_type:
-    type: options_buttons
-    weight: 2
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_filter_content_types:
     type: select2
     weight: 1
@@ -90,4 +83,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_filter_cond_type: true
   status: true

--- a/config/sync/core.entity_form_display.paragraph.filtered_event_list.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.filtered_event_list.default.yml
@@ -18,11 +18,9 @@ third_party_settings:
   field_group:
     group_filters:
       children:
-        - field_filter_cond_type
         - field_filter_tags
         - field_filter_categories
         - field_filter_branches
-        - field_filter_content_types
         - field_max_item_amount
       label: Filters
       region: content
@@ -60,12 +58,6 @@ content:
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }
-  field_filter_cond_type:
-    type: options_buttons
-    weight: 9
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_filter_tags:
     type: select2_entity_reference
     weight: 10
@@ -94,4 +86,5 @@ content:
 hidden:
   created: true
   field_amount_of_events: true
+  field_filter_cond_type: true
   status: true

--- a/config/sync/core.entity_view_display.paragraph.card_grid_automatic.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.card_grid_automatic.preview.yml
@@ -24,7 +24,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 5
+    weight: 4
     region: content
   field_filter_categories:
     type: entity_reference_label
@@ -32,21 +32,14 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 4
-    region: content
-  field_filter_cond_type:
-    type: list_default
-    label: inline
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
+    weight: 3
     region: content
   field_filter_content_types:
     type: list_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   field_filter_tags:
     type: entity_reference_label
@@ -54,7 +47,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   field_title:
     type: string
@@ -65,4 +58,5 @@ content:
     weight: 0
     region: content
 hidden:
+  field_filter_cond_type: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.content_slider_automatic.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.content_slider_automatic.preview.yml
@@ -24,7 +24,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 5
+    weight: 4
     region: content
   field_filter_categories:
     type: entity_reference_label
@@ -32,21 +32,14 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 4
-    region: content
-  field_filter_cond_type:
-    type: list_default
-    label: inline
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
+    weight: 3
     region: content
   field_filter_content_types:
     type: list_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   field_filter_tags:
     type: entity_reference_label
@@ -54,7 +47,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   field_title:
     type: string
@@ -65,4 +58,5 @@ content:
     weight: 0
     region: content
 hidden:
+  field_filter_cond_type: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.filtered_event_list.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.filtered_event_list.preview.yml
@@ -35,13 +35,6 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  field_filter_cond_type:
-    type: list_default
-    label: inline
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_filter_tags:
     type: entity_reference_label
     label: above
@@ -67,4 +60,5 @@ content:
     region: content
 hidden:
   field_amount_of_events: true
+  field_filter_cond_type: true
   search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -41,6 +41,7 @@ module:
   dpl_fbi: 0
   dpl_fbs: 0
   dpl_fees: 0
+  dpl_filter_paragraphs: 0
   dpl_footer: 0
   dpl_instant_loan: 0
   dpl_library_agency: 0

--- a/config/sync/field.field.paragraph.card_grid_automatic.field_filter_cond_type.yml
+++ b/config/sync/field.field.paragraph.card_grid_automatic.field_filter_cond_type.yml
@@ -11,8 +11,8 @@ id: paragraph.card_grid_automatic.field_filter_cond_type
 field_name: field_filter_cond_type
 entity_type: paragraph
 bundle: card_grid_automatic
-label: 'Condition type'
-description: ''
+label: 'Condition type (INACTIVE)'
+description: 'This field will be used in relation to the dpl_related_content in the future, but currently has no effect.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/field.field.paragraph.content_slider_automatic.field_filter_cond_type.yml
+++ b/config/sync/field.field.paragraph.content_slider_automatic.field_filter_cond_type.yml
@@ -11,8 +11,8 @@ id: paragraph.content_slider_automatic.field_filter_cond_type
 field_name: field_filter_cond_type
 entity_type: paragraph
 bundle: content_slider_automatic
-label: 'Condition type'
-description: ''
+label: 'Condition type (INACTIVE)'
+description: 'This field will be used in relation to the dpl_related_content in the future, but currently has no effect.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/field.field.paragraph.filtered_event_list.field_filter_cond_type.yml
+++ b/config/sync/field.field.paragraph.filtered_event_list.field_filter_cond_type.yml
@@ -11,8 +11,8 @@ id: paragraph.filtered_event_list.field_filter_cond_type
 field_name: field_filter_cond_type
 entity_type: paragraph
 bundle: filtered_event_list
-label: 'Condition type'
-description: ''
+label: 'Condition type (INACTIVE)'
+description: 'This field will be used in relation to the dpl_related_content in the future, but currently has no effect.'
 required: true
 translatable: false
 default_value:

--- a/config/sync/views.view.content_paragraphs.yml
+++ b/config/sync/views.view.content_paragraphs.yml
@@ -1,0 +1,340 @@
+uuid: 66163bca-af6b-4db4-b820-3579418763ea
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.card
+  module:
+    - node
+    - user
+id: content_paragraphs
+label: 'Content lists, embedded in Paragraphs'
+module: views
+description: 'Lists for displaying content, through embedded views in paragraphs. Also allows the editor to set filter options in the paragraphs, that will be sent along using contextual filters. See dpl_filter_paragraphs.module'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: ''
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 6
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments:
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+        field_categories_target_id:
+          id: field_categories_target_id
+          table: node__field_categories
+          field: field_categories_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+        field_branch_target_id:
+          id: field_branch_target_id
+          table: node__field_branch
+          field: field_branch_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: node_type
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+      style:
+        type: default
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: card
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  card_grid:
+    id: card_grid
+    display_title: 'Card grid'
+    display_plugin: block
+    position: 1
+    display_options:
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  slider:
+    id: slider
+    display_title: Slider
+    display_plugin: block
+    position: 2
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 16
+      defaults:
+        pager: false
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.filtered_event_list.yml
+++ b/config/sync/views.view.filtered_event_list.yml
@@ -1,0 +1,344 @@
+uuid: 7a8ef9f1-371e-41d6-abc9-d6d5534dc149
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.events
+  module:
+    - search_api
+    - user
+id: filtered_event_list
+label: 'Filtered events'
+module: views
+description: 'This view displays a filtered list of upcoming events sorted by date ascending. Filters include categories, tags and branches'
+tag: ''
+base_table: search_api_index_events
+base_field: search_api_id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        branch:
+          id: branch
+          table: search_api_index_events
+          field: branch
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: search_api_entity
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          link_to_item: false
+          use_highlighting: false
+          multi_type: separator
+          multi_separator: ', '
+          display_methods: {  }
+        branch_1:
+          id: branch_1
+          table: search_api_datasource_events_entity_eventinstance
+          field: branch
+          entity_type: eventinstance
+          plugin_id: search_api_entity
+        branch_2:
+          id: branch_2
+          table: search_api_datasource_events_entity_eventinstance
+          field: branch
+          entity_type: eventinstance
+          plugin_id: search_api_entity
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 16
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: none
+        options: {  }
+      empty: {  }
+      sorts:
+        date:
+          id: date
+          table: search_api_index_events
+          field: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments:
+        event_tags:
+          id: event_tags
+          table: search_api_index_events
+          field: event_tags
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_term
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+        event_categories:
+          id: event_categories
+          table: search_api_index_events
+          field: event_categories
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_term
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+        branch:
+          id: branch
+          table: search_api_index_events
+          field: branch
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+      filters:
+        end_value:
+          id: end_value
+          table: search_api_index_events
+          field: end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_date
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: search_api_index_events
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: search_api
+        options:
+          view_modes:
+            'entity:eventinstance':
+              default: list_teaser
+      query:
+        type: search_api_query
+        options:
+          bypass_access: false
+          skip_access: false
+          preserve_facet_query_args: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - user.permissions
+      tags:
+        - 'config:search_api.index.events'
+        - 'search_api_list:events'

--- a/web/modules/custom/dpl_filter_paragraphs/dpl_filter_paragraphs.deploy.php
+++ b/web/modules/custom/dpl_filter_paragraphs/dpl_filter_paragraphs.deploy.php
@@ -10,9 +10,44 @@
 use Drupal\paragraphs\Entity\Paragraph;
 
 /**
+ * Port existing automatic paragraphs to only pull articles.
+ *
+ * This is the default functionality in the past, but now it is a functionality
+ * that the editor can choose.
+ */
+function dpl_filter_paragraphs_deploy_port_automatic_defaults(): string {
+  $ids =
+    \Drupal::entityQuery('paragraph')
+      ->condition('type', 'card_grid_automatic')
+      ->accessCheck(FALSE)
+      ->execute();
+
+  if (empty($ids) || is_int($ids)) {
+    return 'No entities to update.';
+  }
+
+  $entities =
+    \Drupal::entityTypeManager()->getStorage('paragraph')->loadMultiple($ids);
+
+  foreach ($entities as $entity) {
+    if (!($entity instanceof Paragraph)) {
+      continue;
+    }
+
+    $entity->set('field_filter_content_types', ['article']);
+    $entity->save();
+  }
+
+  return t("Updated @count automatic paragraphs, setting 'article' as CT default.", [
+    "@count" => count($entities),
+  ])->render();
+
+}
+
+/**
  * Port values from field_amount_of_events => field_max_item_amount.
  */
-function dpl_related_content_deploy_port_amount_item(): string {
+function dpl_filter_paragraphs_deploy_port_amount_item(): string {
   $source_field = 'field_amount_of_events';
   $target_field = 'field_max_item_amount';
 

--- a/web/modules/custom/dpl_filter_paragraphs/dpl_filter_paragraphs.module
+++ b/web/modules/custom/dpl_filter_paragraphs/dpl_filter_paragraphs.module
@@ -2,9 +2,162 @@
 
 /**
  * @file
- * This file is left empty on purpose.
- *
- * The dpl_filter_paragraphs module is deprecated, and will be deactivated
- * and deleted in the future, but Drupal will be confused if the .module
- * file is deleted before the module is disabled.
+ * DPL filtered Paragraphs.
  */
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\views\ViewExecutable;
+use Drupal\views\Views;
+
+/**
+ * Implements theme_preprocess_paragraph__NAME().
+ *
+ * @see _dpl_filter_paragraphs_prepare_filter_view()
+ */
+function dpl_filter_paragraphs_preprocess_paragraph__card_grid_automatic(array &$variables): void {
+  $variables = _dpl_filter_paragraphs_prepare_filter_view($variables, 'content_paragraphs', 'card_grid', NULL);
+}
+
+/**
+ * Implements theme_preprocess_paragraph__NAME().
+ *
+ * @see _dpl_filter_paragraphs_prepare_filter_view()
+ */
+function dpl_filter_paragraphs_preprocess_paragraph__content_slider_automatic(array &$variables): void {
+  $variables = _dpl_filter_paragraphs_prepare_filter_view($variables, 'content_paragraphs', 'slider', NULL);
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for paragraph__filtered_list_event.html.twig.
+ *
+ * @param array &$variables
+ *   Variables for the paragraph template, including the 'paragraph' entity.
+ */
+function dpl_filter_paragraphs_preprocess_paragraph__filtered_event_list(array &$variables): void {
+  $paragraph = $variables['paragraph'] ?? NULL;
+
+  if (!($paragraph instanceof Paragraph)) {
+    return;
+  }
+
+  $amount_of_events_to_display = NULL;
+  if ($paragraph->hasField('field_amount_of_events') && !$paragraph->get('field_amount_of_events')->isEmpty()) {
+    $amount_of_events_to_display = $paragraph->get('field_amount_of_events')->value;
+  }
+
+  $variables = _dpl_filter_paragraphs_prepare_filter_view($variables, 'filtered_event_list', 'default', $amount_of_events_to_display);
+}
+
+/**
+ * Getting the content list views, and setting relevant paragraph filters.
+ *
+ * We use the filters to set as contextual filters on the view.
+ *
+ * @param array<mixed> $variables
+ *   See the $variables in theme_preprocess_paragraph__NAME().
+ * @param string $view_name
+ *   The name of the view to load.
+ * @param string $item_view_mode
+ *   The display mode of the view to set.
+ * @param int|null $item_limit
+ *   (optional) The number of items to return. Only used if set.
+ *
+ * @return array<mixed>
+ *   See the $variables in theme_preprocess_paragraph__NAME().
+ */
+function _dpl_filter_paragraphs_prepare_filter_view(array $variables, string $view_name, string $item_view_mode, ?int $item_limit): array {
+  // In the preview (AKA backend view), we don't want to load in the whole view.
+  if ($variables['view_mode'] === 'preview') {
+    return $variables;
+  }
+
+  // Drupal will cache the whole paragraph, as it does not know that it is
+  // embedding a view. We'll add a simple cache tag to the paragraph, so it
+  // be invalidated if any nodes have been updated - e.g. the same kind of
+  // cache tag that the view has.
+  $variables['#cache']['tags'][] = 'node_list';
+
+  $paragraph = $variables['paragraph'] ?? NULL;
+
+  if (!($paragraph instanceof Paragraph)) {
+    return $variables;
+  }
+
+  $view = Views::getView($view_name);
+  if (!$view instanceof ViewExecutable) {
+    return $variables;
+  }
+
+  $view->setDisplay($item_view_mode);
+
+  // The order of this list must be identical to the order of the contextual
+  // filters in the view!
+  $filters = [
+    'field_filter_tags',
+    'field_filter_categories',
+    'field_filter_branches',
+    'field_filter_content_types',
+  ];
+
+  $arguments = [];
+
+  // Looping through our paragraph field filters, and setting any values
+  // as contextual values for the view.
+  foreach ($filters as $filter_name) {
+    // If the paragraph has no matching field, we'll just set the value to
+    // all. THIS IS IMPORTANT, as otherwise there will be a mismatch between
+    // the contextual filters and the keys.
+    if (!$paragraph->hasField($filter_name)) {
+      $arguments[] = 'all';
+
+      continue;
+    }
+
+    $field = $paragraph->get($filter_name);
+    $filter_value = $field->getString();
+    $filter_value = !empty($filter_value) ? $filter_value : 'all';
+
+    // getString() gets values as comma seperated.
+    // We want it to be seperated with + instead, to show view that it's
+    // OR instead of AND.
+    $filter_value = str_replace(', ', '+', $filter_value);
+
+    $arguments[] = $filter_value;
+  }
+
+  // Argument = Contextual filters.
+  $view->setArguments($arguments);
+
+  // If there is an item_limit set, we'll set the pager to that.
+  if ($item_limit) {
+    $view->getPager()->setItemsPerPage($item_limit);
+  }
+
+  // Making a unique cache key, based on the chosen arguments.
+  // We need a unique cache key, as the view is getting embedded, and Drupal
+  // does not understand that different contextual filters should result in
+  // different caching.
+  $cache_key = "filter_paragraphs_{$item_view_mode}:" . md5(serialize($arguments));
+
+  $view->element['#cache'] = NestedArray::mergeDeep($view->element['#cache'], [
+    'keys' => [$cache_key],
+  ]);
+
+  $view->execute();
+
+  $view_has_results = !empty($view->result);
+  $variables['view_has_results'] = $view_has_results;
+
+  if ($paragraph->hasField('field_title')) {
+    // Replacing the view title with our custom paragraph field_title.
+    $paragraph_title = $paragraph->get('field_title')->getString();
+
+    $view->setTitle($paragraph_title);
+  }
+
+  $variables['content']['view'] = $view->buildRenderable($item_view_mode);
+  $view->buildRenderable($item_view_mode);
+
+  return $variables;
+}

--- a/web/modules/custom/dpl_related_content/dpl_related_content.module
+++ b/web/modules/custom/dpl_related_content/dpl_related_content.module
@@ -6,6 +6,7 @@ use Drupal\dpl_related_content\Services\RelatedContent;
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\views\Views;
 
 /**
  * Place a dynamic 'related content' list on articles and eventinstances.
@@ -90,6 +91,16 @@ function dpl_related_content_preprocess_paragraph__filtered_event_list(array &$v
  *   The updated $variables.
  */
 function _dpl_related_content_filter_paragraph(array $variables, RelatedContentListStyle $list_style = RelatedContentListStyle::Slider, ?int $max_items = NULL, ?array $node_bundles = NULL): array {
+  // @todo This code is unused for now. It was merged into develop, but the
+  // functionality regarding RelatedContent+Paragraphs must be deactivated,
+  // to prepare for migration. However, the rest of the RelatedContent
+  // functionality is still relevant.
+  // When removing this, remember to also update
+  // dpl_related_content_field_filter_content_types_options().
+  if (Views::getView('content_paragraphs')) {
+    return $variables;
+  }
+
   $paragraph = $variables['paragraph'] ?? NULL;
   $view_mode = $variables['view_mode'] ?? NULL;
 
@@ -169,8 +180,10 @@ function _dpl_related_content_filter_paragraph(array $variables, RelatedContentL
  *   The options, used in field_filter_content_types dropdown.
  */
 function dpl_related_content_field_filter_content_types_options(): array {
-  $content_types = ['event' => t('Event', [], ['context' => 'DPL admin UX'])];
-
+  // @todo This can first be enabled when RelatedContent is updated to be used
+  // by paragraphs. See _dpl_related_content_filter_paragraph().
+  // $content_types =['event' => t('Event', [], ['context' => 'DPL admin UX'])];
+  $content_types = [];
   $node_types = \Drupal::entityTypeManager()
     ->getStorage('node_type')
     ->loadMultiple();

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -22,6 +22,7 @@ function dpl_update_install(): string {
   $messages[] = dpl_update_update_10001();
   $messages[] = dpl_update_update_10002();
   $messages[] = dpl_update_update_10003();
+  $messages[] = dpl_update_update_10004();
 
   return implode('\r\n', $messages);
 }
@@ -47,6 +48,13 @@ function dpl_update_update_10002(): string {
  */
 function dpl_update_update_10003(): string {
   return _dpl_update_install_modules(['config_perms']);
+}
+
+/**
+ * Installing dpl_filter_paragraphs and dpl_related_content modules.
+ */
+function dpl_update_update_10004(): string {
+  return _dpl_update_install_modules(['dpl_filter_paragraphs', 'dpl_related_content']);
 }
 
 /**

--- a/web/themes/custom/novel/templates/views/views-view-unformatted--content-paragraphs--slider.html.twig
+++ b/web/themes/custom/novel/templates/views/views-view-unformatted--content-paragraphs--slider.html.twig
@@ -1,0 +1,6 @@
+{% include '@novel/components/slider.html.twig'
+  with {
+  'attributes': attributes,
+  'title': view.getTitle(),
+  'items': rows,
+} only %}


### PR DESCRIPTION
- Re-enable `dpl_filtered_paragraphs` module, and re-implement previous views
- Update previous views to also have content type filters
- Port existing automatic paragraphs to only pull articles, as they de-facto did before by default.
- Hide `cond type` field, that is currently inactive
- Temporarily disable paragraphs logic in `dpl_related_content`
