### PR TITLE
DDFFORM 725 breadcrumb children subtitle

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.breadcrumb_children.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.breadcrumb_children.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.breadcrumb_children.field_breadcrumb_target
+    - field.field.paragraph.breadcrumb_children.field_show_subtitles
     - field.field.paragraph.breadcrumb_children.field_title
     - paragraphs.paragraphs_type.breadcrumb_children
   module:
@@ -15,13 +16,20 @@ mode: default
 content:
   field_breadcrumb_target:
     type: select2_entity_reference
-    weight: 1
+    weight: 2
     region: content
     settings:
       width: 100%
       autocomplete: false
       match_operator: CONTAINS
       match_limit: 10
+    third_party_settings: {  }
+  field_show_subtitles:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_title:
     type: string_textfield

--- a/config/sync/core.entity_view_display.paragraph.breadcrumb_children.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.breadcrumb_children.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.breadcrumb_children.field_breadcrumb_target
+    - field.field.paragraph.breadcrumb_children.field_show_subtitles
     - field.field.paragraph.breadcrumb_children.field_title
     - paragraphs.paragraphs_type.breadcrumb_children
 id: paragraph.breadcrumb_children.default
@@ -21,4 +22,5 @@ content:
     region: content
 hidden:
   field_breadcrumb_target: true
+  field_show_subtitles: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.breadcrumb_children.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.breadcrumb_children.preview.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.breadcrumb_children.field_breadcrumb_target
+    - field.field.paragraph.breadcrumb_children.field_show_subtitles
     - field.field.paragraph.breadcrumb_children.field_title
     - paragraphs.paragraphs_type.breadcrumb_children
 id: paragraph.breadcrumb_children.preview
@@ -12,6 +13,16 @@ targetEntityType: paragraph
 bundle: breadcrumb_children
 mode: preview
 content:
+  field_show_subtitles:
+    type: boolean
+    label: above
+    settings:
+      format: unicode-yes-no
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_title:
     type: string
     label: above

--- a/config/sync/field.field.paragraph.breadcrumb_children.field_show_subtitles.yml
+++ b/config/sync/field.field.paragraph.breadcrumb_children.field_show_subtitles.yml
@@ -1,0 +1,23 @@
+uuid: fd72e42e-f823-43e6-993b-31a3bca8c752
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_show_subtitles
+    - paragraphs.paragraphs_type.breadcrumb_children
+id: paragraph.breadcrumb_children.field_show_subtitles
+field_name: field_show_subtitles
+entity_type: paragraph
+bundle: breadcrumb_children
+label: 'Show subtitles'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
+++ b/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
@@ -52,6 +52,9 @@ function dpl_breadcrumb_preprocess_paragraph__breadcrumb_children(array &$variab
 
   $variables['items'] = $service->getRenderedReferencingNodes($breadcrumb_item);
 
+  if ($paragraph->hasField('field_show_subtitles')) {
+    $variables['show_subtitles'] = (bool) $paragraph->get('field_show_subtitles')->value;
+  }
   // Drupal will cache the whole paragraph, as it does not know that it is
   // embedding a dynamic list. We'll add a simple cache tag,
   // so it be invalidated if any nodes have been updated - e.g. the same kind of

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--breadcrumb-children.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--breadcrumb-children.html.twig
@@ -2,4 +2,5 @@
   with {
   title: content.field_title,
   items: items,
+  show_subtitles: show_subtitles,
 } only %}


### PR DESCRIPTION
- **Add field `field_show_subtitles` to paragraph breadcrumb children.**
- **Extend breadcrumb children preprocess to retrieve show_subtitles value**

#### Link to issue

[DDFFORM-725](https://reload.atlassian.net/browse/DDFFORM-725)

#### Description

This PR adds a 'show subtiles' button to the paragraph breadcrumb children. 

Create an article, add the paragraph breadcrumb children, test that subtitles will be shown if enabled. (There might not be a subtitle on whichever test content you are using, so add it ) 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/5832e75d-84b0-49b2-be73-b13238b85a58)


[DDFFORM-725]: https://reload.atlassian.net/browse/DDFFORM-725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ