### PR TITLE
Use same user in cli container as the others

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -106,6 +106,8 @@ jobs:
     name: Test site performance using Lighthouse
     runs-on: ubuntu-latest
     steps:
+      - name: Set UID environment variable
+        run: echo "UID=$(id -u)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           # Our Taskfile requires a proper checkout to function because of
@@ -129,6 +131,8 @@ jobs:
     name: Test accessibility using Pa11y
     runs-on: ubuntu-latest
     steps:
+      - name: Set UID environment variable
+        run: echo "UID=$(id -u)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           # Our Taskfile requires a proper checkout to function because of
@@ -153,6 +157,8 @@ jobs:
     name: Run Cypress functional tests
     runs-on: ubuntu-latest
     steps:
+      - name: Set UID environment variable
+        run: echo "UID=$(id -u)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           # Our Taskfile requires a proper checkout to function because of
@@ -260,6 +266,8 @@ jobs:
     name: Check OpenAPI specification
     runs-on: ubuntu-latest
     steps:
+      - name: Set UID environment variable
+        run: echo "UID=$(id -u)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           # Our Taskfile requires a proper checkout to function because of
@@ -286,6 +294,8 @@ jobs:
     name: Check Drupal Config
     runs-on: ubuntu-latest
     steps:
+      - name: Set UID environment variable
+        run: echo "UID=$(id -u)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           # Our Taskfile requires a proper checkout to function because of

--- a/.github/workflows/translate-source.yml
+++ b/.github/workflows/translate-source.yml
@@ -21,6 +21,8 @@ jobs:
     env:
       LANGUAGE: da
     steps:
+      - name: Set UID environment variable
+        run: echo "UID=$(id -u)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -67,6 +69,8 @@ jobs:
     env:
       LANGUAGE: da
     steps:
+      - name: Set UID environment variable
+        run: echo "UID=$(id -u)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,10 @@ x-volumes:
 
 x-user:
   &default-user
-    # The default user under which the containers should run. Change this if you are on linux and run with another user than id `1000`
-    user: '1000'
+    # The default user under which the containers should run. If you
+    # are on Linux and your UID is something other than 1000, set the
+    # UID environment variable to you UID (`export UID=$(id -u)`).
+    user: '${UID:-1000}'
 
 x-environment:
   &default-environment
@@ -61,8 +63,8 @@ services:
       context: .
       dockerfile: lagoon/cli.dockerfile
     image: &cli-image uselagoon/php-8.1-cli-drupal:latest # this image will be reused as `CLI_IMAGE` in subsequent Docker builds
-    << : *default-volumes # loads the defined volumes from the top
-    user: root
+    # loads the defined volumes and user from the top
+    <<: [*default-volumes, *default-user]
     environment:
       << : *default-environment # loads the defined environment variables from the top
       # Uncomment to enable xdebug for cli tools


### PR DESCRIPTION
Use the same user in the cli container as the others. Means that files created by running cli commands aren't owned by root, causing user inconvenience.