### PR TITLE
Add `metatag_open_graph` module to add specific image for Facebook

### DIFF
--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.article.field_branch
     - field.field.node.article.field_canonical_url
     - field.field.node.article.field_categories
+    - field.field.node.article.field_open_graph_image
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_publication_date
@@ -131,6 +132,15 @@ content:
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }
+  field_open_graph_image:
+    type: media_library_widget
+    weight: 27
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings:
+      media_library_edit:
+        show_edit: '1'
   field_override_author:
     type: string_textfield
     weight: 10

--- a/config/sync/core.entity_view_display.media.image.open_graph.yml
+++ b/config/sync/core.entity_view_display.media.image.open_graph.yml
@@ -1,0 +1,36 @@
+uuid: 74bc5a61-94fd-4de7-9510-a8e839c3c79b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.open_graph
+    - field.field.media.image.field_byline
+    - field.field.media.image.field_media_image
+    - image.style.open_graph
+    - media.type.image
+  module:
+    - image
+id: media.image.open_graph
+targetEntityType: media
+bundle: image
+mode: open_graph
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: open_graph
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_byline: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.node.article.card.yml
+++ b/config/sync/core.entity_view_display.node.article.card.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_branch
     - field.field.node.article.field_canonical_url
     - field.field.node.article.field_categories
+    - field.field.node.article.field_open_graph_image
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_publication_date
@@ -58,6 +59,7 @@ content:
 hidden:
   field_branch: true
   field_canonical_url: true
+  field_open_graph_image: true
   field_override_author: true
   field_paragraphs: true
   field_publication_date: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.article.field_branch
     - field.field.node.article.field_canonical_url
     - field.field.node.article.field_categories
+    - field.field.node.article.field_open_graph_image
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_publication_date
@@ -38,6 +39,15 @@ content:
       link: true
     third_party_settings: {  }
     weight: 110
+    region: content
+  field_open_graph_image:
+    type: entity_reference_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 115
     region: content
   field_override_author:
     type: string

--- a/config/sync/core.entity_view_display.node.article.full.yml
+++ b/config/sync/core.entity_view_display.node.article.full.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_branch
     - field.field.node.article.field_canonical_url
     - field.field.node.article.field_categories
+    - field.field.node.article.field_open_graph_image
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_publication_date
@@ -71,6 +72,7 @@ content:
     region: content
 hidden:
   field_canonical_url: true
+  field_open_graph_image: true
   field_override_author: true
   field_publication_date: true
   field_show_override_author: true

--- a/config/sync/core.entity_view_display.node.article.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.list_teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_branch
     - field.field.node.article.field_canonical_url
     - field.field.node.article.field_categories
+    - field.field.node.article.field_open_graph_image
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_publication_date
@@ -96,6 +97,7 @@ content:
     region: content
 hidden:
   field_canonical_url: true
+  field_open_graph_image: true
   field_paragraphs: true
   field_publication_date: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.article.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.article.nav_spot.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_branch
     - field.field.node.article.field_canonical_url
     - field.field.node.article.field_categories
+    - field.field.node.article.field_open_graph_image
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_publication_date
@@ -51,6 +52,7 @@ hidden:
   field_branch: true
   field_canonical_url: true
   field_categories: true
+  field_open_graph_image: true
   field_override_author: true
   field_paragraphs: true
   field_publication_date: true

--- a/config/sync/core.entity_view_display.node.article.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.nav_teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_branch
     - field.field.node.article.field_canonical_url
     - field.field.node.article.field_categories
+    - field.field.node.article.field_open_graph_image
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_publication_date
@@ -34,6 +35,7 @@ hidden:
   field_branch: true
   field_canonical_url: true
   field_categories: true
+  field_open_graph_image: true
   field_override_author: true
   field_paragraphs: true
   field_publication_date: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_branch
     - field.field.node.article.field_canonical_url
     - field.field.node.article.field_categories
+    - field.field.node.article.field_open_graph_image
     - field.field.node.article.field_override_author
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_publication_date
@@ -32,6 +33,7 @@ hidden:
   field_branch: true
   field_canonical_url: true
   field_categories: true
+  field_open_graph_image: true
   field_override_author: true
   field_paragraphs: true
   field_publication_date: true

--- a/config/sync/core.entity_view_mode.media.open_graph.yml
+++ b/config/sync/core.entity_view_mode.media.open_graph.yml
@@ -1,0 +1,10 @@
+uuid: 11777fb7-570f-45c9-baa4-54cd0809800e
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.open_graph
+label: 'Open graph (1200x630)'
+targetEntityType: media
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -115,6 +115,7 @@ module:
   menu_link_content: 0
   menu_ui: 0
   metatag: 0
+  metatag_open_graph: 0
   multiple_fields_remove_button: 0
   multivalue_form_element: 0
   mysql: 0

--- a/config/sync/field.field.node.article.field_open_graph_image.yml
+++ b/config/sync/field.field.node.article.field_open_graph_image.yml
@@ -1,0 +1,29 @@
+uuid: dfbc4eb5-5bba-4880-ad89-4dd1b2c8791e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_open_graph_image
+    - media.type.image
+    - node.type.article
+id: node.article.field_open_graph_image
+field_name: field_open_graph_image
+entity_type: node
+bundle: article
+label: 'Open graph image'
+description: 'This is used by Facebook when pages are shared'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_open_graph_image.yml
+++ b/config/sync/field.storage.node.field_open_graph_image.yml
@@ -1,0 +1,20 @@
+uuid: 34d5e191-a1af-445a-a290-ce14b645cea2
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_open_graph_image
+field_name: field_open_graph_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/image.style.open_graph.yml
+++ b/config/sync/image.style.open_graph.yml
@@ -1,0 +1,17 @@
+uuid: acc6f42a-570e-4571-9416-959ae8b9629e
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: open_graph
+label: 'Open graph (1200x630)'
+effects:
+  aeba491a-4e0f-4375-935a-ad919ce0b7d3:
+    uuid: aeba491a-4e0f-4375-935a-ad919ce0b7d3
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1200
+      height: 630
+      crop_type: focal_point

--- a/config/sync/metatag.metatag_defaults.eventinstance__default.yml
+++ b/config/sync/metatag.metatag_defaults.eventinstance__default.yml
@@ -1,0 +1,8 @@
+uuid: ff208e03-5b0b-436e-90d9-b486046a273d
+langcode: en
+status: true
+dependencies: {  }
+id: eventinstance__default
+label: 'Event Instance entity: Default'
+tags:
+  og_image: '[eventinstance:event_teaser_image:entity:field_media_image]'

--- a/config/sync/metatag.metatag_defaults.eventseries__default.yml
+++ b/config/sync/metatag.metatag_defaults.eventseries__default.yml
@@ -1,0 +1,8 @@
+uuid: 16155e0b-b96a-41da-9699-bd34a2aaa47f
+langcode: en
+status: true
+dependencies: {  }
+id: eventseries__default
+label: 'Event series entity: Default'
+tags:
+  og_image: '[eventseries:field_teaser_image:entity:field_media_image]'

--- a/config/sync/metatag.metatag_defaults.node.yml
+++ b/config/sync/metatag.metatag_defaults.node.yml
@@ -9,5 +9,8 @@ label: Content
 tags:
   canonical_url: '[node:field_canonical_url:uri]'
   description: '[node:summary]'
-  og_image: '[node:field_teaser_image:entity:field_media_image]'
+  og_image: '[node:field_open_graph_image:entity:field_media_image:open_graph:url]'
+  og_image_height: '[node:field_open_graph_image:entity:field_media_image:open_graph:height]'
+  og_image_url: '[node:field_open_graph_image:entity:field_media_image:open_graph:url]'
+  og_image_width: '[node:field_open_graph_image:entity:field_media_image:open_graph:width]'
   title: '[node:title] | [site:name]'

--- a/config/sync/metatag.metatag_defaults.node.yml
+++ b/config/sync/metatag.metatag_defaults.node.yml
@@ -9,4 +9,5 @@ label: Content
 tags:
   canonical_url: '[node:field_canonical_url:uri]'
   description: '[node:summary]'
+  og_image: '[node:field_teaser_image:entity:field_media_image]'
   title: '[node:title] | [site:name]'


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-904

#### Description

This pull request adds the `metatag_open_graph` module, which allows us to use our teaser image for the `<meta property="og:image" content="" />` tag.

See https://varnish.pr-1294.dpl-cms.dplplat01.dpl.reload.dk/admin/config/search/metatag

#### Screenshot of the result
![screencapture-dapple-cms-docker-admin-config-search-metatag-2024-06-24-13_50_34](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/7dc8a81c-10d4-4f0a-9c39-4d3a95cc1b6c)

#### Test
It can be tested by looking at the source code (right-click on the page and click "view source") for example, view-source:https://varnish.pr-1294.dpl-cms.dplplat01.dpl.reload.dk/artikler/3-gode-til-godnat-3-6-ar and checking that `<meta property="og:image" content="https://varnish.pr-1294.dpl-cms.dplplat01.dpl.reload.dk/sites/default/files/2024-02/ed-robertson-eeSdJfLfx1A-unsplash.jpg" />` is there.

If a teaser image is not set, this will not be applied.





