### PR TITLE
Reduce number of required items to render a card grid to 1 [DDFFORM-946]

### DIFF
--- a/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
+++ b/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
@@ -549,7 +549,7 @@ class RelatedContent {
     if ($this->listStyle == RelatedContentListStyle::Grid) {
       // Visually, grid looks broken with less than 3 items, and does not
       // support more than 6.
-      $this->minItems = 3;
+      $this->minItems = 1;
       $this->maxItems = 6;
     }
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-946

#### Description

It creates some confusion and support work to explain that these components are not rendered if they do not live up to the required number of elements.

The card grid does not look too bad with only 1 element so lower the requirement to this.

