### PR TITLE
Remove `alt` text from watch icon

### DIFF
--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -40,7 +40,7 @@
             <div class="pagefold-triangle--medium"></div>
         </div>
         <a href="{{ opening_hours_url }}" class="header__clock-items">
-            <img loading="lazy" width="58" height="58" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" class="mb-8" alt="clock icon"/>
+            <img loading="lazy" width="58" height="58" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" class="mb-8" alt=""/>
             <span  class="text-small-caption">{{ "Opening hours"|t }}</span>
         </a>
     </div>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-761

#### Description

For accessibility purposes. The icon is marked as decorative since the link already contains descriptive text.

#### Test
https://varnish.pr-1437.dpl-cms.dplplat01.dpl.reload.dk/frontpage