### PR TITLE
Update WorkIdSearchForMaterialWIdget translation strings.

### DIFF
--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
@@ -75,6 +75,13 @@ final class WorkIdSearchForMaterialWidget extends WidgetBase {
         'material-search-amount-of-results-text' => $this->t('Total amount of results', [], ['context' => 'Material search']),
         'material-search-aria-button-select-work-with-text' => $this->t('Select work with the title @title', [], ['context' => 'Material search']),
         'material-search-search-input-placeholder-text' => $this->t('Search for material', [], ['context' => 'Material search']),
+        'material-search-warning-title-text' => $this->t('Warning', [], ['context' => 'Material search']),
+        'material-search-error-title-text' => $this->t('Title', [], ['context' => 'Material search']),
+        'material-search-error-author-text' => $this->t('Author', [], ['context' => 'Material search']),
+        'material-search-error-link-text' => $this->t('Link', [], ['context' => 'Material search']),
+        'material-search-error-header-text' => $this->t('This material needs to be updated.', [], ['context' => 'Material search']),
+        'material-search-error-material-type-not-found-text' => $this->t('The currently selected type of the material is no longer available in the system. <br> As a result of this, the link is likely broken. <br> Use the title or link underneath to find and update the material and its type, or replace / delete it.', [], ['context' => 'Material search']),
+        'material-search-error-work-not-found-text' => $this->t('The material that was previously selected is no longer available in the system. Either delete this entry or search for a new material to replace it.', [], ['context' => 'Material search']),
       ] + DplReactAppsController::externalApiBaseUrls(),
     ];
 


### PR DESCRIPTION
The react app has been updated and this adds the necessary translateable strings.

DDFFORM-900

#### Link to issue

[DDFFORM-900](https://reload.atlassian.net/browse/DDFFORM-900)

[React pr](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1304)

[Designs system pr](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/674)
#### Description

As part of updating the react app MaterialSearch this PR aims to update the necessary translatable strings the app expects. 

#### Additional comments or questions

Please do perform some manual testing of this error change. 


If you want to do it on the PR, you will need to manually created material grids/ recommendation, and then alter the saved data in the database. 


I suggest that if you do this, it is done after testing the react app itself in storybook perhaps. 

Up to you. 

[DDFFORM-900]: https://reload.atlassian.net/browse/DDFFORM-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ