### PR TITLE
DDFLSBP-756 - Delete contact webform configuration translation

### DIFF
--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -36,3 +36,22 @@ function dpl_webform_update_10001(): string {
 
   return 'All webform email handlers saved.';
 }
+
+/**
+ * Delete all webform configuration translations.
+ *
+ * We don't want to have translated webform configurations as
+ * they are taking preceedence over the original configuration,
+ * and thus making editors unable to change configuration on the
+ * contact webform.
+ */
+function dpl_webform_update_10002(): string {
+  $webform_id = 'webform.webform.contact';
+  $language = 'da';
+
+  /** @var \Drupal\language\Config\LanguageConfigFactoryOverride $language_config_factory_override */
+  $language_config_factory_override = \Drupal::service('language.config_factory_override');
+  $language_config_factory_override->getOverride($language, $webform_id)->delete();
+
+  return 'All translations for the webform ' . $webform_id . ' have been deleted.';
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-756

#### Description

This PR adds a new update hook to dpl_webform.install.

A previous translation has been added to the contact webform through PoEditor. This update hook is removing that translation. The reason we want to remove the translation is that it overrides the changes the editors make on the original contact webform configuration.