### PR TITLE
Delete faulty webform translation

### DIFF
--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -5,6 +5,9 @@
  * DPL webform install file.
  */
 
+use Drupal\drupal_typed\DrupalTyped;
+use Drupal\locale\StringStorageInterface;
+
 /**
  * Add all webforms to config ignore.
  */
@@ -72,4 +75,18 @@ function dpl_webform_update_10003(): string {
   $language_config_factory_override->getOverride($language, $config_id)->delete();
 
   return "DA translations for the $config_id have been deleted.";
+}
+
+/**
+ * Remove last traces of faulty webform translation.
+ */
+function dpl_webform_update_10004(): string {
+  $translation_storage = DrupalTyped::service(StringStorageInterface::class, 'locale.storage');
+  $translation = $translation_storage->findTranslation(['context' => 'webform.settings:test:names']);
+  if ($translation) {
+    $translation->delete();
+    return 'Deleted faulty translation for webform.settings:test:names';
+  } else {
+    return 'Unable to locate faulty translation for webform.settings:test:names.';
+  }
 }

--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -81,23 +81,29 @@ function dpl_webform_update_10003(): string {
  * Remove last traces of faulty webform translation.
  */
 function dpl_webform_update_10004(): string {
-  // Let's try to re-run the deletion of lang.da.webform_settings.
-  // We add it in a try catch, to avoid any issues incase it has already
-  // been deleted.
-  try {
-    dpl_webform_update_10003();
-  }
-  catch (Exception) {
+  $feedback = [];
 
+  // Rerun deletion of existing translation. It will have been recreated if
+  // translation import has run after dpl_webform_update_10003() as the
+  // translation will be lingering in the local string storage.
+  try {
+    $feedback[] = dpl_webform_update_10003();
+  }
+  catch (\Throwable $t) {
+    $feedback[] = "Unable to rerun dpl_webform_update_10003: {$t->getMessage()}.";
   }
 
   $translation_storage = DrupalTyped::service(StringStorageInterface::class, 'locale.storage');
+  // webform.settings:test:names is the part of the configuration with invalid
+  // data. This is set as the translation context so we can query based on this.
   $translation = $translation_storage->findTranslation(['context' => 'webform.settings:test:names']);
   if ($translation) {
     $translation->delete();
-    return 'Deleted faulty translation for webform.settings:test:names';
+    $feedback[] = 'Deleted faulty local translation string for webform.settings:test:names.';
   }
   else {
-    return 'Unable to locate faulty translation for webform.settings:test:names.';
+    $feedback[] = 'Unable to locate faulty local translation string for webform.settings:test:names.';
   }
+
+  return implode("\n", $feedback);
 }

--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -81,12 +81,23 @@ function dpl_webform_update_10003(): string {
  * Remove last traces of faulty webform translation.
  */
 function dpl_webform_update_10004(): string {
+  // Let's try to re-run the deletion of lang.da.webform_settings.
+  // We add it in a try catch, to avoid any issues incase it has already
+  // been deleted.
+  try {
+    dpl_webform_update_10003();
+  }
+  catch (Exception) {
+
+  }
+
   $translation_storage = DrupalTyped::service(StringStorageInterface::class, 'locale.storage');
   $translation = $translation_storage->findTranslation(['context' => 'webform.settings:test:names']);
   if ($translation) {
     $translation->delete();
     return 'Deleted faulty translation for webform.settings:test:names';
-  } else {
+  }
+  else {
     return 'Unable to locate faulty translation for webform.settings:test:names.';
   }
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFNEXT-354

#### Description

It turns out the way configuration translation is handled by the
config_translation module is:

1. Import the translation strings from the remove source into Drupal translation
   strings.
2. Import translation strings into configuration.

This causes problems when we want to remove a local faulty translation as in
dpl_webform_update_10003(). Even though we have removed the translated
configuration (1) it still lingers as a translation string (2). This will be i
ncluded in the translated configuration when rerunning the configuration
translation process.

Consequently: To remove the faulty translation for webform.settings entirely
we have to remove it from the local string translations as well.

The problematic part is in the test names part of the configuration so we can
query based on this.