### PR TITLE
Add open graph meta tags for Facebook

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -116,6 +116,7 @@ module:
   menu_link_content: 0
   menu_ui: 0
   metatag: 0
+  metatag_open_graph: 0
   multiple_fields_remove_button: 0
   multivalue_form_element: 0
   mysql: 0

--- a/config/sync/image.style.open_graph.yml
+++ b/config/sync/image.style.open_graph.yml
@@ -1,0 +1,17 @@
+uuid: 019d1ff4-6a3c-4b40-8643-96ce5ef2d2de
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: open_graph
+label: 'Open graph (1200x630)'
+effects:
+  91c78e07-efa7-42a2-8a40-47f4916ac17c:
+    uuid: 91c78e07-efa7-42a2-8a40-47f4916ac17c
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1200
+      height: 630
+      crop_type: focal_point

--- a/config/sync/metatag.metatag_defaults.eventinstance__default.yml
+++ b/config/sync/metatag.metatag_defaults.eventinstance__default.yml
@@ -1,0 +1,11 @@
+uuid: 0a7c6808-8bbe-4808-813d-9646f4e72d17
+langcode: en
+status: true
+dependencies: {  }
+id: eventinstance__default
+label: 'Event Instance entity: Default'
+tags:
+  og_image: '[eventinstance:event_teaser_image:entity:field_media_image:open_graph]'
+  og_image_height: '[eventinstance:event_teaser_image:entity:field_media_image:open_graph:height]'
+  og_image_url: '[eventinstance:event_teaser_image:entity:field_media_image:open_graph:url]'
+  og_image_width: '[eventinstance:event_teaser_image:entity:field_media_image:open_graph:width]'

--- a/config/sync/metatag.metatag_defaults.eventseries__default.yml
+++ b/config/sync/metatag.metatag_defaults.eventseries__default.yml
@@ -1,0 +1,11 @@
+uuid: 54f6a4e8-967c-4492-b6e6-9ec6210f5557
+langcode: en
+status: true
+dependencies: {  }
+id: eventseries__default
+label: 'Event series entity: Default'
+tags:
+  og_image: '[eventseries:field_teaser_image:entity:field_media_image:open_graph]'
+  og_image_height: '[eventseries:field_teaser_image:entity:field_media_image:open_graph:height]'
+  og_image_url: '[eventseries:field_teaser_image:entity:field_media_image:open_graph:url]'
+  og_image_width: '[eventseries:field_teaser_image:entity:field_media_image:open_graph:width]'

--- a/config/sync/metatag.metatag_defaults.node.yml
+++ b/config/sync/metatag.metatag_defaults.node.yml
@@ -9,4 +9,8 @@ label: Content
 tags:
   canonical_url: '[node:field_canonical_url:uri]'
   description: '[node:summary]'
+  og_image: '[node:field_teaser_image:entity:field_media_image:open_graph]'
+  og_image_height: '[node:field_teaser_image:entity:field_media_image:open_graph:height]'
+  og_image_url: '[node:field_teaser_image:entity:field_media_image:open_graph:url]'
+  og_image_width: '[node:field_teaser_image:entity:field_media_image:open_graph:width]'
   title: '[node:title] | [site:name]'

--- a/config/sync/metatag.metatag_defaults.node__branch.yml
+++ b/config/sync/metatag.metatag_defaults.node__branch.yml
@@ -1,0 +1,11 @@
+uuid: 02184065-7ff3-44ec-89a2-d9e6482db32d
+langcode: en
+status: true
+dependencies: {  }
+id: node__branch
+label: 'Content: Branch'
+tags:
+  og_image: '[node:field_main_media:entity:field_media_image:open_graph]'
+  og_image_height: '[node:field_main_media:entity:field_media_image:open_graph:height]'
+  og_image_url: '[node:field_main_media:entity:field_media_image:open_graph:url]'
+  og_video_width: '[node:field_main_media:entity:field_media_image:open_graph:width]'


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-904

#### Description

This pull request enables the metatag_open_graph module, which allows us to use our teaser image for the <meta property="og:image" content="" /> tag.

This change ensures that the correctly formatted image is served for Facebook by adding a new image style in the 1200x630 format.

I used the main image for the branch content type, which does not have a teaser image.

#### Test
http://varnish.pr-1317.dpl-cms.dplplat01.dpl.reload.dk/frontpage
http://varnish.pr-1317.dpl-cms.dplplat01.dpl.reload.dk/artikler/3-gode-til-godnat-3-6-ar
http://varnish.pr-1317.dpl-cms.dplplat01.dpl.reload.dk/hovedbiblioteket

