### PR TITLE
Allow setting any end time for events. DDFFORM-877 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -363,7 +363,8 @@
                 "3468521: (1/4) When changing recurrance, identical date combinations should not be deleted and recreated": "https://git.drupalcode.org/project/recurring_events/-/commit/67261f4ac34546f2c9514199d9febb6dcce6fd10.patch",
                 "3468521: (2/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/603d34936b97535f66e11429dcc9a2c61fc7cb40.patch",
                 "3468521: (3/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad8a4294b1ffb754a338bb2cfa0146f203aa6fc1.patch",
-                "3468521: (4/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad99ae79f5c55fc2db17427e9936ab141314609d.patch"
+                "3468521: (4/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad99ae79f5c55fc2db17427e9936ab141314609d.patch",
+                "xxx": "https://git.drupalcode.org/project/recurring_events/-/merge_requests/104.patch"
             },
             "drupal/theme_permission": {
                 "3105637: Edit, install and uninstall permission": "https://www.drupal.org/files/issues/2024-02-01/theme-permission-edit-install-uninstall-3105637-7.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ef474525d222039727484711e755b63",
+    "content-hash": "dcee3ff2132cb26ec966228540a61dca",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/recurring_events.eventseries.config.yml
+++ b/config/sync/recurring_events.eventseries.config.yml
@@ -1,8 +1,8 @@
 _core:
   default_config_hash: HuNc0wdz6BZa5IceY8HDpVfwTwqvp1rpRQeuS5szwSo
-interval: 15
-min_time: '08:00am'
-max_time: '11:45pm'
+interval: 0
+min_time: '08:00'
+max_time: '23:59'
 date_format: 'd/m/y - H:i'
 time_format: 'H:i'
 days: 'monday,tuesday,wednesday,thursday,friday,saturday,sunday'


### PR DESCRIPTION
Updating the module, means that some of the upstream patches have been merged.
This commit also adds a new upstream patch, made by us. The patch fixes it, so the editor can create events that start at 00:00.

https://www.drupal.org/project/recurring_events/issues/3468300

Description of patch:

> Up until now, the min_time/max_time in the settings form, are just text fields, that take data in AM/PM.
> This is problematic, because the code that parses it, fails when an editor has inserted "00:00".
> This commit changes the form to instead use time inputs, and ports any existing data to the new format.
> This also makes the new format 24h instead of 12h.

#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-877

