### PR TITLE
Fix issues with webform test data

### DIFF
--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -355,10 +355,6 @@ test:
     address:
       - '10 Main Street'
       - '11 Brook Alley Road. APT 1'
-    zip:
-      - '11111'
-      - '12345'
-      - '12345-6789'
     postal_code:
       - '11111'
       - '12345'

--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -63,7 +63,7 @@ function dpl_webform_update_10002(): string {
  * has duplicate keys, which causes major issues on the site when loading
  * the webform settings.
  */
-function dpl_webform_update_10003(): string {
+function dpl_webform_update_10004(): string {
   $config_id = 'webform.settings';
   $language = 'da';
 


### PR DESCRIPTION
Apparantly, the faulty keys in the webform.settings.yml that get
translated and duplicated as 2x"Postnummer" still exists - our hope
was that it was some kind of broken state.
Instead, we'll remove the key from the source config, so it does
not get translated at all.
Apparantly, the data is test data, so it should be safe.

After doing this, we'll also re-delete the translation, by just
bumping the hook_update number