### PR TITLE
Fix dev:reset task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -144,7 +144,7 @@ tasks:
       # (Re)run Drupal scaffolding.
       - task dev:cli -- composer drupal:scaffold
       # Build dev scripts
-      - task dev:cli -- $(cd dev-scripts/dpl-react; composer install)
+      - task dev:cli -- composer -d dev-scripts/dpl-react install
       # Pull the images (necessary for the first reset)
       - task dev:pull
       # Start local environment.


### PR DESCRIPTION
Using `$()` makes the shell insert the output of the subcommand into the outer command, which is not the intention here.

It "worked" due to the fact that the subshell was run locally by task, but I haven't figured out why the `task dev:cli` command then didn't fail when passed the output from the former command. Well it did for me, but for CI and everybody else that is.

Besides, running composer install locally rather than in the container is a very loose definition of "works".

The second problem is that `task dev:cli` doesn't actually support multiple CLI commands due to quoting and escaping, so I had to pass the working directory to composer as an argument. Making `cd <somewhere> && <some command>` work would require changing the `dev:cli` and checking up on each usage to provide the appropriate escaping/quoting, and that seems a bit invasive at this point.
