### PR TITLE
Event screen name

### DIFF
--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -57,7 +57,6 @@ third_party_settings:
       children:
         - field_categories
         - field_tags
-        - field_screen_names
       label: Tagging
       region: content
       parent_name: ''
@@ -80,6 +79,22 @@ third_party_settings:
       region: content
       parent_name: ''
       weight: 12
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
+    group_infoscreen:
+      children:
+        - field_screen_names
+      label: Infoscreen
+      region: content
+      parent_name: ''
+      weight: 15
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -295,7 +310,7 @@ content:
           dialog_style: tiles
   path:
     type: path
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_external_admin_link
+    - field.field.eventinstance.default.field_screen_names
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -56,6 +57,7 @@ third_party_settings:
       children:
         - field_categories
         - field_tags
+        - field_screen_names
       label: Tagging
       region: content
       parent_name: ''
@@ -219,13 +221,23 @@ content:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-  field_tags:
+  field_screen_names:
     type: select2_entity_reference
     weight: 7
     region: content
     settings:
       width: 100%
       autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
+  field_tags:
+    type: select2_entity_reference
+    weight: 6
+    region: content
+    settings:
+      width: 100%
+      autocomplete: true
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
     - field.field.eventseries.default.field_relevant_ticket_manager
+    - field.field.eventseries.default.field_screen_names
     - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
@@ -57,6 +58,7 @@ third_party_settings:
       children:
         - field_categories
         - field_tags
+        - field_screen_names
       label: Tagging
       region: content
       parent_name: ''
@@ -222,6 +224,16 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_screen_names:
+    type: select2_entity_reference
+    weight: 34
+    region: content
+    settings:
+      width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
     third_party_settings: {  }
   field_tags:
     type: select2_entity_reference

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -58,7 +58,6 @@ third_party_settings:
       children:
         - field_categories
         - field_tags
-        - field_screen_names
       label: Tagging
       region: content
       parent_name: ''
@@ -81,6 +80,22 @@ third_party_settings:
       region: content
       parent_name: ''
       weight: 21
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
+    group_infoscreen:
+      children:
+        - field_screen_names
+      label: Infoscreen
+      region: content
+      parent_name: ''
+      weight: 24
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -227,7 +242,7 @@ content:
     third_party_settings: {  }
   field_screen_names:
     type: select2_entity_reference
-    weight: 34
+    weight: 35
     region: content
     settings:
       width: 100%
@@ -305,7 +320,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 24
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.taxonomy_term.screen_name.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.screen_name.default.yml
@@ -1,0 +1,53 @@
+uuid: de724c1c-3c49-4e4c-aa3f-466895689de0
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.screen_name
+  module:
+    - path
+    - text
+id: taxonomy_term.screen_name.default
+targetEntityType: taxonomy_term
+bundle: screen_name
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  publish_on: true
+  unpublish_on: true

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_external_admin_link
+    - field.field.eventinstance.default.field_screen_names
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -75,6 +76,22 @@ content:
       format: default
       format_custom_false: ''
       format_custom_true: ''
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_name:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_names:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
     third_party_settings: {  }
     weight: 60
     region: content
@@ -144,6 +161,7 @@ hidden:
   field_event_state: true
   field_event_title: true
   field_external_admin_link: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -79,17 +79,9 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
-  event_screen_name:
-    type: entity_reference_label
-    label: visible
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 60
-    region: content
   event_screen_names:
     type: entity_reference_label
-    label: visible
+    label: above
     settings:
       link: true
     third_party_settings: {  }
@@ -122,7 +114,7 @@ content:
     region: content
   event_ticket_capacity:
     type: number_integer
-    label: visible
+    label: above
     settings:
       thousand_separator: ''
       prefix_suffix: true

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_external_admin_link
+    - field.field.eventinstance.default.field_screen_names
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -130,6 +131,14 @@ content:
     third_party_settings: {  }
     weight: 7
     region: content
+  event_screen_names:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
   event_tags:
     type: entity_reference_label
     label: hidden
@@ -191,6 +200,7 @@ hidden:
   body: true
   description: true
   event_relevant_ticket_manager: true
+  event_screen_name: true
   event_state: true
   event_ticket_capacity: true
   field_categories: true
@@ -203,6 +213,7 @@ hidden:
   field_event_state: true
   field_event_title: true
   field_external_admin_link: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -200,7 +200,6 @@ hidden:
   body: true
   description: true
   event_relevant_ticket_manager: true
-  event_screen_name: true
   event_state: true
   event_ticket_capacity: true
   field_categories: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -139,14 +139,6 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
-  event_screen_name:
-    type: entity_reference_label
-    label: visible
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 60
-    region: content
   event_screen_names:
     type: entity_reference_label
     label: visible

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_external_admin_link
+    - field.field.eventinstance.default.field_screen_names
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -138,6 +139,22 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
+  event_screen_name:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_names:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
   event_tags:
     type: entity_reference_label
     label: above
@@ -209,6 +226,7 @@ hidden:
   field_event_state: true
   field_event_title: true
   field_external_admin_link: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -142,14 +142,6 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
-  event_screen_name:
-    type: entity_reference_label
-    label: visible
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 60
-    region: content
   event_screen_names:
     type: entity_reference_label
     label: visible

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_external_admin_link
+    - field.field.eventinstance.default.field_screen_names
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -141,6 +142,22 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
+  event_screen_name:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_names:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
   event_tags:
     type: entity_reference_label
     label: above
@@ -201,6 +218,7 @@ hidden:
   field_event_state: true
   field_event_title: true
   field_external_admin_link: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser_stacked_parent.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser_stacked_parent.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_external_admin_link
+    - field.field.eventinstance.default.field_screen_names
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -141,6 +142,22 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
+  event_screen_name:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_names:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
   event_tags:
     type: entity_reference_label
     label: hidden
@@ -208,6 +225,7 @@ hidden:
   field_event_state: true
   field_event_title: true
   field_external_admin_link: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser_stacked_parent.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser_stacked_parent.yml
@@ -142,14 +142,6 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
-  event_screen_name:
-    type: entity_reference_label
-    label: visible
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 60
-    region: content
   event_screen_names:
     type: entity_reference_label
     label: visible

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
@@ -55,14 +55,6 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
-  event_screen_name:
-    type: entity_reference_label
-    label: visible
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 60
-    region: content
   event_screen_names:
     type: entity_reference_label
     label: visible

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_external_admin_link
+    - field.field.eventinstance.default.field_screen_names
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -51,6 +52,22 @@ content:
       format: default
       format_custom_false: ''
       format_custom_true: ''
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_name:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_names:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
     third_party_settings: {  }
     weight: 60
     region: content
@@ -115,6 +132,7 @@ hidden:
   field_event_state: true
   field_event_title: true
   field_external_admin_link: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_external_admin_link
+    - field.field.eventinstance.default.field_screen_names
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -51,6 +52,22 @@ content:
       format: default
       format_custom_false: ''
       format_custom_true: ''
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_name:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_names:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
     third_party_settings: {  }
     weight: 60
     region: content
@@ -108,6 +125,7 @@ hidden:
   field_event_state: true
   field_event_title: true
   field_external_admin_link: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_ticket_capacity: true

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
@@ -55,14 +55,6 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
-  event_screen_name:
-    type: entity_reference_label
-    label: visible
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 60
-    region: content
   event_screen_names:
     type: entity_reference_label
     label: visible

--- a/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
@@ -84,14 +84,6 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
-  event_screen_name:
-    type: entity_reference_label
-    label: visible
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 60
-    region: content
   event_screen_names:
     type: entity_reference_label
     label: visible

--- a/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.eventinstance.default.field_event_state
     - field.field.eventinstance.default.field_event_title
     - field.field.eventinstance.default.field_external_admin_link
+    - field.field.eventinstance.default.field_screen_names
     - field.field.eventinstance.default.field_tags
     - field.field.eventinstance.default.field_teaser_image
     - field.field.eventinstance.default.field_teaser_text
@@ -83,6 +84,22 @@ content:
     third_party_settings: {  }
     weight: 60
     region: content
+  event_screen_name:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
+  event_screen_names:
+    type: entity_reference_label
+    label: visible
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 60
+    region: content
   event_ticket_capacity:
     type: number_integer
     label: visible
@@ -127,6 +144,7 @@ hidden:
   field_event_state: true
   field_event_title: true
   field_external_admin_link: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventseries.default.card.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.card.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
     - field.field.eventseries.default.field_relevant_ticket_manager
+    - field.field.eventseries.default.field_screen_names
     - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
@@ -80,6 +81,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_relevant_ticket_manager: true
+  field_screen_names: true
   field_tags: true
   field_ticket_capacity: true
   field_ticket_categories: true

--- a/config/sync/core.entity_view_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
     - field.field.eventseries.default.field_relevant_ticket_manager
+    - field.field.eventseries.default.field_screen_names
     - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
@@ -166,6 +167,7 @@ hidden:
   event_registration: true
   field_event_state: true
   field_relevant_ticket_manager: true
+  field_screen_names: true
   field_ticket_capacity: true
   monthly_recurring_date: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.eventseries.default.list.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.list.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
     - field.field.eventseries.default.field_relevant_ticket_manager
+    - field.field.eventseries.default.field_screen_names
     - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
@@ -54,6 +55,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_relevant_ticket_manager: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true

--- a/config/sync/core.entity_view_display.eventseries.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.nav_spot.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
     - field.field.eventseries.default.field_relevant_ticket_manager
+    - field.field.eventseries.default.field_screen_names
     - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
@@ -71,6 +72,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_relevant_ticket_manager: true
+  field_screen_names: true
   field_tags: true
   field_ticket_capacity: true
   field_ticket_categories: true

--- a/config/sync/core.entity_view_display.eventseries.default.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.nav_teaser.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.eventseries.default.field_event_place
     - field.field.eventseries.default.field_event_state
     - field.field.eventseries.default.field_relevant_ticket_manager
+    - field.field.eventseries.default.field_screen_names
     - field.field.eventseries.default.field_tags
     - field.field.eventseries.default.field_teaser_image
     - field.field.eventseries.default.field_teaser_text
@@ -62,6 +63,7 @@ hidden:
   field_event_place: true
   field_event_state: true
   field_relevant_ticket_manager: true
+  field_screen_names: true
   field_tags: true
   field_teaser_image: true
   field_ticket_capacity: true

--- a/config/sync/field.field.eventinstance.default.field_screen_names.yml
+++ b/config/sync/field.field.eventinstance.default.field_screen_names.yml
@@ -1,0 +1,29 @@
+uuid: 6cb51b10-df02-4bf8-aa68-ef641a1dd1a1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventinstance.field_screen_names
+    - recurring_events.eventinstance_type.default
+    - taxonomy.vocabulary.screen_name
+id: eventinstance.default.field_screen_names
+field_name: field_screen_names
+entity_type: eventinstance
+bundle: default
+label: 'Screen names'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      screen_name: screen_name
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.eventinstance.default.field_screen_names.yml
+++ b/config/sync/field.field.eventinstance.default.field_screen_names.yml
@@ -11,7 +11,7 @@ field_name: field_screen_names
 entity_type: eventinstance
 bundle: default
 label: 'Screen names'
-description: ''
+description: 'Select which screens to display this event on. '
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.eventseries.default.field_screen_names.yml
+++ b/config/sync/field.field.eventseries.default.field_screen_names.yml
@@ -1,0 +1,29 @@
+uuid: 1587448d-7660-4bd9-849c-d0de6318a5a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventseries.field_screen_names
+    - recurring_events.eventseries_type.default
+    - taxonomy.vocabulary.screen_name
+id: eventseries.default.field_screen_names
+field_name: field_screen_names
+entity_type: eventseries
+bundle: default
+label: 'Screen names'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      screen_name: screen_name
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.eventseries.default.field_screen_names.yml
+++ b/config/sync/field.field.eventseries.default.field_screen_names.yml
@@ -11,7 +11,7 @@ field_name: field_screen_names
 entity_type: eventseries
 bundle: default
 label: 'Screen names'
-description: ''
+description: 'Select which screens to display this event on.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.storage.eventinstance.field_screen_names.yml
+++ b/config/sync/field.storage.eventinstance.field_screen_names.yml
@@ -1,0 +1,20 @@
+uuid: b56885e7-70a1-4449-af48-edd59248dc55
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+    - taxonomy
+id: eventinstance.field_screen_names
+field_name: field_screen_names
+entity_type: eventinstance
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.eventseries.field_screen_names.yml
+++ b/config/sync/field.storage.eventseries.field_screen_names.yml
@@ -1,0 +1,20 @@
+uuid: 10baea55-1be7-453c-9578-13ad99e319a7
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+    - taxonomy
+id: eventseries.field_screen_names
+field_name: field_screen_names
+entity_type: eventseries
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field_inheritance.field_inheritance.eventinstance_default_event_screen_names.yml
+++ b/config/sync/field_inheritance.field_inheritance.eventinstance_default_event_screen_names.yml
@@ -1,0 +1,14 @@
+uuid: 96438ecf-b991-4e51-b0be-860c23dfc8cf
+langcode: en
+status: true
+dependencies: {  }
+id: eventinstance_default_event_screen_names
+label: 'Event screen names'
+type: fallback
+sourceEntityType: eventseries
+sourceEntityBundle: default
+sourceField: field_screen_names
+destinationEntityType: eventinstance
+destinationEntityBundle: default
+destinationField: field_screen_names
+plugin: entity_reference_inheritance

--- a/config/sync/language.content_settings.taxonomy_term.screen_name.yml
+++ b/config/sync/language.content_settings.taxonomy_term.screen_name.yml
@@ -1,0 +1,11 @@
+uuid: 1775adfc-d12c-49ab-964a-71e30d949c91
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.screen_name
+id: taxonomy_term.screen_name
+target_entity_type_id: taxonomy_term
+target_bundle: screen_name
+default_langcode: da
+language_alterable: false

--- a/config/sync/taxonomy.vocabulary.screen_name.yml
+++ b/config/sync/taxonomy.vocabulary.screen_name.yml
@@ -1,0 +1,29 @@
+uuid: 956b17d2-80b6-410b-8f23-b728b068287a
+langcode: da
+status: true
+dependencies:
+  module:
+    - scheduler
+    - taxonomy_unique
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+  taxonomy_unique:
+    enabled: false
+    message: 'Term "%term" already exists in vocabulary "%vocabulary".'
+name: 'Screen name'
+vid: screen_name
+description: 'Screens to display content on'
+weight: 0
+new_revision: false

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -19,6 +19,7 @@ dependencies:
     - taxonomy.vocabulary.breadcrumb_structure
     - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.opening_hours_categories
+    - taxonomy.vocabulary.screen_name
     - taxonomy.vocabulary.tags
     - taxonomy.vocabulary.webform_email_categories
   module:
@@ -140,6 +141,7 @@ permissions:
   - 'create terms in breadcrumb_structure'
   - 'create terms in categories'
   - 'create terms in opening_hours_categories'
+  - 'create terms in screen_name'
   - 'create terms in tags'
   - 'create terms in webform_email_categories'
   - 'create url aliases'
@@ -183,6 +185,7 @@ permissions:
   - 'delete terms in breadcrumb_structure'
   - 'delete terms in categories'
   - 'delete terms in opening_hours_categories'
+  - 'delete terms in screen_name'
   - 'delete terms in tags'
   - 'delete terms in webform_email_categories'
   - 'disable cookie information consent'
@@ -216,6 +219,7 @@ permissions:
   - 'edit terms in breadcrumb_structure'
   - 'edit terms in categories'
   - 'edit terms in opening_hours_categories'
+  - 'edit terms in screen_name'
   - 'edit terms in tags'
   - 'edit terms in webform_email_categories'
   - 'edit themes novel'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -19,6 +19,7 @@ dependencies:
     - taxonomy.vocabulary.breadcrumb_structure
     - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.opening_hours_categories
+    - taxonomy.vocabulary.screen_name
     - taxonomy.vocabulary.tags
     - taxonomy.vocabulary.webform_email_categories
   module:
@@ -113,6 +114,7 @@ permissions:
   - 'create terms in breadcrumb_structure'
   - 'create terms in categories'
   - 'create terms in opening_hours_categories'
+  - 'create terms in screen_name'
   - 'create terms in tags'
   - 'create terms in webform_email_categories'
   - 'create url aliases'
@@ -183,6 +185,7 @@ permissions:
   - 'edit terms in breadcrumb_structure'
   - 'edit terms in categories'
   - 'edit terms in opening_hours_categories'
+  - 'edit terms in screen_name'
   - 'edit terms in tags'
   - 'edit terms in webform_email_categories'
   - 'edit themes novel'

--- a/openapi.json
+++ b/openapi.json
@@ -1079,6 +1079,14 @@
                         "description": "An absolute URL provided by the third party where editorial users can administer the event. Accessing this URL should require authentication."
                       }
                     }
+                  },
+                  "screen_names": {
+                    "type": "array",
+                    "description": "The screens this event should be shown on.",
+                    "items": {
+                      "type": "string",
+                      "description": "A screen name."
+                    }
                   }
                 },
                 "required": ["uuid", "title", "created_at", "updated_at", "url", "state", "date_time"]

--- a/packages/cms-api/Model/EventsGET200ResponseInner.php
+++ b/packages/cms-api/Model/EventsGET200ResponseInner.php
@@ -241,6 +241,18 @@ class EventsGET200ResponseInner
     protected ?EventPATCHRequestExternalData $externalData = null;
 
     /**
+     * The screens this event should be shown on.
+     *
+     * @var string[]|null
+     * @SerializedName("screen_names")
+     * @Assert\All({
+     *   @Assert\Type("string")
+     * })
+     * @Type("array<string>")
+     */
+    protected ?array $screenNames = null;
+
+    /**
      * Constructor
      * @param array|null $data Associated array of property values initializing the model
      */
@@ -266,6 +278,7 @@ class EventsGET200ResponseInner
             $this->series = array_key_exists('series', $data) ? $data['series'] : $this->series;
             $this->body = array_key_exists('body', $data) ? $data['body'] : $this->body;
             $this->externalData = array_key_exists('externalData', $data) ? $data['externalData'] : $this->externalData;
+            $this->screenNames = array_key_exists('screenNames', $data) ? $data['screenNames'] : $this->screenNames;
         }
     }
 
@@ -759,6 +772,32 @@ class EventsGET200ResponseInner
     public function setExternalData(?EventPATCHRequestExternalData $externalData = null): self
     {
         $this->externalData = $externalData;
+
+        return $this;
+    }
+
+    /**
+     * Gets screenNames.
+     *
+     * @return string[]|null
+     */
+    public function getScreenNames(): ?array
+    {
+        return $this->screenNames;
+    }
+
+
+
+    /**
+     * Sets screenNames.
+     *
+     * @param string[]|null $screenNames  The screens this event should be shown on.
+     *
+     * @return $this
+     */
+    public function setScreenNames(?array $screenNames = null): self
+    {
+        $this->screenNames = $screenNames;
 
         return $this;
     }

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -309,7 +309,13 @@ function dpl_event_entity_query_taxonomy_vocabulary_alter(QueryInterface $query)
  * Alter event forms to hide screen names when the feature is disabled.
  */
 function dpl_event_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
-  if (!in_array($form_id, ['eventseries_default_edit_form', 'eventinstance_default_edit_form'])) {
+  $forms = [
+    'eventseries_default_edit_form',
+    'eventseries_default_add_form',
+    'eventinstance_default_edit_form',
+    'eventinstance_default_add_form',
+  ];
+  if (!in_array($form_id, $forms)) {
     return;
   }
 

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -8,9 +8,12 @@
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\dpl_event\EventState;
 use Drupal\dpl_event\EventWrapper;
+use Drupal\dpl_event\Form\SettingsForm;
 use Drupal\dpl_event\Workflows\OccurredSchedule;
 use Drupal\dpl_event\Workflows\UnpublishSchedule;
 use Drupal\drupal_typed\DrupalTyped;
@@ -286,4 +289,35 @@ function dpl_event_gin_content_form_routes() : array {
     'entity.eventseries.add_instance_form',
     'entity.eventinstance.edit_form',
   ];
+}
+
+/**
+ * Implements hook_entity_query_TAG_alter().
+ *
+ * Alter vocabulary queries to hide the vocabulary when the screens feature
+ * is disabled.
+ */
+function dpl_event_entity_query_taxonomy_vocabulary_alter(QueryInterface $query): void {
+  if (!\Drupal::config(SettingsForm::CONFIG_NAME)->get('enable_screen_name')) {
+    $query->condition('vid', 'screen_name', '<>');
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Alter event forms to hide screen names when the feature is disabled.
+ */
+function dpl_event_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  if (!in_array($form_id, ['eventseries_default_edit_form', 'eventinstance_default_edit_form'])) {
+    return;
+  }
+
+  if (\Drupal::config(SettingsForm::CONFIG_NAME)->get('enable_screen_name')) {
+    return;
+  }
+
+  if (isset($form['field_screen_names'])) {
+    $form['field_screen_names']['#access'] = FALSE;
+  }
 }

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -318,7 +318,9 @@ function dpl_event_form_alter(array &$form, FormStateInterface $form_state, stri
   }
 
   // Undo select2s adding of help text.
-  if (isset($form['field_screen_names']['widget']['#description']['#items'])) {
+  if (isset($form['field_screen_names']['widget']['#description']) &&
+      is_array($form['field_screen_names']['widget']['#description']) &&
+      is_array($form['field_screen_names']['widget']['#description']['#items'])) {
     $form['field_screen_names']['widget']['#description'] =
       $form['field_screen_names']['widget']['#description']['#items'][0];
   }

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -313,11 +313,19 @@ function dpl_event_form_alter(array &$form, FormStateInterface $form_state, stri
     return;
   }
 
+  if (!isset($form['field_screen_names'])) {
+    return;
+  }
+
+  // Undo select2s adding of help text.
+  if (isset($form['field_screen_names']['widget']['#description']['#items'])) {
+    $form['field_screen_names']['widget']['#description'] =
+      $form['field_screen_names']['widget']['#description']['#items'][0];
+  }
+
   if (\Drupal::config(SettingsForm::CONFIG_NAME)->get('enable_screen_name')) {
     return;
   }
 
-  if (isset($form['field_screen_names'])) {
-    $form['field_screen_names']['#access'] = FALSE;
-  }
+  $form['field_screen_names']['#access'] = FALSE;
 }

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -294,8 +294,11 @@ function dpl_event_gin_content_form_routes() : array {
 /**
  * Implements hook_entity_query_TAG_alter().
  *
- * Alter vocabulary queries to hide the vocabulary when the screens feature
- * is disabled.
+ * Deny access to the screen name vocabulary when the feature is disabled.
+ *
+ * This is to totally hide the vocabulary when the feature is disabled.
+ *
+ * hook_entity_query_TAG_alter() is the way to hook into `accessCheck(TRUE)`.
  */
 function dpl_event_entity_query_taxonomy_vocabulary_alter(QueryInterface $query): void {
   if (!\Drupal::config(SettingsForm::CONFIG_NAME)->get('enable_screen_name')) {

--- a/web/modules/custom/dpl_event/src/EventWrapper.php
+++ b/web/modules/custom/dpl_event/src/EventWrapper.php
@@ -121,6 +121,25 @@ class EventWrapper {
   }
 
   /**
+   * Getting associated screen names.
+   *
+   * @return string[]
+   *   The screen names.
+   */
+  public function getScreenNames(): array {
+    $names = [];
+
+    /** @var \Drupal\taxonomy\TermInterface[] $screens */
+    $screens = $this->event->get('event_screen_names')->referencedEntities();
+
+    foreach ($screens as $screen) {
+      $names[] = $screen->getName();
+    }
+
+    return $names;
+  }
+
+  /**
    * Get the EventState object of an eventinstance.
    */
   public function getState(): ?EventState {

--- a/web/modules/custom/dpl_event/src/Form/SettingsForm.php
+++ b/web/modules/custom/dpl_event/src/Form/SettingsForm.php
@@ -108,6 +108,13 @@ final class SettingsForm extends ConfigFormBase {
       '#description' => $this->t('How much time should pass after an event has occurred before it should be unpublished automatically.', [], ['context' => "DPL event"]),
     ];
 
+    $form['enable_screen_name'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable screen names'),
+      '#default_value' => $config->get('enable_screen_name'),
+      '#description' => $this->t('Enable screen names on events. Requires an external system to actually fetch and display the events on real physical screens.'),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -118,6 +125,7 @@ final class SettingsForm extends ConfigFormBase {
     $this->config(self::CONFIG_NAME)
       ->set('price_currency', $form_state->getValue('price_currency'))
       ->set('unpublish_schedule', $form_state->getValue('unpublish_schedule'))
+      ->set('enable_screen_name', $form_state->getValue('enable_screen_name'))
       ->save();
     parent::submitForm($form, $form_state);
 

--- a/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
+++ b/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
@@ -245,6 +245,14 @@ final class EventsResource extends EventResourceBase {
                       ],
                     ],
                   ],
+                  'screen_names' => [
+                    'type' => 'array',
+                    'description' => 'The screens this event should be shown on.',
+                    'items' => [
+                      'type' => 'string',
+                      'description' => 'A screen name.',
+                    ],
+                  ],
                 ],
                 'required' => ['uuid', 'title', 'created_at', 'updated_at', 'url', 'state', 'date_time'],
               ],

--- a/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
+++ b/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
@@ -73,6 +73,7 @@ class EventRestMapper {
       'series' => new EventsGET200ResponseInnerSeries([
         'uuid' => $this->event->getEventSeries()->uuid(),
       ]),
+      'screenNames' => $this->eventWrapper->getScreenNames(),
     ]);
   }
 

--- a/web/modules/custom/dpl_update/dpl_update.deploy.php
+++ b/web/modules/custom/dpl_update/dpl_update.deploy.php
@@ -250,3 +250,10 @@ function dpl_update_deploy_field_relevant_ticket_manager(): string {
 function dpl_update_deploy_update_term_url_aliases(): string {
   return _dpl_update_generate_url_aliases('taxonomy_term');
 }
+
+/**
+ * Link new event_screen_names inheritance on eventinstances.
+ */
+function dpl_update_update_screen_name_field_inheritance(): string {
+  return _dpl_update_field_inheritance('event_screen_names');
+}


### PR DESCRIPTION
#### Link to issue

[KBHBIB-14](https://reload.atlassian.net/browse/KBHBIB-14)

#### Description

Adds a screen name to events, for external screen systems.

Screens are simply taxonomy terms. Appropriate fields have been added to event series and instances, and the `/api/v1/events` API extended with an extra field.

A setting has been added to `/admin/config/dpl-event/settings` to enable the feature (disabled per default). When the feature is disabled, the vocabulary and the fields on events are hidden, but the data isn't deleted. 

#### Screenshot of the result

![image](https://github.com/user-attachments/assets/9592b87c-2a58-4a68-a273-0cdc5d35f5ea)
![image](https://github.com/user-attachments/assets/e5c4544b-7c51-4a0f-99d0-6e4829d51bf2)

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.


[KBHBIB-14]: https://reload.atlassian.net/browse/KBHBIB-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ