### PR TITLE
Remove the link from event tags.

### DIFF
--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -134,7 +134,7 @@ content:
     type: entity_reference_label
     label: hidden
     settings:
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 13
     region: content
@@ -157,7 +157,7 @@ content:
     region: content
   event_ticket_capacity:
     type: number_integer
-    label: visible
+    label: above
     settings:
       thousand_separator: ''
       prefix_suffix: true


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-909

#### Description

This pull request addresses the removal of links from event tags.

Given the absence of a dedicated site for these tags, the links are not relevant and have been removed.


https://varnish.pr-1295.dpl-cms.dplplat01.dpl.reload.dk/bronshoj-bibliotek/arrangementer/design-teknologi/fernisering-moderne-dans


Note:
When exporting the event tags setting, the `event_ticket_capacity` label is also changed to "above." The reason for this change is unclear, but it appears to be inconsequential.

#### Screenshot of the result
https://varnish.pr-1295.dpl-cms.dplplat01.dpl.reload.dk/admin/structure/events/instance/types/eventinstance_type/default/edit/display
![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/49920322/f86917e9-3de1-4824-8022-21c8da8b5fad)
