### PR TITLE
DDFFORM 883 deleting materialsearch

### DIFF
--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
@@ -75,6 +75,13 @@ final class WorkIdSearchForMaterialWidget extends WidgetBase {
         'material-search-amount-of-results-text' => $this->t('Total amount of results', [], ['context' => 'Material search']),
         'material-search-aria-button-select-work-with-text' => $this->t('Select work with the title @title', [], ['context' => 'Material search']),
         'material-search-search-input-placeholder-text' => $this->t('Search for material', [], ['context' => 'Material search']),
+        'material-search-warning-title-text' => $this->t('Warning', [], ['context' => 'Material search']),
+        'material-search-error-title-text' => $this->t('Title', [], ['context' => 'Material search']),
+        'material-search-error-author-text' => $this->t('Author', [], ['context' => 'Material search']),
+        'material-search-error-link-text' => $this->t('Link', [], ['context' => 'Material search']),
+        'material-search-error-header-text' => $this->t('This material needs to be updated.', [], ['context' => 'Material search']),
+        'material-search-error-material-type-not-found-text' => $this->t('The currently selected type of the material is no longer available in the system. <br> As a result of this, the link is likely broken. <br> Use the title or link underneath to find and update the material and its type, or replace / delete it.', [], ['context' => 'Material search']),
+        'material-search-error-work-not-found-text' => $this->t('The material that was previously selected is no longer available in the system. Either delete this entry or search for a new material to replace it.', [], ['context' => 'Material search']),
       ] + DplReactAppsController::externalApiBaseUrls(),
     ];
 

--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
@@ -60,8 +60,6 @@ final class WorkIdSearchForMaterialWidget extends WidgetBase {
       '#name' => 'material-search',
       '#data' => [
         'class' => ['react-app-container'],
-        'previously-selected-work-id' => $items[$delta]->value ?? NULL,
-        'previously-selected-material-type' => $items[$delta]->material_type ?? NULL,
         'unique-identifier' => $identifier,
         'material-search-search-input-text' => $this->t('Search for material', [], ['context' => 'Material search']),
         'material-search-material-type-selector-text' => $this->t('Select material type', [], ['context' => 'Material search']),

--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
@@ -83,6 +83,8 @@ final class WorkIdSearchForMaterialWidget extends WidgetBase {
         'material-search-error-header-text' => $this->t('This material needs to be updated.', [], ['context' => 'Material search']),
         'material-search-error-material-type-not-found-text' => $this->t('The currently selected type of the material is no longer available in the system. <br> As a result of this, the link is likely broken. <br> Use the title or link underneath to find and update the material and its type, or replace / delete it.', [], ['context' => 'Material search']),
         'material-search-error-work-not-found-text' => $this->t('The material that was previously selected is no longer available in the system. Either delete this entry or search for a new material to replace it.', [], ['context' => 'Material search']),
+        'material-search-error-hidden-inputs-not-found-heading-text' => $this->t('Error retrieving saved data. Inputs not found.', [], ['context' => 'Material search']),
+        'material-search-error-hidden-inputs-not-found-description-text' => $this->t('Something went wrong when trying to find the previously saved values. Please try again. If the problem persists, something could be wrong with the app.', [], ['context' => 'Material search']),
       ] + DplReactAppsController::externalApiBaseUrls(),
     ];
 

--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/WorkIdSearchForMaterialWidget.php
@@ -22,11 +22,12 @@ final class WorkIdSearchForMaterialWidget extends WidgetBase {
 
   /**
    * {@inheritdoc}
+   *
+   * @throws \Random\RandomException
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
 
-    $uniqueFieldId = $items->getFieldDefinition()->getUniqueIdentifier();
-    $identifier = "{$uniqueFieldId}-{$delta}";
+    $identifier = bin2hex(random_bytes(16));
 
     $element['fields_container'] = [
       '#type' => 'container',


### PR DESCRIPTION
- **Adjust identifier that is sent to each materialSearch app.**
- **Update WorkIdSearchForMaterialWIdget translation strings.**
- **Updated `WorkIdSearchForMaterialWidget` app translations.**

#### Link to issue

jira [DDFFORM-883](https://reload.atlassian.net/browse/DDFFORM-883)

#### Description

Update translation strings and remove previouslySelected values since they are no longer necessary to pass as props. 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/a4415027-b080-4d12-bb13-eb32dd3c6d38)

#### Additional comments or questions

With this change, as well as [DDFFORM-914](https://reload.atlassian.net/browse/DDFFORM-914)
and [DDFFORM-900](https://reload.atlassian.net/browse/DDFFORM-900), it should be possible to: 

- Create multiple recommendations that will in any variation, keep displaying the correct material that was selected for that field. 

- Create a material grid on the same page that will do the same. 

- Delete any entry in any order, and see that the correct field item and app is being deleted, and not an incorrect one. 

- Save the items with incorrect ids/types ( find the selected and uncheck display:none; for the fields_container ), and when reopening this seeing all individual applications display the appropriate error. 

[DDFFORM-883]: https://reload.atlassian.net/browse/DDFFORM-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDFFORM-914]: https://reload.atlassian.net/browse/DDFFORM-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDFFORM-900]: https://reload.atlassian.net/browse/DDFFORM-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ