### PR TITLE
Add UUID for ticket prices in event API. DDFFORM-966

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -987,6 +987,11 @@
                     "items": {
                       "type": "object",
                       "properties": {
+                        "uuid": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "A unique identifier for the ticket category."
+                        },
                         "title": {
                           "type": "string",
                           "description": "The name of the ticket category."

--- a/packages/cms-api/Model/EventsGET200ResponseInnerTicketCategoriesInner.php
+++ b/packages/cms-api/Model/EventsGET200ResponseInnerTicketCategoriesInner.php
@@ -44,6 +44,16 @@ use JMS\Serializer\Annotation\SerializedName;
 class EventsGET200ResponseInnerTicketCategoriesInner 
 {
         /**
+     * A unique identifier for the ticket category.
+     *
+     * @var string|null
+     * @SerializedName("uuid")
+     * @Assert\Type("string")
+     * @Type("string")
+     */
+    protected ?string $uuid = null;
+
+    /**
      * The name of the ticket category.
      *
      * @var string|null
@@ -71,9 +81,36 @@ class EventsGET200ResponseInnerTicketCategoriesInner
     public function __construct(array $data = null)
     {
         if (is_array($data)) {
+            $this->uuid = array_key_exists('uuid', $data) ? $data['uuid'] : $this->uuid;
             $this->title = array_key_exists('title', $data) ? $data['title'] : $this->title;
             $this->price = array_key_exists('price', $data) ? $data['price'] : $this->price;
         }
+    }
+
+    /**
+     * Gets uuid.
+     *
+     * @return string|null
+     */
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+    }
+
+
+
+    /**
+     * Sets uuid.
+     *
+     * @param string|null $uuid  A unique identifier for the ticket category.
+     *
+     * @return $this
+     */
+    public function setUuid(?string $uuid = null): self
+    {
+        $this->uuid = $uuid;
+
+        return $this;
     }
 
     /**

--- a/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
+++ b/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
@@ -169,6 +169,11 @@ final class EventsResource extends EventResourceBase {
                     'items' => [
                       'type' => 'object',
                       'properties' => [
+                        'uuid' => [
+                          'type' => 'string',
+                          'format' => 'uuid',
+                          'description' => 'A unique identifier for the ticket category.',
+                        ],
                         'title' => [
                           'type' => 'string',
                           'description' => 'The name of the ticket category.',

--- a/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
+++ b/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
@@ -211,6 +211,7 @@ class EventRestMapper {
       ]);
 
       $categories[] = new EventsGET200ResponseInnerTicketCategoriesInner([
+        'uuid' => $paragraph->uuid(),
         'title' => $title,
         'price' => $price,
       ]);


### PR DESCRIPTION
This is to avoid problems for ticket manager systems, when an editor fixes a typo in the name of a ticket.

https://reload.atlassian.net/browse/DDFFORM-966

https://varnish.pr-1487.dpl-cms.dplplat01.dpl.reload.dk/api/v1/events

<img width="486" alt="Screenshot 2024-08-19 at 08 35 54" src="https://github.com/user-attachments/assets/60c10998-fd76-48a2-8844-d81d941ccc05">
