### PR TITLE
Re-introduce missing markup and title for event-list.

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.filtered_event_list.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.filtered_event_list.default.yml
@@ -15,7 +15,15 @@ id: paragraph.filtered_event_list.default
 targetEntityType: paragraph
 bundle: filtered_event_list
 mode: default
-content: {  }
+content:
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   field_amount_of_events: true
   field_filter_branches: true
@@ -23,5 +31,4 @@ hidden:
   field_filter_cond_type: true
   field_filter_tags: true
   field_max_item_amount: true
-  field_title: true
   search_api_excerpt: true

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--filtered-event-list.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--filtered-event-list.html.twig
@@ -1,0 +1,25 @@
+{#
+  @todo This file can be deleted when RelatedContent takes over again.
+  This markup already exists in event-list.html.twig, but due to how this and
+  the old (this) view works, it cannot use a single twig file like
+  RelatedContent can.
+#}
+{{ attach_library('novel/show-more') }}
+
+{% if view_has_results %}
+  <div {{ attributes.addClass('filtered-event-list') }} data-show-more-list-wrapper>
+    {% if content.field_title %}
+      <h2 class="filtered-event-list__heading">{{ content.field_title }}</h2>
+    {% endif %}
+    {{ content.view }}
+    <button class="filtered-event-list__button btn-primary btn-outline
+    btn-medium"
+            type="button"
+            aria-expanded="false"
+            data-show-more-button
+            data-show-more-text="{{ 'Show all'|trans }}"
+            data-show-less-text="{{ 'Show less'|trans }}">
+      {{ 'Show all'|trans }}
+    </button>
+  </div>
+{% endif %}

--- a/web/themes/custom/novel/templates/views/views-view-unformatted--filtered-event-list.html.twig
+++ b/web/themes/custom/novel/templates/views/views-view-unformatted--filtered-event-list.html.twig
@@ -1,0 +1,17 @@
+{#
+@todo This file (and view) can be deleted when RelatedContent takes over again.
+This markup already exists in event-list.html.twig, but due to how this and
+the old (this) view works, it cannot use a single twig file like
+RelatedContent can.
+#}
+<ul class="filtered-event-list__list"
+    data-show-more-list
+    data-initial-visible-items="4"
+    data-hide-list-button-after-expand="true"
+    data-show-more-list-id="{{ 'filtered-event-list'|clean_unique_id }}">
+  {% for row in rows %}
+    <li class="filtered-event-list__list-item" data-show-more-item>
+      {{ row.content }}
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
As part of moving the automatic paragraphs back to the pre-RelatedContent state, we re-introduced a view and module. However, we forgot to introduce the matching twig files, meaning that the event-list looks different.
The issue is that as part of testing, we only tested a few results, but the proper styling is only really visible when several items are added - and the title was not tested.

There is nothing new in this code - it's taken from the previous state, and it is only temporary.

https://reload.atlassian.net/browse/DDFFORM-861