### PR TITLE
Ignore drupal/potion with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,8 @@ updates:
           - "drupal/core*"
         update-types:
           - "patch"
+    ignore:
+      - dependency-name: 'drupal/potion'
     schedule:
       interval: weekly
       timezone: Europe/Copenhagen


### PR DESCRIPTION
#### Description

Dependabot seems to get confused with our locally defined package and fails with the error git_dependency_reference_not_found.

drupal/potion seems to be publicly unmaintained and heavily patched locally that it does not make sense to try to use dependabot to maintain it.

To avoid errors we ignore it instead.

#### Screenshot of the result

![dpl-cms 2024-07-15 22-51-27](https://github.com/user-attachments/assets/36fc238f-7b3a-4456-bd6c-57f00d58220b)

