### PR TITLE
Make sure nodes are re-saved when placed in the breadcrumb tree. DDFFORM-847

### DIFF
--- a/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.install
+++ b/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.install
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * DPL breadcrumb update hooks.
+ *
+ * These get run BEFORE config-import.
+ */
+
+/**
+ * Re-save all breadcrumb terms, to get breadcrumb structure up-to-date.
+ *
+ * @see _dpl_breadcrumb_taxonomy_term_post_save()
+ */
+function dpl_breadcrumb_update_10001(): string {
+  $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')
+    ->loadByProperties([
+      'vid' => 'breadcrumb_structure',
+    ]);
+
+  foreach ($terms as $term) {
+    try {
+      $term->save();
+    }
+    catch (\Exception $exception) {
+      \Drupal::logger('dpl_breadcrumb')->warning($exception->getMessage());
+    }
+  }
+
+  $count = count($terms);
+
+  return "Updated $count breadcrumb terms, and corresponding nodes.";
+}

--- a/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
+++ b/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
@@ -189,7 +189,26 @@ function dpl_breadcrumb_node_presave(Node $node): void {
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function dpl_breadcrumb_taxonomy_term_insert(TermInterface $term): void {
+  _dpl_breadcrumb_taxonomy_term_post_save($term);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function dpl_breadcrumb_taxonomy_term_update(TermInterface $term): void {
+  _dpl_breadcrumb_taxonomy_term_post_save($term);
+}
+
+/**
  * Make sure nodes are re-saved when placed in the breadcrumb tree.
+ *
+ * This is a custom helper function, that is called using _update() and
+ * _insert() hooks above.
+ * We cannot use _presave(), as the term needs to be saved before we can
+ * do the node_presave() logic.
  *
  * On some node types, we have a structure field, that allows the editor to
  * place the node as a child of an term.
@@ -197,13 +216,13 @@ function dpl_breadcrumb_node_presave(Node $node): void {
  * term has been created, that links to this node), we want to take this
  * editor control away, and automatically update the field.
  * This happens in dpl_breadcrumb_node_presave().
- * However, if you first setup the node with all it's content, and then go
+ * However, if you first set up the node with all it's content, and then go
  * add it to the tree, no save is triggered on the node, and then it ends up
  * with a "broken" state.
  * This hook's task, is to run save() on nodes that have been placed in
  * the tree.
  */
-function dpl_breadcrumb_taxonomy_term_presave(TermInterface $term): void {
+function _dpl_breadcrumb_taxonomy_term_post_save(TermInterface $term): void {
   $service = DrupalTyped::service(BreadcrumbHelper::class, 'dpl_breadcrumb.breadcrumb_helper');
 
   if ($term->bundle() !== $service->getStructureVid() || !$term->hasField('field_content')) {

--- a/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
+++ b/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.module
@@ -186,7 +186,39 @@ function dpl_breadcrumb_node_presave(Node $node): void {
   $breadcrumb_parent = $service->getStructureParent($breadcrumb_item);
 
   $node->set($field_name, [$breadcrumb_parent?->id()]);
+}
 
+/**
+ * Make sure nodes are re-saved when placed in the breadcrumb tree.
+ *
+ * On some node types, we have a structure field, that allows the editor to
+ * place the node as a child of an term.
+ * However, when the actual node is placed in the tree as a parent (as in, a
+ * term has been created, that links to this node), we want to take this
+ * editor control away, and automatically update the field.
+ * This happens in dpl_breadcrumb_node_presave().
+ * However, if you first setup the node with all it's content, and then go
+ * add it to the tree, no save is triggered on the node, and then it ends up
+ * with a "broken" state.
+ * This hook's task, is to run save() on nodes that have been placed in
+ * the tree.
+ */
+function dpl_breadcrumb_taxonomy_term_presave(TermInterface $term): void {
+  $service = DrupalTyped::service(BreadcrumbHelper::class, 'dpl_breadcrumb.breadcrumb_helper');
+
+  if ($term->bundle() !== $service->getStructureVid() || !$term->hasField('field_content')) {
+    return;
+  }
+
+  $contents = $term->get('field_content')->referencedEntities();
+
+  foreach ($contents as $content) {
+    if (!($content instanceof FieldableEntityInterface)) {
+      continue;
+    }
+
+    $content->save();
+  }
 }
 
 /**


### PR DESCRIPTION
On some node types, we have a structure field, that allows the editor to place the node as a child of an term.
However, when the actual node is placed in the tree as a parent (as in, a
term has been created, that links to this node), we want to take this editor control away, and automatically update the field. This happens in dpl_breadcrumb_node_presave().
However, if you first setup the node with all it's content, and then go add it to the tree, no save is triggered on the node, and then it ends up with a "broken" state.
To fix this, we run `save()` on nodes, when we detect a save on a breadcrumb term.

#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-847

----

I know it's a bit confusing :) If you'd like to get a better idea of the problem, then try to go through the test that Stefan has written in the ticket
