### PR TITLE
Remove version from docker-compose.yml

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,3 @@
-version: '2.3'
-
 services:
   node-chrome:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@
 #
 # Consult https://github.com/danskernesdigitalebibliotek/dpl-platform for
 # further details.
-version: '2.3'
 
 # This block is used for inclusion in the environment section of each container.
 x-volumes:


### PR DESCRIPTION
#### Description

This is now obsolete and spawn warnings in our scripts: WARN[0000] /Users/kasper/Projects/dapple/cms/docker-compose.yml: `version` is obsolete

Remove it.