### PR TITLE
DDFLSBP-695 - Allow uppercase and dashes in webform element key patterns

### DIFF
--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -125,7 +125,7 @@ form:
   filter_category: ''
   filter_state: ''
 element:
-  machine_name_pattern: a-z0-9_
+  machine_name_pattern: a-zA-Z0-9_-
   empty_message: '{Empty}'
   allowed_tags: admin
   wrapper_classes: |


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-695

#### Description

This PR updates webform settings to allow for both uppercase letters and dashes in element key patterns. This will give the editors more freedom when creating element keys. This is useful in cases where specific element keys needs to have a specific name that includes either dashes or uppercase letters.
