### PR TITLE
Fix zipCode for events api.

### DIFF
--- a/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
+++ b/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
@@ -247,13 +247,14 @@ class EventRestMapper {
     $address_1 = $value[0]['address_line1'] ?? NULL;
     $address_2 = $value[0]['address_line2'] ?? NULL;
 
-    return new EventsGET200ResponseInnerAddress([
-      'location' => $this->getValue('event_place'),
-      'street' => "$address_1 $address_2",
-      'zip_code' => !empty($zip) ? intval($zip) : NULL,
-      'city' => $value[0]['locality'] ?? NULL,
-      'country' => $value[0]['country_code'] ?? NULL,
-    ]);
+    $address = new EventsGET200ResponseInnerAddress();
+    $address->setLocation($this->getValue('event_place'));
+    $address->setStreet("$address_1 $address_2");
+    $address->setZipCode(!empty($zip) ? intval($zip) : NULL);
+    $address->setCity($value[0]['locality'] ?? NULL);
+    $address->setCountry($value[0]['country_code'] ?? NULL);
+
+    return $address;
   }
 
   /**


### PR DESCRIPTION
The error is due to a typo between how zipcode is spelled, and generated in grapqhl.

DDFFORM-878

#### Link to issue

[DDFFORM-878](https://reload.atlassian.net/browse/DDFFORM-878)

#### Description

Fixed a typo for zipCode so that zipcode is displayed in the events API. 

Run the site, go to the events api `/api/v1/events?from_date=2024-04-03` and verify that you can see the zipcodes. 


#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/12091098-a42d-4edb-bee9-56091e99a465)
#### Additional comments or questions


[DDFFORM-878]: https://reload.atlassian.net/browse/DDFFORM-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ