### PR TITLE
Delete faulty translation of `webform.settings.yml`

### DIFF
--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -55,3 +55,21 @@ function dpl_webform_update_10002(): string {
 
   return 'All translations for the webform ' . $webform_id . ' have been deleted.';
 }
+
+/**
+ * Delete translation of webform.settings.yml.
+ *
+ * Due to some faulty, prior translation, the danish version of this file
+ * has duplicate keys, which causes major issues on the site when loading
+ * the webform settings.
+ */
+function dpl_webform_update_10003(): string {
+  $config_id = 'webform.settings';
+  $language = 'da';
+
+  /** @var \Drupal\language\Config\LanguageConfigFactoryOverride $language_config_factory_override */
+  $language_config_factory_override = \Drupal::service('language.config_factory_override');
+  $language_config_factory_override->getOverride($language, $config_id)->delete();
+
+  return "DA translations for the $config_id have been deleted.";
+}


### PR DESCRIPTION
Due to some faulty, prior translation, the danish version of this file has duplicate keys, which causes major issues on the site when loading the webform settings.

We do not know what has caused this, but essentially, the contact forms (and other webforms) fail because the danish translation has two keys that are duplicates. (Postnummer x2)


Tada:

https://varnish.pr-1388.dpl-cms.dplplat01.dpl.reload.dk/kontakt