### PR TITLE
Show watch on small screens - DDFFORM-852 

### DIFF
--- a/cypress/e2e/adgangsplatformen.cy.ts
+++ b/cypress/e2e/adgangsplatformen.cy.ts
@@ -78,7 +78,7 @@ describe("Adgangsplatformen", () => {
     cy.clearCookies();
     cy.visit("/arrangementer");
     // Open user menu.
-    cy.get(".header__menu-profile").click();
+    cy.getBySel("header-menu-profile-button").click();
     // Click create profile.
     cy.get(".modal-login__btn-create-profile").click();
     cy.get("main#main-content")
@@ -104,7 +104,7 @@ describe("Adgangsplatformen", () => {
 
     cy.clearCookies();
     cy.visit("/arrangementer");
-    cy.get(".header__menu-profile").click();
+    cy.getBySel("header-menu-profile-button").click();
     cy.get(".modal-login__btn-create-profile").click();
     cy.get("main#main-content")
       .get(".paragraphs__item--user_registration_section__link")
@@ -140,7 +140,7 @@ describe("Adgangsplatformen", () => {
 
     cy.clearCookies();
     cy.visit("/arrangementer");
-    cy.get(".header__menu-profile").click();
+    cy.getBySel("header-menu-profile-button").click();
     cy.get(".modal-login__btn-create-profile").click();
     cy.get("main#main-content")
       .get(".paragraphs__item--user_registration_section__link")

--- a/web/themes/custom/novel/templates/layout/header.html.twig
+++ b/web/themes/custom/novel/templates/layout/header.html.twig
@@ -8,7 +8,7 @@
             <div>
                 <div class="header__menu-navigation-mobile">
                   <button
-                  class="header__menu-navigation-button header__button"
+                  class="header__button header__button--right-border"
                   id="header-sidebar-nav__toggle"
                   aria-controls="sidebarNav"
                   aria-expanded="false"
@@ -26,10 +26,14 @@
                 {{ drupal_menu('main') }}
             </div>
       {{ patron_menu }}
-            <div class="header__menu-bookmarked header__button">
-                <a href="{{ url('dpl_favorites_list.list') }}">
-                    <img width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt="{{ 'List of bookmarks'|t({}, {'context': 'Header'}) }}"/>
-                    <span class="text-small-caption">{{ "Liked"|t({}, {'context': 'Global'}) }}</span>
+            <div class="header__button-responsive-switch">
+                <a href="{{ opening_hours_url }}" class="header__button header__button--left-border">
+                    <img class="header__button-icon" loading="lazy" width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-watch-static.svg" alt="clock icon"/>
+                    <span  class="header__button-text">{{ "Opening hours"|t }}</span>
+                </a>
+                <a href="{{ url('dpl_favorites_list.list') }}" class="header__button header__button--left-border">
+                    <img class="header__button-icon" width="24" height="24" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-heart.svg" alt="{{ 'List of bookmarks'|t({}, {'context': 'Header'}) }}"/>
+                    <span class="header__button-text">{{ "Liked"|t({}, {'context': 'Global'}) }}</span>
                 </a>
             </div>
         </nav>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-852
https://www.figma.com/design/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem


#### Description
This pull request updates the markup and CSS classes to align with the changes in the dpl-design-system (see: [dpl-design-system PR #694](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/694)). The goal is to display the watch on small screens instead of the favorite list.

It depends on the following changes in the dpl-design-system and dpl-react, which should be merged before this one:

[dpl-design-system PR #694](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/694)
[dpl-react PR #1355](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1355)

#### Screenshots
<img width="533" alt="image" src="https://github.com/user-attachments/assets/3b9bfd7b-f9ac-43d4-a506-95a227f52e74">

<img width="992" alt="image" src="https://github.com/user-attachments/assets/8f4b611f-4dc4-46f4-96e7-b4569fe6cdc3">



#### Test
https://varnish.pr-1442.dpl-cms.dplplat01.dpl.reload.dk/frontpage