### PR TITLE
DDFLSBP-693 - Remove language warning when editing webforms

### DIFF
--- a/web/modules/custom/dpl_webform/dpl_webform.module
+++ b/web/modules/custom/dpl_webform/dpl_webform.module
@@ -112,3 +112,20 @@ function dpl_webform_form_webform_handler_form_alter(array &$form, FormStateInte
   $form['settings']['from']['from_mail']['from_mail']['#default_value'] = '[site:mail]';
   $form['settings']['from']['from_name']['from_name']['#default_value'] = '';
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function dpl_webform_form_webform_edit_form_alter(array &$form, FormStateInterface &$form_state, string $form_id): void {
+
+  /** @var \Drupal\webform\WebformInterface $webform */
+  $webform = \Drupal::routeMatch()->getParameter('webform');
+
+  // Editors with their default language set to danish, kept getting
+  // a warning message when editting webforms. The warning said that
+  // they were editting the original english version of the webform.
+  // We do not care about the warning, since that is the expected
+  // behaviour. To avoid showing the warning, we simply set the
+  // langcode to danish on the webform edit forms.
+  $webform->set('langcode', 'da');
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-693

#### Description

Editors with their default language set to danish, kept getting a warning message when editting webforms. The warning said that they were editting the original english version of the webform. We do not care about the warning, since that is the expected behaviour. To avoid showing the warning, we simply set the langcode to danish on the webform edit forms.

#### Other comments

Before going with this solution, I tried to simply remove the language warning from the form like this `unset($form['langcode_message'])` in a form alter hook. 

But I found out that `webform` module own form alter hook was running after my form alter hook in our `dpl_webform` module, which meant whatever I did in my hook wouldn't matter as it was getting "overwritten" by the `webform` form alter hook. 
So I tried changing the order of which hook was running last by using [hook_module_implements_alter](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_module_implements_alter/10), but I found out that the `webform` module was also using the same hook, and thus I ended up with the same problem as before.

Lastly I decided to try to change the weight of `dpl_webform` module to always be higher than the `webform` module. I did that using an update hook using the function [module_set_weight](https://api.drupal.org/api/drupal/core%21includes%21module.inc/function/module_set_weight/9). Even though I changed the module weight to be higher than `webform`, I couldn't make my form alter function be the last to run. 

In the end I didn't want to use more time on it, and instead I came up with the solution presented in this PR.