### PR TITLE
Deal with PHP `reset()` sometimes returning `false`

### DIFF
--- a/web/modules/custom/dpl_breadcrumb/src/EventSubscriber/StructureTermRedirect.php
+++ b/web/modules/custom/dpl_breadcrumb/src/EventSubscriber/StructureTermRedirect.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dpl_breadcrumb\EventSubscriber;
 
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\dpl_breadcrumb\Services\BreadcrumbHelper;
 use Drupal\taxonomy\Entity\Term;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -62,11 +63,12 @@ class StructureTermRedirect implements EventSubscriberInterface {
       }
 
       $contents = $term->get('field_content')->referencedEntities();
-      /** @var \Drupal\Core\Entity\FieldableEntityInterface $content */
       $content = reset($contents);
 
-      $response = new RedirectResponse($content->toUrl()->toString());
-      $event->setResponse($response);
+      if ($content instanceof FieldableEntityInterface) {
+        $response = new RedirectResponse($content->toUrl()->toString());
+        $event->setResponse($response);
+      }
     }
   }
 

--- a/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
+++ b/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
@@ -339,8 +339,9 @@ class BreadcrumbHelper {
     }
 
     $breadcrumb_items = $entity->get($field_key)->referencedEntities();
+    $first_breadcrumb = reset($breadcrumb_items);
 
-    return reset($breadcrumb_items);
+    return $first_breadcrumb instanceof TermInterface ? $first_breadcrumb : NULL;
   }
 
   /**
@@ -423,8 +424,9 @@ class BreadcrumbHelper {
     }
 
     $slice = array_slice($parents, 1, 1, TRUE);
+    $first_slide = reset($slice);
 
-    return reset($slice);
+    return $first_slide instanceof TermInterface ? $first_slide : NULL;
   }
 
   /**

--- a/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
+++ b/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
@@ -123,6 +123,11 @@ class ReoccurringDateFormatter {
     // Load the first event instance - the remaining IDs are useful later on,
     // when we want to check if it is alone or not.
     $upcoming_event_id = reset($upcoming_ids);
+
+    if (!$upcoming_event_id) {
+      return NULL;
+    }
+
     $event_instance = EventInstance::load($upcoming_event_id);
 
     if (!($event_instance instanceof EventInstance)) {


### PR DESCRIPTION
This has caused a failed deploy, in relation to the breadcrumb logic, as the latest deploy re-saves all nodes.
