### PR TITLE
Adjust identifier that is sent to each materialSearch app.

### DIFF
--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
@@ -22,11 +22,12 @@ final class WorkIdSearchForMaterialWidget extends WidgetBase {
 
   /**
    * {@inheritdoc}
+   *
+   * @throws \Random\RandomException
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
 
-    $uniqueFieldId = $items->getFieldDefinition()->getUniqueIdentifier();
-    $identifier = "{$uniqueFieldId}-{$delta}";
+    $identifier = bin2hex(random_bytes(16));
 
     $element['fields_container'] = [
       '#type' => 'container',


### PR DESCRIPTION
The previous implementation did not work. The same ID was being to multiple apps, causing them to update incorret apps.

DDFFORM-914

#### Link to issue

jira [DDFFORM-914](https://reload.atlassian.net/browse/DDFFORM-914)

#### Description

This PR addresses an issue, where multiple usages of the recommendation or material grid manual were updating incorrect apps, when searching for materials using the material search app. 


The same ID was being applied to multiple apps. 

The new approach should fix that. 



- Test that you can create 3-4 recommendation paragraphs in a row where they are not updating eachother. See the ticket for example. 

[DDFFORM-914]: https://reload.atlassian.net/browse/DDFFORM-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ