### PR TITLE
Only run |date in twig if value exists. + Update existing, failed nodes.

### DIFF
--- a/web/modules/custom/dpl_publication/dpl_publication.deploy.php
+++ b/web/modules/custom/dpl_publication/dpl_publication.deploy.php
@@ -38,3 +38,39 @@ function dpl_publication_deploy_default_publication_date(): string {
 
   return 'Updated nodes: ' . implode(', ', $node_labels);
 }
+
+/**
+ * Update field_publication_date on nodes that does not have data.
+ *
+ * We previously forgot to do this to unpublished nodes. This will add the
+ * publication date to any nodes that does not already have data, either
+ * programmatically or manually created.
+ */
+function dpl_publication_deploy_default_publication_dates_again(): string {
+  $nids = Drupal::entityQuery('node')
+    ->condition('type', ['article', 'page'], 'IN')
+    ->notExists('field_publication_date')
+    ->accessCheck(FALSE)
+    ->execute();
+
+  if (empty($nids)) {
+    return 'No nodes found to update.';
+  }
+
+  $nodes = Node::loadMultiple($nids);
+
+  $node_labels = [];
+  foreach ($nodes as $node) {
+    $creation_time = $node->getCreatedTime();
+
+    $creation_date = DrupalDateTime::createFromTimestamp($creation_time)
+      ->format('Y-m-d');
+
+    $node->set('field_publication_date', $creation_date);
+    $node->save();
+
+    $node_labels[] = $node->label();
+  }
+
+  return 'Updated nodes: ' . implode(', ', $node_labels);
+}

--- a/web/themes/custom/novel/templates/components/article-header-info.html.twig
+++ b/web/themes/custom/novel/templates/components/article-header-info.html.twig
@@ -1,6 +1,6 @@
 {% set publication_date = node.created.value %}
 
-{% if node.hasField('field_publication_date') %}
+{% if node.field_publication_date.value is not empty %}
   {% set publication_date = node.field_publication_date.value|date('U') %}
 {% endif %}
 

--- a/web/themes/custom/novel/templates/layout/node--article--list-teaser.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--article--list-teaser.html.twig
@@ -1,6 +1,6 @@
 {% set publication_date = node.created.value %}
 
-{% if node.hasField('field_publication_date') %}
+{% if node.field_publication_date.value is not empty %}
   {% set publication_date = node.field_publication_date.value|date('U') %}
 {% endif %}
 

--- a/web/themes/custom/novel/templates/layout/node--card.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--card.html.twig
@@ -1,6 +1,6 @@
 {% set publication_date = node.created.value %}
 
-{% if node.hasField('field_publication_date') %}
+{% if node.field_publication_date.value is not empty %}
   {% set publication_date = node.field_publication_date.value|date('U') %}
 {% endif %}
 


### PR DESCRIPTION
This is the fabled "hjørring" issue.
Apparantly, some nodes has not received data in the new field_publication_date This means that while `hasField()` returns true, and despite the field being required, `.value` returns NULL, and causes an error with twig's `|date`.

This fixes it, and sets the default to `created` instead, which is what should have happened in the update hooks regardless. I believe it went wrong, cause of MySQL/Deployment issues originally.

#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
