### PR TITLE
DDFLSBP-651 - Implement cookie blocking placeholder

### DIFF
--- a/web/modules/custom/dpl_cookies/dpl_cookies.module
+++ b/web/modules/custom/dpl_cookies/dpl_cookies.module
@@ -16,6 +16,7 @@ function dpl_cookies_preprocess_field__media__video(array &$variables): void {
       $item['content']['#attributes']['data-once'] = 'cookieinformation-iframe';
       $item['content']['#attributes']['data-category-consent'] = 'cookie_cat_marketing';
       $item['content']['#attributes']['data-consent-src'] = $item['content']['#attributes']['src'];
+      $item['content']['#attributes']['src'] = '';
     }
   }
 }

--- a/web/themes/custom/novel/templates/fields/field--media--video.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--media--video.html.twig
@@ -1,7 +1,3 @@
-{% for item in items %}
-  {{ item.content }}
-{% endfor %}
-
 <div class="consent-placeholder cookie-placeholder cookie-placeholder__hide" data-category="cookie_cat_marketing">
   <div class="pagefold-triangle--medium pagefold-inherit-parent"></div>
   <div class="cookie-placeholder__wrapper">
@@ -20,3 +16,6 @@
     </button>
   </div>
 </div>
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-651

#### Description

This PR makes sure to empty out the src attribute of the iFrame after copying it to the "data-consent-src" attribute. If the "src" attribute is not empty, it will still set cookies before the user gives consent.
