### PR TITLE
Limit number of items per purge to 30

### DIFF
--- a/config/sync/varnish_purger.settings.30cd45a1b1.yml
+++ b/config/sync/varnish_purger.settings.30cd45a1b1.yml
@@ -18,5 +18,5 @@ runtime_measurement: true
 timeout: 1.0
 connect_timeout: 1.0
 cooldown_time: 0.0
-max_requests: 100
+max_requests: 30
 http_errors: true

--- a/config/sync/varnish_purger.settings.65fc931232.yml
+++ b/config/sync/varnish_purger.settings.65fc931232.yml
@@ -21,5 +21,5 @@ runtime_measurement: true
 timeout: 1.0
 connect_timeout: 1.0
 cooldown_time: 0.0
-max_requests: 100
+max_requests: 30
 http_errors: true


### PR DESCRIPTION
#### Description

Sometimes we see errors during deployment in the form:

Drupal\Core\Database\DatabaseExceptionWrapper: SQLSTATE[HY000]: General error: 2006 MySQL server has gone away: SELECT * FROM "purge_queue" q WHERE ((expire = 0) OR (:now > expire)) ORDER BY created, item_id ASC LIMIT 0, 100;
Example: https://ui.lagoon.dplplat01.dpl.reload.dk/projects/naestved/naestved-main/deployments/lagoon-build-lbvhex

These typically occur after the import of configuration translation as been completed and is triggered by the LateRuntimeProcessor.

We do not understand the reason why this error occurs:

1. It does not seem as it the table in question is very large.
2. MySQL documentation does not offer any hints which makes sense in relation to the actual MySQL configuration
https://dev.mysql.com/doc/refman/8.4/en/gone-away.html
3. This does not happen for all sites
4. The database does not seem to be under any load

We have discussed different options for handling this including:

1. Moving to a different storage engine for the purge queue e.g. Redis. This would be possible and also reduce writes to the database. It would not be trivial since this would require a persistent Redis (which we do not use at the moment) and a sandbox module:
- https://www.drupal.org/sandbox/marvin_b8/3417595
- https://docs.lagoon.sh/docker-images/redis/#persistent

2. Dropping late runtime processing of the purge queue and rely solely on cron/worker. This would avoid errors during deployment and any potential slowdown users might experience due to the current problem. On the other hand the problem would likely not go away entirely and end users would see out of date cached content for longer.

In an attempt to address the issue we reduce the number of items significantly to avoid the problem of long/heavy queries/responses. During deployments we clear the entire Varnish cache anyway by running drush cache:rebuild-external -y as defined in .lagoon.yml.
