### PR TITLE
Install Health check module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,6 +126,7 @@
         "drupal/gin_login": "^2.1",
         "drupal/gin_toolbar": "^1.0@RC",
         "drupal/handy_cache_tags": "^1.4",
+        "drupal/health_check": "^3.1",
         "drupal/honeypot": "^2.1",
         "drupal/job_scheduler": "^4.0",
         "drupal/jsnlog": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88871fb8deadf16e6a989e5b0bd25181",
+    "content-hash": "acce99f5bbb85b73b00393967299e8e4",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -4437,6 +4437,56 @@
             "homepage": "https://www.drupal.org/project/handy_cache_tags",
             "support": {
                 "source": "https://git.drupalcode.org/project/handy_cache_tags"
+            }
+        },
+        {
+            "name": "drupal/health_check",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/health_check.git",
+                "reference": "3.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/health_check-3.1.0.zip",
+                "reference": "3.1.0",
+                "shasum": "7c72666fa1c0c688f7f27f5cad2a0e29a934d5d0"
+            },
+            "require": {
+                "drupal/core": "^9.4 || ^10 || ^11",
+                "php": "^8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.1.0",
+                    "datestamp": "1718772797",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "back-2-95",
+                    "homepage": "https://www.drupal.org/user/327328"
+                },
+                {
+                    "name": "bfr",
+                    "homepage": "https://www.drupal.org/user/369262"
+                }
+            ],
+            "description": "Health check for load balancers",
+            "homepage": "https://www.drupal.org/project/health_check",
+            "support": {
+                "source": "https://git.drupalcode.org/project/health_check",
+                "issues": "https://www.drupal.org/project/issues/health_check"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -94,6 +94,7 @@ module:
   gin_login: 0
   gin_toolbar: 0
   handy_cache_tags: 0
+  health_check: 0
   honeypot: 0
   image: 0
   job_scheduler: 0

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -190,3 +190,10 @@ function dpl_update_update_10010() : string {
   }
   return "dpl_example_breadcrumb module was not located. Skipped removal";
 }
+
+/**
+ * Install health check module.
+ */
+function dpl_update_update_10011(): string {
+  return _dpl_update_install_modules(['health_check']);
+}


### PR DESCRIPTION
#### Description

This module provides an uncached endpoint at `/health` which checks whether Drupal
is able to bootstrap.

By checking this we should ensure that the site is in a relatively
healthy state - most importantly that we have a connection to the
database and that the cache is not corrupt. This will be useful for monitoring set up by @ITViking and @hypesystem.

The health check module provides a relatively simple module for doing
so, it is well-maintained and we have good experience using it in
other projects.

#### Additional comments or questions

Note that the module does not check for other aspects of a health site such as a recently ran cron, a working token to integrate with external systems and the like.

If we want such a check we need to look at more advanced solutions than the Health Check module.