### PR TITLE
Change Lighthouse performance scoring from error to warning

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -45,7 +45,7 @@ module.exports = {
         // translates to a score between 90 and 100 - or 0.9-1.
         // TODO: Implement inline critial CSS to raise score above 0.9
         // TODO: Implement depedency splitting to raise score above 0.75
-        "categories:performance": ["error", { minScore: 0.75 }],
+        "categories:performance": ["warn", { minScore: 0.75 }],
         "categories:accessibility": ["error", { minScore: 0.9 }],
         "categories:best-practices": ["error", { minScore: 0.9 }],
         "categories:seo": ["error", { minScore: 0.9 }],

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -6,9 +6,7 @@ module.exports = {
         // https://reload.atlassian.net/browse/DDFLSBP-668
         // "http://varnish:8080/",
         "http://varnish:8080/search?q=harry+potter&x=0&y=0",
-        // TODO: Unfortunately the work page test is failing due to a low Lighthouse score.
-        // When performance is improved this should be re-enabled.
-        // "http://varnish:8080/work/work-of:870970-basis:25245784?type=bog"
+        "http://varnish:8080/work/work-of:870970-basis:25245784?type=bog"
         // Article page from DPL Example Content
         // "http://varnish:8080/by_uuid/node/2cd0fe5e-4159-4452-86aa-e1a1ac8db4a1",
         // Event instance page from DPL Example Content


### PR DESCRIPTION
#### Description

Over time performance has been a tricky thing to measure using Lighthouse in CI/GitHub Actions:

1. Performance varies between runs. This is likely due to variance in the underlying resources available during each run. Attempts to control this by configuring throttling have not worked.
2. Performance is a downward slope. Developers see the CI process fail but do not see a direct correlation to the individual change. We do not have a place to monitor if any change has caused a significant degradation but not crossed any threshold.

This has lead to a situation where developers have tried to rerun the Lighthouse tests until they pass. When we are at a point where they cannot we as a team are not at point where we can actually address this as errors in CI stop all development.

In the past we have tried to handle this by lowering the score a couple of times. This has not worked.

To avoid this going forward we will try something different:

1. Prevent Lighthouse from causing CI errors
2. Raise current known improvements as actionable issues to be prioritized
3. Do periodical performance reviews of the application

This addresses 1) by changing the level for performance from error to warn. This means that  audit result will be checked, and the result will be printed to stderr, but failure will not result in a non-zero exit code.

We do not want to disable Lighthouse entirely as we still value other reported findings.

#### Screenshot of the result

Lighthouse checks for content pages are currently not reenabled due to https://reload.atlassian.net/browse/DDFFORM-925.