### PR TITLE
Prevent updating eventseries schedule from failing [DDFFORM-947]

### DIFF
--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -175,3 +175,12 @@
     max-width: 100%;
   }
 }
+
+/**
+ Hide default action button on confirm form.
+ Editors should focus on the date-related changes.
+ Selector is convoluted due to Gin DOM structure.
+*/
+body:has(.eventseries-form--confirm) .form-actions {
+  display: none;
+}

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -325,3 +325,33 @@ function dpl_admin_toolbar_alter(array &$items): void {
     ],
   ];
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Altering the form for EDITING (not creating) an event series.
+ */
+function dpl_admin_form_eventseries_default_edit_form_alter(array &$form, FormStateInterface $form_state): void {
+  // When saving a series, and changing the dates, the recurring_events module
+  // will make a "custom" submit button, showing a 'are you sure' button.
+  // However, this does not include a 'cancel' button. This is because cancel
+  // basically just means navigating away, but, this is confusing for editors.
+  // We'll add our own "button", that is really just a link the same edit page.
+  if (!empty($form['diff']['confirm'])) {
+    $form['diff']['cancel'] = [
+      '#type' => 'link',
+      '#title' => t('Cancel all changes', [], ['context' => 'DPL admin UX']),
+      '#url' => Url::fromRoute('<current>'),
+      '#attributes' => [
+        'class' => [
+          'action-link', 'action-link--danger', 'action-link--icon-trash',
+        ],
+      ],
+    ];
+
+    // The save/delete buttons on the page does nothing, when a diff confirm
+    // is relevant. We'll hide them, just to make it less confusing for the
+    // editors.
+    unset($form['actions']);
+  }
+}

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -338,6 +338,8 @@ function dpl_admin_form_eventseries_default_edit_form_alter(array &$form, FormSt
   // basically just means navigating away, but, this is confusing for editors.
   // We'll add our own "button", that is really just a link the same edit page.
   if (!empty($form['diff']['confirm'])) {
+    $form['#attributes']['class'][] = 'eventseries-form--confirm';
+
     $form['diff']['cancel'] = [
       '#type' => 'link',
       '#title' => t('Cancel all changes', [], ['context' => 'DPL admin UX']),
@@ -348,10 +350,5 @@ function dpl_admin_form_eventseries_default_edit_form_alter(array &$form, FormSt
         ],
       ],
     ];
-
-    // The save/delete buttons on the page does nothing, when a diff confirm
-    // is relevant. We'll hide them, just to make it less confusing for the
-    // editors.
-    unset($form['actions']);
   }
 }

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -8,7 +8,6 @@
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\dpl_event\EventState;
 use Drupal\dpl_event\EventWrapper;
@@ -287,34 +286,4 @@ function dpl_event_gin_content_form_routes() : array {
     'entity.eventseries.add_instance_form',
     'entity.eventinstance.edit_form',
   ];
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- *
- * Altering the form for EDITING (not creating) an event series.
- */
-function dpl_event_form_eventseries_default_edit_form_alter(array &$form, FormStateInterface $form_state): void {
-  // When saving a series, and changing the dates, the recurring_events module
-  // will make a "custom" submit button, showing a 'are you sure' button.
-  // However, this does not include a 'cancel' button. This is because cancel
-  // basically just means navigating away, but, this is confusing for editors.
-  // We'll add our own "button", that is really just a link the same edit page.
-  if (!empty($form['diff']['confirm'])) {
-    $form['diff']['cancel'] = [
-      '#type' => 'link',
-      '#title' => t('Cancel all changes', [], ['context' => 'DPL admin UX']),
-      '#url' => Url::fromRoute('<current>'),
-      '#attributes' => [
-        'class' => [
-          'action-link', 'action-link--danger', 'action-link--icon-trash',
-        ],
-      ],
-    ];
-
-    // The save/delete buttons on the page does nothing, when a diff confirm
-    // is relevant. We'll hide them, just to make it less confusing for the
-    // editors.
-    unset($form['actions']);
-  }
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-947

#### Description

When updating the schedule for an event series the recurring events
module shows a summary of the change and asks the user to confirm it
as this will recreate all instances.

In this situation we want to hide the default form actions as they
make little sense in this situation even though they are fully
functional.

Until now we have achieved this by removing the form elements from the
form.

After updating the Gin administration theme and Drupal Core from 10.1
to 10.3 this approach no longer works. Gin expects the actions to be
available and throws a hard PHP error if they are not.

Attempt to address this using alternate approaches using the Drupal
Form API e.g. #access=FALSE or #disabled=TRUE has not worked due to
the rather complex form manipulations of Gin.

Instead we switch to a CSS-based approach which hides the form
elements instead. This should not make a huge difference compared to
the original approach.

Gin also does interesting things to the DOM structure so the resulting
CSS selector also becomes a bit complex.

In the process I also move the handling of the improvement from the event module to the admin module. It makes just as much sense to keep them there.

The module also already has CSS files which we may need to improve
handling of events for admins.

#### Screenshot of the result

<img width="1392" alt="Monosnap Edit default Event Fernisering Moderne Dans | DPL CMS | Logged in 2024-07-15 13-14-06" src="https://github.com/user-attachments/assets/54ab141d-ac37-469b-b3ee-bea7973db563">

#### Additional comments or questions

A quick test shows that we could achieve the same by patching the `recurring_events` module and preventing access to `actions` [immediatly as a schedule change is detected and a confirmation form is added](https://git.drupalcode.org/project/recurring_events/-/blob/2.0.x/src/Form/EventSeriesForm.php?ref_type=heads#L236).

<img width="1392" alt="Monosnap Edit default Event Fernisering Moderne Dans | DPL CMS | Logged in 2024-07-15 13-14-06" src="https://github.com/user-attachments/assets/89932fe2-3ca4-4197-bb04-789d4fd57590">

