### PR TITLE
Alter `entity_clone_template` view to display edit button.

### DIFF
--- a/config/sync/views.view.entity_clone_template.yml
+++ b/config/sync/views.view.entity_clone_template.yml
@@ -302,7 +302,56 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '<a class="button" href="/entity_clone/node/{{ nid }}">Clone</a>'
+            text: '<a class="button" href="/entity_clone/node/{{ nid }}">{{ ''Use template''|trans }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+        nothing_1:
+          id: nothing_1
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<a href="/node/{{ nid }}/edit" class="button">{{ ''Edit template''|trans }}</a>'
             make_link: false
             path: ''
             absolute: false
@@ -776,6 +825,55 @@ display:
           alter:
             alter_text: true
             text: '<a class="button" href="/entity_clone/node/{{ nid }}">{{ ''Use template''|trans }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+        nothing_1:
+          id: nothing_1
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<a href="/node/{{ nid }}/edit" class="button">{{ ''Edit template''|trans }}</a>'
             make_link: false
             path: ''
             absolute: false


### PR DESCRIPTION

#### Link to issue

[DDFFORM-624](https://reload.atlassian.net/browse/DDFFORM-624)

#### Description

This adds an "Edit Template" button to the block and the page of the `entity_clone_template` view.

Create an article and mark it as a template. 

Go to add content

See that there now is an "edit template" button" for the template, that takes you to the edit page. 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/8aa01ffb-31c7-46fe-a821-3f3815460a1a)



[DDFFORM-624]: https://reload.atlassian.net/browse/DDFFORM-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ