### PR TITLE
Re-factor and fix admin list of users. DDFFORM-952

### DIFF
--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -22,6 +22,7 @@ dependencies:
     - taxonomy.vocabulary.tags
     - taxonomy.vocabulary.webform_email_categories
   module:
+    - administerusersbyrole
     - content_lock
     - dpl_admin
     - dpl_footer
@@ -57,6 +58,8 @@ permissions:
   - 'access site in maintenance mode'
   - 'access taxonomy overview'
   - 'access toolbar'
+  - 'access user profiles'
+  - 'access users overview'
   - 'access webform overview'
   - 'add eventseries entity'
   - 'add new links to main menu'
@@ -183,3 +186,4 @@ permissions:
   - 'view unpublished eventinstance entity'
   - 'view unpublished eventseries entity'
   - 'view unpublished paragraphs'
+  - 'view users by role'

--- a/config/sync/user.role.external_system.yml
+++ b/config/sync/user.role.external_system.yml
@@ -6,6 +6,7 @@ dependencies:
     - rest.resource.event
     - rest.resource.events
   module:
+    - administerusersbyrole
     - openapi
     - rest
     - system
@@ -18,6 +19,8 @@ permissions:
   - 'access administration pages'
   - 'access openapi api docs'
   - 'access toolbar'
+  - 'access user profiles'
   - 'restful get events'
   - 'restful patch event'
   - 'view the administration theme'
+  - 'view users by role'

--- a/config/sync/user.role.mediator.yml
+++ b/config/sync/user.role.mediator.yml
@@ -14,6 +14,7 @@ dependencies:
     - node.type.page
     - taxonomy.vocabulary.tags
   module:
+    - administerusersbyrole
     - content_lock
     - dpl_admin
     - entity_clone
@@ -44,6 +45,8 @@ permissions:
   - 'access site in maintenance mode'
   - 'access taxonomy overview'
   - 'access toolbar'
+  - 'access user profiles'
+  - 'access users overview'
   - 'add eventseries entity'
   - 'administer entity field inheritance'
   - 'administer redirects'
@@ -118,3 +121,4 @@ permissions:
   - 'view unpublished eventinstance entity'
   - 'view unpublished eventseries entity'
   - 'view unpublished paragraphs'
+  - 'view users by role'

--- a/config/sync/views.view.administerusersbyrole_people.yml
+++ b/config/sync/views.view.administerusersbyrole_people.yml
@@ -1,6 +1,6 @@
 uuid: 50de8267-3970-4e5c-9dd1-d444caad143c
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - field.storage.user.field_author_name

--- a/config/sync/views.view.user_admin_people.yml
+++ b/config/sync/views.view.user_admin_people.yml
@@ -1,9 +1,10 @@
 uuid: 6513da2f-8a2a-4aa6-ad90-0b472a9cb9e9
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - field.storage.user.field_author_name
+    - user.role.patron
   module:
     - user
 _core:
@@ -74,6 +75,70 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+        mail:
+          id: mail
+          table: users_field_data
+          field: mail
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         name:
           id: name
           table: users_field_data
@@ -134,11 +199,11 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: Name
+          label: 'Name & Email'
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ field_author_name__value }} <br><small>{{ mail }}</small>'
             make_link: false
             path: ''
             absolute: false
@@ -203,7 +268,7 @@ display:
           exclude: false
           alter:
             alter_text: false
-            text: ''
+            text: '{{ status__value }} '
             make_link: false
             path: ''
             absolute: false
@@ -240,11 +305,22 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          click_sort_column: value
           type: boolean
           settings:
             format: custom
             format_custom_false: Blocked
             format_custom_true: Active
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         roles_target_id:
           id: roles_target_id
           table: user__roles
@@ -459,70 +535,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-        mail:
-          id: mail
-          table: users_field_data
-          field: mail
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: user
-          entity_field: mail
-          plugin_id: field
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: basic_string
-          settings: {  }
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
       pager:
         type: full
         options:
@@ -558,7 +570,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'administer users'
+          perm: 'access users overview'
       cache:
         type: tag
       empty:
@@ -815,24 +827,23 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        uid_raw:
-          id: uid_raw
-          table: users_field_data
-          field: uid_raw
+        roles_target_id_1:
+          id: roles_target_id_1
+          table: user__roles
+          field: roles_target_id
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: user
-          plugin_id: numeric
-          operator: '!='
+          entity_field: roles
+          plugin_id: user_roles
+          operator: not
           value:
-            min: ''
-            max: ''
-            value: '0'
+            patron: patron
           group: 1
           exposed: false
           expose:
-            operator_id: '0'
+            operator_id: ''
             label: ''
             description: ''
             use_operator: false
@@ -845,6 +856,7 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            reduce: false
           is_grouped: false
           group_info:
             label: ''
@@ -857,6 +869,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          reduce_duplicates: false
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
The module `administerusersbyrole` introduced its own version of /admin/people, but this view has a bug, meaning editors cannot see administrators.
I've disabled this view, and re-enabled and tweaked the core view.

https://reload.atlassian.net/browse/DDFFORM-952

You can test it, by logging in as `local_administrator`, and see that https://varnish.pr-1448.dpl-cms.dplplat01.dpl.reload.dk/admin/people shows `administrator`