### PR TITLE
Fix context not being applied to EventState translations.

### DIFF
--- a/web/modules/custom/dpl_event/src/EventState.php
+++ b/web/modules/custom/dpl_event/src/EventState.php
@@ -35,14 +35,13 @@ enum EventState: string {
    */
   public function label(): string {
     $translation = \Drupal::translation();
-    $options = ['context' => 'dpl_event'];
 
     return match($this) {
-      EventState::TicketSaleNotOpen => $translation->translate('Ticket sale not open', [], $options)->render(),
-      EventState::Active => $translation->translate('Active', [], $options)->render(),
-      EventState::SoldOut => $translation->translate('Sold out', [], $options)->render(),
-      EventState::Cancelled => $translation->translate('Canceled', [], $options)->render(),
-      EventState::Occurred => $translation->translate('Occurred', [], $options)->render(),
+      EventState::TicketSaleNotOpen => $translation->translate('Ticket sale not open', [], ['context' => 'dpl_event'])->render(),
+      EventState::Active => $translation->translate('Active', [], ['context' => 'dpl_event'])->render(),
+      EventState::SoldOut => $translation->translate('Sold out', [], ['context' => 'dpl_event'])->render(),
+      EventState::Cancelled => $translation->translate('Canceled', [], ['context' => 'dpl_event'])->render(),
+      EventState::Occurred => $translation->translate('Occurred', [], ['context' => 'dpl_event'])->render(),
     };
   }
 


### PR DESCRIPTION
#### Link to issue

[DDFFORM-828](https://reload.atlassian.net/browse/DDFFORM-828)

#### Description

EventStates were not being translated correctly. 

Our tooling cannot pick up if translations are put into variables such as `$options = ['context' => 'dpl_event'];`.

By adding them directly for each translation our tooling should pick it up and add the context.



[DDFFORM-828]: https://reload.atlassian.net/browse/DDFFORM-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ