### PR TITLE
Increase wait time for Lagoon PR environment deployments to 20 mins

### DIFF
--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -65,9 +65,9 @@ jobs:
         uses: iFaxity/wait-on-action@v1.1.0
         with:
           resource: ${{ steps.environment.outputs.url }}
-          # Time in ms. Wait for 15 mins for deployment to complete. We have
-          # seen deployments taking up to 12 mins.
-          timeout: 900000
+          # Time in ms. Wait for 20 mins for deployment to complete. We have
+          # seen deployments taking up to 17 mins.
+          timeout: 1200000
           # Poll every 10 seconds. For whatever reason Lagoon environments may
           # return 200 during the deployment process even though the deployment
           # is not complete. Reduce polling interval to the risk of this


### PR DESCRIPTION
#### Description

After enabling example content on environments deployments take even longer. The current situation leads to false negatives because the wait times out.

Increase time to 20 minutes to avoid this.