### PR TITLE
Insert missing blocked reason

### DIFF
--- a/web/modules/custom/dpl_fbs/src/Patron/BlockedReason.php
+++ b/web/modules/custom/dpl_fbs/src/Patron/BlockedReason.php
@@ -14,6 +14,7 @@ use MyCLabs\Enum\Enum;
  * @method static BlockedReason EXTENDED_SUSPENSION()
  * @method static BlockedReason SUSPENSION()
  * @method static BlockedReason ACCOUNT_STOLEN()
+ * @method static BlockedReason FEE()
  * @method static BlockedReason MISSING_PATRON_CATEGORY()
  * @method static BlockedReason UNKNOWN()
  */
@@ -24,6 +25,7 @@ class BlockedReason extends Enum {
   private const EXTENDED_SUSPENSION = 'F';
   private const SUSPENSION = 'U';
   private const ACCOUNT_STOLEN = 'O';
+  private const FEE = 'E';
   /**
    * The user has not been assigned a correct patron category.
    *


### PR DESCRIPTION
The reason is used (in the moment of this writing) in the frontend and might be useful in the future in the backend as well.
