### PR TITLE
Ddfform 879

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -801,12 +801,12 @@
                     "url": {
                       "type": "string",
                       "format": "uri",
-                      "description": "An absolute url provided by the third party where end users can access the event."
+                      "description": "An absolute URL provided by the third party where end users can access the event."
                     },
                     "admin_url": {
                       "type": "string",
                       "format": "uri",
-                      "description": "An absolute url provided by the third party where editorial users can administer the event. Accessing this url should require authentication."
+                      "description": "An absolute URL provided by the third party where editorial users can administer the event. Accessing this URL should require authentication."
                     }
                   }
                 }
@@ -871,7 +871,7 @@
                   "uuid": {
                     "type": "string",
                     "format": "uuid",
-                    "description": "A unique identifer for the event."
+                    "description": "A unique identifier for the event."
                   },
                   "title": {
                     "type": "string",
@@ -884,7 +884,7 @@
                   "url": {
                     "type": "string",
                     "format": "uri",
-                    "description": "An absolute url end users should use to view the event at the website."
+                    "description": "An absolute URL end users should use to view the event at the website."
                   },
                   "created_at": {
                     "type": "string",
@@ -903,7 +903,7 @@
                       "url": {
                         "type": "string",
                         "format": "uri",
-                        "description": "An absolute url for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event."
+                        "description": "An absolute URL for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event."
                       }
                     },
                     "required": ["url"]
@@ -916,7 +916,6 @@
                   "date_time": {
                     "type": "object",
                     "description": "When the event occurs.",
-                    "required": ["start", "end"],
                     "properties": {
                       "start": {
                         "type": "string",
@@ -928,7 +927,8 @@
                         "format": "date-time",
                         "description": "End time in ISO 8601 format."
                       }
-                    }
+                    },
+                    "required": ["start", "end"]
                   },
                   "branches": {
                     "type": "array",
@@ -1029,12 +1029,12 @@
                       "url": {
                         "type": "string",
                         "format": "uri",
-                        "description": "An absolute url provided by the third party where end users can access the event."
+                        "description": "An absolute URL provided by the third party where end users can access the event."
                       },
                       "admin_url": {
                         "type": "string",
                         "format": "uri",
-                        "description": "An absolute url provided by the third party where editorial users can administer the event. Accessing this url should require authentication."
+                        "description": "An absolute URL provided by the third party where editorial users can administer the event. Accessing this URL should require authentication."
                       }
                     }
                   }

--- a/openapi.json
+++ b/openapi.json
@@ -858,6 +858,14 @@
             "required": true,
             "description": "Request format",
             "default": "json"
+          }, 
+          {
+            "name": "from_date",
+            "type": "string",
+            "format": "date",
+            "description": "Retrieve events which occur after and including the provided date. In ISO 8601 format.",
+            "in": "query",
+            "required": false
           }
         ],
         "responses": {

--- a/packages/cms-api/Model/EventPATCHRequestExternalData.php
+++ b/packages/cms-api/Model/EventPATCHRequestExternalData.php
@@ -46,7 +46,7 @@ use JMS\Serializer\Annotation\SerializedName;
 class EventPATCHRequestExternalData 
 {
         /**
-     * An absolute url provided by the third party where end users can access the event.
+     * An absolute URL provided by the third party where end users can access the event.
      *
      * @var string|null
      * @SerializedName("url")
@@ -56,7 +56,7 @@ class EventPATCHRequestExternalData
     protected ?string $url = null;
 
     /**
-     * An absolute url provided by the third party where editorial users can administer the event. Accessing this url should require authentication.
+     * An absolute URL provided by the third party where editorial users can administer the event. Accessing this URL should require authentication.
      *
      * @var string|null
      * @SerializedName("admin_url")
@@ -92,7 +92,7 @@ class EventPATCHRequestExternalData
     /**
      * Sets url.
      *
-     * @param string|null $url  An absolute url provided by the third party where end users can access the event.
+     * @param string|null $url  An absolute URL provided by the third party where end users can access the event.
      *
      * @return $this
      */
@@ -118,7 +118,7 @@ class EventPATCHRequestExternalData
     /**
      * Sets adminUrl.
      *
-     * @param string|null $adminUrl  An absolute url provided by the third party where editorial users can administer the event. Accessing this url should require authentication.
+     * @param string|null $adminUrl  An absolute URL provided by the third party where editorial users can administer the event. Accessing this URL should require authentication.
      *
      * @return $this
      */

--- a/packages/cms-api/Model/EventsGET200ResponseInner.php
+++ b/packages/cms-api/Model/EventsGET200ResponseInner.php
@@ -44,7 +44,7 @@ use JMS\Serializer\Annotation\SerializedName;
 class EventsGET200ResponseInner 
 {
         /**
-     * A unique identifer for the event.
+     * A unique identifier for the event.
      *
      * @var string|null
      * @SerializedName("uuid")
@@ -76,7 +76,7 @@ class EventsGET200ResponseInner
     protected ?string $description = null;
 
     /**
-     * An absolute url end users should use to view the event at the website.
+     * An absolute URL end users should use to view the event at the website.
      *
      * @var string|null
      * @SerializedName("url")
@@ -260,7 +260,7 @@ class EventsGET200ResponseInner
     /**
      * Sets uuid.
      *
-     * @param string|null $uuid  A unique identifer for the event.
+     * @param string|null $uuid  A unique identifier for the event.
      *
      * @return $this
      */
@@ -338,7 +338,7 @@ class EventsGET200ResponseInner
     /**
      * Sets url.
      *
-     * @param string|null $url  An absolute url end users should use to view the event at the website.
+     * @param string|null $url  An absolute URL end users should use to view the event at the website.
      *
      * @return $this
      */

--- a/packages/cms-api/Model/EventsGET200ResponseInnerImage.php
+++ b/packages/cms-api/Model/EventsGET200ResponseInnerImage.php
@@ -46,7 +46,7 @@ use JMS\Serializer\Annotation\SerializedName;
 class EventsGET200ResponseInnerImage 
 {
         /**
-     * An absolute url for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event.
+     * An absolute URL for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event.
      *
      * @var string|null
      * @SerializedName("url")
@@ -82,7 +82,7 @@ class EventsGET200ResponseInnerImage
     /**
      * Sets url.
      *
-     * @param string|null $url  An absolute url for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event.
+     * @param string|null $url  An absolute URL for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event.
      *
      * @return $this
      */

--- a/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventResource.php
+++ b/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventResource.php
@@ -4,14 +4,12 @@ namespace Drupal\dpl_event\Plugin\rest\resource\v1;
 
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventPATCHRequest;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventPATCHRequestExternalData;
+use Drupal\Component\Utility\NestedArray;
 use Drupal\recurring_events\Entity\EventInstance;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-// Descriptions quickly become long and Doctrine annotations have no good way
-// of handling multiline strings.
-// phpcs:disable Drupal.Files.LineLength.TooLong
 /**
  * REST resource for working with single events.
  *
@@ -20,80 +18,86 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *   label = @Translation("Update single events"),
  *   uri_paths = {
  *     "canonical" = "/api/v1/events/{uuid}",
- *   },
- *
- *   route_parameters = {
- *     "GET" = {
- *       "uuid" = {
- *         "name" = "uuid",
- *         "description" = "The unique identifier of the event to update. Use the same value as provided for the event in the event list.",
- *         "type" = "string",
- *         "in" = "query",
- *         "required" = TRUE,
- *       },
- *     },
- *   },
- *
- *   payload = {
- *     "name" = "event",
- *     "description" = "Data to update the event with.",
- *     "in" = "body",
- *     "required" = TRUE,
- *     "schema" = {
- *       "type" = "object",
- *       "properties" = {
- *         "state" = {
- *           "type" = "string",
- *           "description" = "The state of the event.",
- *           "enum" = {
- *             "TicketSaleNotOpen",
- *             "Active",
- *             "SoldOut",
- *             "Cancelled",
- *             "Occurred",
- *           },
- *         },
- *         "external_data" = {
- *           "type" = "object",
- *           "description" = "Data for the event provided by a third party.",
- *           "properties" = {
- *             "url" = {
- *               "type" = "string",
- *               "format" = "uri",
- *               "description" = "An absolute url provided by the third party where end users can access the event.",
- *             },
- *             "admin_url" = {
- *               "type" = "string",
- *               "format" = "uri",
- *               "description" = "An absolute url provided by the third party where editorial users can administer the event. Accessing this url should require authentication.",
- *             },
- *           },
- *         },
- *       },
- *     },
- *   },
- *
- *   responses = {
- *     200 = {
- *       "description" = "OK",
- *     },
- *     400 = {
- *      "description" = "Invalid input format"
- *     },
- *     403 = {
- *      "description" = "Access denied"
- *     },
- *     404 = {
- *       "description" = "Event not found"
- *     },
- *     500 = {
- *       "description" = "Internal server error"
- *     },
  *   }
  * )
  */
 final class EventResource extends EventResourceBase {
-// phpcs:enable Drupal.Files.LineLength.TooLong
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getPluginDefinition(): array {
+    return NestedArray::mergeDeep(
+      parent::getPluginDefinition(),
+      [
+        'route_parameters' => [
+          'GET' => [
+            'uuid' => [
+              'name' => 'uuid',
+              'description' => 'The unique identifier of the event to update. Use the same value as provided for the event in the event list.',
+              'type' => 'string',
+              'in' => 'query',
+              'required' => TRUE,
+            ],
+          ],
+        ],
+        'payload' => [
+          'name' => 'event',
+          'description' => 'Data to update the event with.',
+          'in' => 'body',
+          'required' => TRUE,
+          'schema' => [
+            'type' => 'object',
+            'properties' => [
+              'state' => [
+                'type' => 'string',
+                'description' => 'The state of the event.',
+                'enum' => [
+                  'TicketSaleNotOpen',
+                  'Active',
+                  'SoldOut',
+                  'Cancelled',
+                  'Occurred',
+                ],
+              ],
+              'external_data' => [
+                'type' => 'object',
+                'description' => 'Data for the event provided by a third party.',
+                'properties' => [
+                  'url' => [
+                    'type' => 'string',
+                    'format' => 'uri',
+                    'description' => 'An absolute URL provided by the third party where end users can access the event.',
+                  ],
+                  'admin_url' => [
+                    'type' => 'string',
+                    'format' => 'uri',
+                    'description' => 'An absolute URL provided by the third party where editorial users can administer the event. Accessing this URL should require authentication.',
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+        'responses' => [
+          200 => [
+            'description' => 'OK',
+          ],
+          400 => [
+            'description' => 'Invalid input format',
+          ],
+          403 => [
+            'description' => 'Access denied',
+          ],
+          404 => [
+            'description' => 'Event not found',
+          ],
+          500 => [
+            'description' => 'Internal server error',
+          ],
+        ],
+      ]);
+  }
 
   /**
    * PATCH requests - Load the relevant eventinstance, and update values.

--- a/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
+++ b/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
@@ -2,15 +2,15 @@
 
 namespace Drupal\dpl_event\Plugin\rest\resource\v1;
 
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\CacheableResponse;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\drupal_typed\RequestTyped;
 use Drupal\recurring_events\Entity\EventInstance;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-// Descriptions quickly become long and Doctrine annotations have no good way
-// of handling multiline strings.
-// phpcs:disable Drupal.Files.LineLength.TooLong
 /**
  * REST resource for listing events.
  *
@@ -19,232 +19,213 @@ use Symfony\Component\HttpFoundation\Response;
  *   label = @Translation("Retrieve all events"),
  *   uri_paths = {
  *     "canonical" = "/api/v1/events",
- *   },
- *
- *   responses = {
- *     200 = {
- *       "description" = "List of all publicly available events.",
- *       "schema" = {
- *         "type" = "array",
- *         "items" = {
- *           "type" = "object",
- *           "properties" = {
- *             "uuid" = {
- *               "type" = "string",
- *               "format" = "uuid",
- *               "description" = "A unique identifer for the event.",
- *             },
- *             "title" = {
- *               "type" = "string",
- *               "description" = "The event title.",
- *             },
- *             "description" = {
- *                "type" = "string",
- *                "description" = "The short event description.",
- *              },
- *             "url" = {
- *               "type" = "string",
- *               "format" = "uri",
- *               "description" = "An absolute url end users should use to view the event at the website.",
- *             },
- *             "created_at" = {
- *               "type" = "string",
- *               "format" = "date-time",
- *               "description" = "When the event was created. In ISO 8601 format.",
- *             },
- *             "updated_at" = {
- *               "type" = "string",
- *               "format" = "date-time",
- *               "description" = "When the event was last updated. In ISO 8601 format.",
- *             },
- *             "image" = {
- *               "type" = "object",
- *               "description" = "The main image for the event.",
- *               "properties" = {
- *                 "url" = {
- *                   "type" = "string",
- *                   "format" = "uri",
- *                   "description" = "An absolute url for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event.",
- *                 },
- *               },
- *               "required" = {
- *                 "url",
- *               }
- *             },
- *             "state" = {
- *               "type" = "string",
- *               "description" = "The state of the event.",
- *               "enum" = {
- *                 "TicketSaleNotOpen",
- *                 "Active",
- *                 "SoldOut",
- *                 "Cancelled",
- *                 "Occurred",
- *               },
- *             },
- *             "date_time" = {
- *               "type" = "object",
- *               "description" = "When the event occurs.",
- *               "required" = TRUE,
- *               "properties" = {
- *                 "start" = {
- *                   "type" = "string",
- *                   "format" = "date-time",
- *                   "description" = "Start time in ISO 8601 format.",
- *                 },
- *                 "end" = {
- *                   "type" = "string",
- *                   "format" = "date-time",
- *                   "description" = "End time in ISO 8601 format.",
- *                 },
- *               },
- *               "required" = {
- *                 "start",
- *                 "end",
- *               }
- *             },
- *             "branches" = {
- *               "type" = "array",
- *               "description" = "The associated library branches.",
- *                "items" = {
- *                   "type" = "string",
- *                   "description" = "The name of a branch.",
- *                 },
- *             },
- *             "address" = {
- *               "type" = "object",
- *               "description" = "Where the event occurs.",
- *               "properties" = {
- *                 "location" = {
- *                   "type" = "string",
- *                   "description" = "Name of the location where the event occurs. This could be the name of a library branch.",
- *                 },
- *                 "street" = {
- *                   "type" = "string",
- *                   "description" = "Street name and number.",
- *                 },
- *                 "zip_code" = {
- *                   "type" = "integer",
- *                   "description" = "Zip code.",
- *                 },
- *                 "city" = {
- *                   "type" = "string",
- *                   "description" = "City.",
- *                 },
- *                 "country" = {
- *                   "type" = "string",
- *                   "description" = "Country code in ISO 3166-1 alpha-2 format. E.g. DK for Denmark.",
- *                 },
- *               },
- *               "required" = {
- *                 "street",
- *                 "zip_code",
- *                 "city",
- *                 "country",
- *               }
- *             },
- *             "tags" = {
- *                "type" = "array",
- *                "description" = "The tags associated with the event.",
- *                "items" = {
- *                  "type" = "string",
- *                  "description" = "The name of a tag.",
- *                },
- *             },
- *             "ticket_categories" = {
- *               "type" = "array",
- *               "description" = "Ticket categories used for the event. Not present for events without ticketing.",
- *               "items" = {
- *                 "type" = "object",
- *                 "properties" = {
- *                   "title" = {
- *                     "type" = "string",
- *                     "description" = "The name of the ticket category.",
- *                   },
- *                   "price" = {
- *                     "type" = "object",
- *                     "description" = "The price of a ticket in the category",
- *                     "properties" = {
- *                       "currency" = {
- *                         "type" = "string",
- *                         "description" = "The currency of the price in ISO 4217 format. E.g. DKK for Danish krone.",
- *                       },
- *                       "value" = {
- *                         "type" = "number",
- *                         "description" = "The price of a ticket in the minor unit of the currency. E.g. 750 for 7,50 EUR. Use 0 for free tickets.",
- *                       },
- *                     },
- *                     "required" = {
- *                       "currency",
- *                       "value",
- *                     }
- *                   },
- *                 },
- *                 "required" = {
- *                   "title",
- *                   "price",
- *                 }
- *               },
- *             },
- *             "ticket_capacity" = {
- *                "type" = "integer",
- *                "description" = "Total number of tickets which can be sold for the event.",
- *             },
- *             "series" = {
- *               "type" = "object",
- *               "description" = "An event may be part of a series. One example of this is recurring events.",
- *               "properties" = {
- *                 "uuid" = {
- *                   "type" = "string",
- *                   "format" = "uuid",
- *                   "description" = "The unique identifier for the series. All events belonging to the same series will have the same value.",
- *                 },
- *               },
- *               "required" = {
- *                 "uuid",
- *               }
- *             },
- *             "body" = {
- *               "type" = "string",
- *               "description" = "An editorial WYSIWYG/HTML description of the event.",
- *             },
- *             "external_data" = {
- *               "type" = "object",
- *               "description" = "Data for the event provided by a third party.",
- *               "properties" = {
- *                 "url" = {
- *                   "type" = "string",
- *                   "format" = "uri",
- *                   "description" = "An absolute url provided by the third party where end users can access the event.",
- *                 },
- *                 "admin_url" = {
- *                   "type" = "string",
- *                   "format" = "uri",
- *                   "description" = "An absolute url provided by the third party where editorial users can administer the event. Accessing this url should require authentication.",
- *                 },
- *               },
- *             },
- *           },
- *           "required" = {
- *             "uuid",
- *             "title",
- *             "created_at",
- *             "updated_at",
- *             "url",
- *             "state",
- *             "date_time",
- *           }
- *         },
- *       },
- *     },
- *     500 = {
- *       "description" = "Internal server error",
- *     },
  *   }
  * )
  */
 final class EventsResource extends EventResourceBase {
-// phpcs:enable Drupal.Files.LineLength.TooLong
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getPluginDefinition(): array {
+    return NestedArray::mergeDeep(
+      parent::getPluginDefinition(),
+      [
+        'responses' => [
+          200 => [
+            'description' => 'List of all publicly available events.',
+            'schema' => [
+              'type' => 'array',
+              'items' => [
+                'type' => 'object',
+                'properties' => [
+                  'uuid' => [
+                    'type' => 'string',
+                    'format' => 'uuid',
+                    'description' => 'A unique identifier for the event.',
+                  ],
+                  'title' => [
+                    'type' => 'string',
+                    'description' => 'The event title.',
+                  ],
+                  'description' => [
+                    'type' => 'string',
+                    'description' => 'The short event description.',
+                  ],
+                  'url' => [
+                    'type' => 'string',
+                    'format' => 'uri',
+                    'description' => 'An absolute URL end users should use to view the event at the website.',
+                  ],
+                  'created_at' => [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                    'description' => 'When the event was created. In ISO 8601 format.',
+                  ],
+                  'updated_at' => [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                    'description' => 'When the event was last updated. In ISO 8601 format.',
+                  ],
+                  'image' => [
+                    'type' => 'object',
+                    'description' => 'The main image for the event.',
+                    'properties' => [
+                      'url' => [
+                        'type' => 'string',
+                        'format' => 'uri',
+                        'description' => 'An absolute URL for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event.',
+                      ],
+                    ],
+                    'required' => ['url'],
+                  ],
+                  'state' => [
+                    'type' => 'string',
+                    'description' => 'The state of the event.',
+                    'enum' => [
+                      'TicketSaleNotOpen',
+                      'Active',
+                      'SoldOut',
+                      'Cancelled',
+                      'Occurred',
+                    ],
+                  ],
+                  'date_time' => [
+                    'type' => 'object',
+                    'description' => 'When the event occurs.',
+                    'properties' => [
+                      'start' => [
+                        'type' => 'string',
+                        'format' => 'date-time',
+                        'description' => 'Start time in ISO 8601 format.',
+                      ],
+                      'end' => [
+                        'type' => 'string',
+                        'format' => 'date-time',
+                        'description' => 'End time in ISO 8601 format.',
+                      ],
+                    ],
+                    'required' => ['start', 'end'],
+                  ],
+                  'branches' => [
+                    'type' => 'array',
+                    'description' => 'The associated library branches.',
+                    'items' => [
+                      'type' => 'string',
+                      'description' => 'The name of a branch.',
+                    ],
+                  ],
+                  'address' => [
+                    'type' => 'object',
+                    'description' => 'Where the event occurs.',
+                    'properties' => [
+                      'location' => [
+                        'type' => 'string',
+                        'description' => 'Name of the location where the event occurs. This could be the name of a library branch.',
+                      ],
+                      'street' => [
+                        'type' => 'string',
+                        'description' => 'Street name and number.',
+                      ],
+                      'zip_code' => [
+                        'type' => 'integer',
+                        'description' => 'Zip code.',
+                      ],
+                      'city' => [
+                        'type' => 'string',
+                        'description' => 'City.',
+                      ],
+                      'country' => [
+                        'type' => 'string',
+                        'description' => 'Country code in ISO 3166-1 alpha-2 format. E.g. DK for Denmark.',
+                      ],
+                    ],
+                    'required' => ['street', 'zip_code', 'city', 'country'],
+                  ],
+                  'tags' => [
+                    'type' => 'array',
+                    'description' => 'The tags associated with the event.',
+                    'items' => [
+                      'type' => 'string',
+                      'description' => 'The name of a tag.',
+                    ],
+                  ],
+                  'ticket_categories' => [
+                    'type' => 'array',
+                    'description' => 'Ticket categories used for the event. Not present for events without ticketing.',
+                    'items' => [
+                      'type' => 'object',
+                      'properties' => [
+                        'title' => [
+                          'type' => 'string',
+                          'description' => 'The name of the ticket category.',
+                        ],
+                        'price' => [
+                          'type' => 'object',
+                          'description' => 'The price of a ticket in the category',
+                          'properties' => [
+                            'currency' => [
+                              'type' => 'string',
+                              'description' => 'The currency of the price in ISO 4217 format. E.g. DKK for Danish krone.',
+                            ],
+                            'value' => [
+                              'type' => 'number',
+                              'description' => 'The price of a ticket in the minor unit of the currency. E.g. 750 for 7,50 EUR. Use 0 for free tickets.',
+                            ],
+                          ],
+                          'required' => ['currency', 'value'],
+                        ],
+                      ],
+                      'required' => ['title', 'price'],
+                    ],
+                  ],
+                  'ticket_capacity' => [
+                    'type' => 'integer',
+                    'description' => 'Total number of tickets which can be sold for the event.',
+                  ],
+                  'series' => [
+                    'type' => 'object',
+                    'description' => 'An event may be part of a series. One example of this is recurring events.',
+                    'properties' => [
+                      'uuid' => [
+                        'type' => 'string',
+                        'format' => 'uuid',
+                        'description' => 'The unique identifier for the series. All events belonging to the same series will have the same value.',
+                      ],
+                    ],
+                    'required' => ['uuid'],
+                  ],
+                  'body' => [
+                    'type' => 'string',
+                    'description' => 'An editorial WYSIWYG/HTML description of the event.',
+                  ],
+                  'external_data' => [
+                    'type' => 'object',
+                    'description' => 'Data for the event provided by a third party.',
+                    'properties' => [
+                      'url' => [
+                        'type' => 'string',
+                        'format' => 'uri',
+                        'description' => 'An absolute URL provided by the third party where end users can access the event.',
+                      ],
+                      'admin_url' => [
+                        'type' => 'string',
+                        'format' => 'uri',
+                        'description' => 'An absolute URL provided by the third party where editorial users can administer the event. Accessing this URL should require authentication.',
+                      ],
+                    ],
+                  ],
+                ],
+                'required' => ['uuid', 'title', 'created_at', 'updated_at', 'url', 'state', 'date_time'],
+              ],
+            ],
+          ],
+          500 => [
+            'description' => 'Internal server error',
+          ],
+        ],
+      ]);
+  }
 
   /**
    * GET request: Get all eventinstances, hopefully cached.


### PR DESCRIPTION
EventAPI: Replace Annotation with PHP code.

Up until now, we've defined the API using @rest code comments, but this
is really hard to manage and debug.
The commit changes it to a classic PHP array.

-----

Expand EventAPI to include limiting `from_date` parameter. DDFFORM-879

https://reload.atlassian.net/browse/DDFFORM-879