### PR TITLE
Revert "Limit number of items per purge to 30"

### DIFF
--- a/config/sync/varnish_purger.settings.30cd45a1b1.yml
+++ b/config/sync/varnish_purger.settings.30cd45a1b1.yml
@@ -18,5 +18,5 @@ runtime_measurement: true
 timeout: 1.0
 connect_timeout: 1.0
 cooldown_time: 0.0
-max_requests: 30
+max_requests: 100
 http_errors: true

--- a/config/sync/varnish_purger.settings.65fc931232.yml
+++ b/config/sync/varnish_purger.settings.65fc931232.yml
@@ -21,5 +21,5 @@ runtime_measurement: true
 timeout: 1.0
 connect_timeout: 1.0
 cooldown_time: 0.0
-max_requests: 30
+max_requests: 100
 http_errors: true


### PR DESCRIPTION
After introducing this change we have seen the frequency of MySQL gone away errors go up.

We no longer think that the purge queue batch size is the cause of these problems so to reduce the problem we revert the change and return to the default value of 100.

Reverts danskernesdigitalebibliotek/dpl-cms#1274