### PR TITLE
WIP: Change event time settings to allow events to start from 00:00

### DIFF
--- a/config/sync/recurring_events.eventseries.config.yml
+++ b/config/sync/recurring_events.eventseries.config.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: HuNc0wdz6BZa5IceY8HDpVfwTwqvp1rpRQeuS5szwSo
-interval: 15
+interval: 0
 min_time: '12:00am'
 max_time: '11:45pm'
 date_format: 'd/m/y - H:i'

--- a/config/sync/recurring_events.eventseries.config.yml
+++ b/config/sync/recurring_events.eventseries.config.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: HuNc0wdz6BZa5IceY8HDpVfwTwqvp1rpRQeuS5szwSo
 interval: 15
-min_time: '08:00am'
+min_time: '12:00am'
 max_time: '11:45pm'
 date_format: 'd/m/y - H:i'
 time_format: 'H:i'


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-877

#### Description
To accommodate the use of the AM/PM time format, I have adjusted the min_time setting to 12:00 AM, equivalent to 00:00 in our timezone to be able to have events before 08. Additionally, I modified the time interval to 0, enabling events to be scheduled at any time.

#### Test
http://varnish.pr-1337.dpl-cms.dplplat01.dpl.reload.dk/arrangementer