### PR TITLE
Use `.uri` for links to avoid proxy problems where `:` are changed to `%3A` - DDFFORM-811

### DIFF
--- a/web/themes/custom/novel/templates/components/hero.html.twig
+++ b/web/themes/custom/novel/templates/components/hero.html.twig
@@ -6,9 +6,9 @@
 %}
 
 <section {{ attributes.addClass(classes) }}>
-  {% if link %}
-    {% set url = link.0['#url'] %}
-    {% set target = url.options.target|default('_self') %}
+  {% if link.0 %}
+    {% set url = link.0['#url'].external ? link.0['#url'].uri : link.0['#url'].toString() %}
+    {% set target = link.0['#url'].options.target|default('_self') %}
 
     <a href="{{ url }}" target="{{ target }}" class="hero__content arrow arrow__hover--right-large">
       {% include "@novel/components/hero-inner.html.twig" %}

--- a/web/themes/custom/novel/templates/fields/field--field-event-link.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--field-event-link.html.twig
@@ -1,6 +1,6 @@
 {% if has_event_link %}
   {% for item in items %}
-      {% set url = item.content['#url'].toString() %}
+      {% set url = item.content['#url'].external ? item.content['#url'].uri : item.content['#url'].toString() %}
       {% set title = item.content['#title'] %}
 
       {% set classes = [

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--banner.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--banner.html.twig
@@ -7,8 +7,8 @@
   {% endif %}
 {% endif %}
 
-{% set url = content.field_banner_link[0]['#url'] %}
-{% set target = url.options.target|default('_self') %}
+{% set url = content.field_banner_link[0]['#url'].external ? content.field_banner_link[0]['#url'].uri : content.field_banner_link[0]['#url'].toString() %}
+{% set target = content.field_banner_link[0]['#url'].options.target|default('_self') %}
 
 <a href="{{ url }}" target="{{ target }}" class="banner arrow__hover--right-large {{ image_url ? 'banner--has-image' : '' }}"
   {% if image_url %} style="background-image: url('{{ image_url }}');" {% endif %}>

--- a/web/themes/custom/novel/templates/paragraphs/paragraph--simple-links.html.twig
+++ b/web/themes/custom/novel/templates/paragraphs/paragraph--simple-links.html.twig
@@ -1,7 +1,7 @@
 {% for item in content.field_link %}
   {% if item['#type'] == 'link' %}
-    <a href="{{ item['#url'].toString() }}" target="{{ item['#options'].attributes.target|default('_self') }}"
-       class="simple-link arrow__hover--right-small">
+    {% set url = item['#url'].external ? item['#url'].uri : item['#url'].toString() %}
+    <a href="{{ url }}" target="{{ item['#options'].attributes.target|default('_self') }}" class="simple-link arrow__hover--right-small">
       {{ item['#title'] }}
       {{ source(baseIconPath ~ '/arrow-ui/icon-arrow-ui-small-right.svg') }}    </a>
   {% endif %}


### PR DESCRIPTION
#### Link to Issue
https://reload.atlassian.net/browse/DDFFORM-811

#### Description
This pull request addresses the proxy issue where `:` is changed to `%3A` in external links. To resolve this, I have used `.uri` instead of `['#url']`.

This adjustment applies to external links, including:
- Hero
- Banner
- Simple-links
- Event-link

Internal links are excluded since they do not encounter this problem:
- Card-grids
- User-registration

#### Test 
https://varnish.pr-1474.dpl-cms.dplplat01.dpl.reload.dk/paragraph-side


##### Note
A ticket might need to be created for this.

If an external link is added in card-grids, it results in an error that isn't very descriptive.

<img width="1398" alt="image" src="https://github.com/user-attachments/assets/16d7855d-8ad9-43f7-8d36-f1cef271055c">

It is also not intended for external links to be added here, but I would have expected an error message in the paragraph.
