### PR TITLE
Update view mode for `event_teaser_image` to hide "Byline" in filtered event list paragraph

### DIFF
--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -143,14 +143,14 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: hero_wide
+      view_mode: list_teaser
       link: false
     third_party_settings: {  }
     weight: 12
     region: content
   event_ticket_capacity:
     type: number_integer
-    label: visible
+    label: above
     settings:
       thousand_separator: ''
       prefix_suffix: true


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-888

#### Description

This pull request updates the view mode for `event_teaser_image`.

This change will prevent the display of the byline in the filtered event list paragraph.

#### Test

https://varnish.pr-1305.dpl-cms.dplplat01.dpl.reload.dk/test-ingen-byline-pa-event-list

This event has a byline:
https://varnish.pr-1305.dpl-cms.dplplat01.dpl.reload.dk/bronshoj-bibliotek/arrangementer/design-teknologi/fernisering-moderne-dans