### PR TITLE
Specify PHP version in composer.json to support Dependabot

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -301,3 +301,28 @@ jobs:
         run: task dev:cli -- drush config-export -y
       - name: Check for uncommited configuration after install
         run: git diff --ignore-space-at-eol --exit-code config/sync/*.yml
+
+  CheckPhpVersion:
+    name: Check PHP version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check PHP version in composer.json
+        run: |
+          if ! jq .require.php composer.json | grep ${{ env.PHP_VERSION }}; then
+            echo "PHP version in composer.json does not match the version in the GitHub Actions."
+            exit 1
+          fi
+      - name: Check PHP version in PHP service
+        run: |
+          if ! docker compose run php -- php --version | grep ${{ env.PHP_VERSION }}; then
+            echo "PHP version for PHP service docker-compose.yml does not match the version in the GitHub Actions."
+            exit 1
+          fi
+      - name: Check PHP version in CLI service
+        run: |
+          if ! docker compose run php -- php --version | grep ${{ env.PHP_VERSION }}; then
+            echo "PHP version for CLI service docker-compose.yml does not match the version in the GitHub Actions."
+            exit 1
+          fi

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
         }
     ],
     "require": {
+        "php": "8.1.*",
         "amazeeio/drupal_integrations": "^0.4",
         "bower-asset/jsnlog": "^2.30",
         "brick/math": "^0.12.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03bb63991bed067fbf257065c7e1ab4b",
+    "content-hash": "4212e58419de340efc0ad063d2b956d4",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -19008,7 +19008,9 @@
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "8.1.*"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
#### Description

Require PHP 8.1 in Composer. We already use PHP 8.1 in the platform.

Adding this as a requirement should allow Dependabot to use the right version when checking for dependency updates.

Defining this in multiple places can be a problem but we now have GitHub Action to help us check for this.

The current Dependabot logs are full of errors like this:

```
2024/07/09 06:53:57 ERROR <job_853344707> Your requirements could not be resolved to an installable set of packages.
updater |   Problem 1
updater |     - brick/math is locked to version 0.12.1 and an update of this package was not requested.
updater |     - brick/math 0.12.1 requires php ^8.1 -> your php version (7.4.33) does not satisfy that requirement.
updater |   Problem 2
updater |     - drupal/dynamic_entity_reference is locked to version 3.1.0 and an update of this package was not requested.
updater |     - drupal/dynamic_entity_reference 3.1.0 requires php >=8.1 -> your php version (7.4.33) does not satisfy that requirement.
updater |   Problem 3
updater |     - drupal/metatag is locked to version 2.0.0 and an update of this package was not requested.
updater |     - drupal/metatag 2.0.0 requires php >=8.0 -> your php version (7.4.33) does not satisfy that requirement.
updater |   Problem 4
updater |     - drupal/webform is locked to version 6.2.2 and an update of this package was not requested.
updater |     - drupal/webform 6.2.2 requires php >=8.1 -> your php version (7.4.33) does not satisfy that requirement.
updater |   Problem 5
updater |     - drush/drush is locked to version 12.5.2 and an update of this package was not requested.
updater |     - drush/drush 12.5.2 requires php >=8.1 -> your php version (7.4.33) does not satisfy that requirement.
updater |   Problem 6
updater |     - symfony/property-access is locked to version v6.4.8 and an update of this package was not requested.
updater |     - symfony/property-access v6.4.8 requires php >=8.1 -> your php version (7.4.33) does not satisfy that requirement.
updater |   Problem 7
updater |     - symfony/property-info is locked to version v6.4.9 and an update of this package was not requested.
updater |     - symfony/property-info v6.4.9 requires php >=8.1 -> your php version (7.4.33) does not satisfy that requirement.
updater |   Problem 8
updater |     - vincentlanglet/twig-cs-fixer is locked to version 2.0.0 and an update of this package was not requested.
updater |     - vincentlanglet/twig-cs-fixer 2.0.0 requires php >=8.0 -> your php version (7.4.33) does not satisfy that requirement.
updater |   Problem 9
updater |     - symfony/validator v6.4.9 requires php >=8.1 -> your php version (7.4.33) does not satisfy that requirement.
updater |     - drupal/core-recommended 10.3.1 requires symfony/validator ~v6.4.7 -> satisfiable by symfony/
```