### PR TITLE
Unset beta setting for GIN, so save button is always visible.

### DIFF
--- a/config/sync/gin.settings.yml
+++ b/config/sync/gin.settings.yml
@@ -23,4 +23,4 @@ focus_color: ''
 layout_density: medium
 show_description_toggle: false
 show_user_theme_settings: false
-sticky_action_buttons: true
+sticky_action_buttons: false


### PR DESCRIPTION
As part of the module update, a BETA function for the gin admin theme was enabled, that placed save buttons in the top, as sticky. This however breaks the experience when editing views (and maybe other also places).
