### PR TITLE
DDFLSBP-785 - Add update hooks for fixing webform configuration translations

### DIFF
--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -7,6 +7,7 @@
 
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\locale\StringStorageInterface;
+use function Safe\preg_match;
 
 /**
  * Add all webforms to config ignore.
@@ -103,6 +104,92 @@ function dpl_webform_update_10004(): string {
   }
   else {
     $feedback[] = 'Unable to locate faulty local translation string for webform.settings:test:names.';
+  }
+
+  return implode("\n", $feedback);
+}
+
+/**
+ * Set default language to english.
+ *
+ * We have experienced issues with the default site language being set to
+ * danish, which causes issues when doing configuration translations. To
+ * prevent this in the future, we now set the default language to english.
+ */
+function dpl_webform_update_10005(): string {
+  $feedback = [];
+
+  \Drupal::configFactory()->getEditable('system.site')->set('langcode', 'en')->save();
+  \Drupal::configFactory()->getEditable('system.site')->set('default_langcode', 'en')->save();
+
+  return implode("\n", $feedback);
+}
+
+/**
+ * Remove unwanted webform settings from config ignore.
+ *
+ * Some libraries has been able to add unwanted webform settings to the
+ * config ignore list. This is preventing us from fixing some faulty
+ * webform translation configurations. This update hook will remove all
+ * webform.webform_options.* and webform.settings from the ignore list.
+ */
+function dpl_webform_update_10006(): string {
+  $config_factory = \Drupal::configFactory();
+  $config_ignore_auto_settings = $config_factory->getEditable('config_ignore_auto.settings');
+  $ignored_configs = $config_ignore_auto_settings->get('ignored_config_entities');
+
+  // Remove webform.settings from config ignore list.
+  if (($key = array_search('webform.settings', $ignored_configs)) !== FALSE) {
+    unset($ignored_configs[$key]);
+    $config_ignore_auto_settings->set('ignored_config_entities', $ignored_configs)->save();
+    $feedback[] = "Removed 'webform.settings' from ignored_config_entities.";
+  }
+  else {
+    $feedback[] = "Config 'webform.settings' not found in ignored_config_entities.";
+  }
+
+  // Filter out all strings matching the pattern webform.webform_options.*.
+  $pattern_to_remove = '/^webform\.webform_options\..*/';
+  $filtered_configs = array_filter($ignored_configs, function ($config) use ($pattern_to_remove) {
+    return !preg_match($pattern_to_remove, $config);
+  });
+
+  if (count($ignored_configs) !== count($filtered_configs)) {
+    $config_ignore_auto_settings->set('ignored_config_entities', array_values($filtered_configs))->save();
+    $feedback[] = "Removed all strings matching 'webform.webform_options.*' from ignored_config_entities.";
+  }
+  else {
+    $feedback[] = "No strings matching 'webform.webform_options.*' found in ignored_config_entities.";
+  }
+  return implode("\n", $feedback);
+}
+
+/**
+ * Rerun old update hooks.
+ *
+ * Some earlier update hooks did not have the desired effect due to
+ * some configuration ignore issues. We will rerun the update hooks
+ * here again, to make sure that we have deleted all faulty translations.
+ * We rerun update_10002 to delete existing contact webform translations.
+ * We rerun update 10004 to make sure to delete faulty translations with
+ * duplicate keys.
+ */
+function dpl_webform_update_10007(): string {
+
+  $feedback = [];
+
+  try {
+    $feedback[] = dpl_webform_update_10002();
+  }
+  catch (\Throwable $t) {
+    $feedback[] = "Unable to rerun dpl_webform_update_10002: {$t->getMessage()}.";
+  }
+
+  try {
+    $feedback[] = dpl_webform_update_10004();
+  }
+  catch (\Throwable $t) {
+    $feedback[] = "Unable to rerun dpl_webform_update_10004: {$t->getMessage()}.";
   }
 
   return implode("\n", $feedback);

--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -137,7 +137,7 @@ function dpl_webform_update_10006(): string {
   $ignored_configs = $config_ignore_auto_settings->get('ignored_config_entities');
 
   // Remove webform.settings from config ignore list.
-  if (($key = array_search('webform.settings', $ignored_configs))) {
+  if (($key = array_search('webform.settings', $ignored_configs)) !== FALSE) {
     unset($ignored_configs[$key]);
     $config_ignore_auto_settings->set('ignored_config_entities', $ignored_configs)->save();
     $feedback[] = "Removed 'webform.settings' from ignored_config_entities.";
@@ -165,10 +165,11 @@ function dpl_webform_update_10006(): string {
 /**
  * Rerun old update hooks.
  *
- * Some earlier update hooks did not have the desired effect due to
- * some configuration ignore issues. We will rerun the update hooks
- * here again, to make sure that we have deleted all faulty translations.
+ * Some earlier update hooks did not have the desired effect due to some
+ * configuration ignore issues. We will rerun the code from the update
+ * hooks again, to make sure that we have deleted all faulty translations.
  * We rerun update_10002 to delete existing contact webform translations.
+ * We rerun update_10003 to delete existing webform.settings translations.
  * We rerun update 10004 to make sure to delete faulty translations with
  * duplicate keys.
  */
@@ -176,18 +177,35 @@ function dpl_webform_update_10007(): string {
 
   $feedback = [];
 
-  try {
-    $feedback[] = dpl_webform_update_10002();
-  }
-  catch (\Throwable $t) {
-    $feedback[] = "Unable to rerun dpl_webform_update_10002: {$t->getMessage()}.";
-  }
+  // Rerun update_10002 update hook.
+  $webform_id = 'webform.webform.contact';
+  $language = 'da';
 
-  try {
-    $feedback[] = dpl_webform_update_10004();
+  /** @var \Drupal\language\Config\LanguageConfigFactoryOverride $language_config_factory_override */
+  $language_config_factory_override = \Drupal::service('language.config_factory_override');
+  $language_config_factory_override->getOverride($language, $webform_id)->delete();
+  $feedback[] = 'All translations for the webform ' . $webform_id . ' have been deleted.';
+
+  // Rerun update_10003 update hook.
+  $config_id = 'webform.settings';
+
+  /** @var \Drupal\language\Config\LanguageConfigFactoryOverride $language_config_factory_override */
+  $language_config_factory_override = \Drupal::service('language.config_factory_override');
+  $language_config_factory_override->getOverride($language, $config_id)->delete();
+
+  $feedback[] = "DA translations for the $config_id have been deleted.";
+
+  // Rerun update_10004 update hook.
+  $translation_storage = DrupalTyped::service(StringStorageInterface::class, 'locale.storage');
+  // webform.settings:test:names is the part of the configuration with invalid
+  // data. This is set as the translation context so we can query based on this.
+  $translation = $translation_storage->findTranslation(['context' => 'webform.settings:test:names']);
+  if ($translation) {
+    $translation->delete();
+    $feedback[] = 'Deleted faulty local translation string for webform.settings:test:names.';
   }
-  catch (\Throwable $t) {
-    $feedback[] = "Unable to rerun dpl_webform_update_10004: {$t->getMessage()}.";
+  else {
+    $feedback[] = 'Unable to locate faulty local translation string for webform.settings:test:names.';
   }
 
   return implode("\n", $feedback);

--- a/web/modules/custom/dpl_webform/dpl_webform.install
+++ b/web/modules/custom/dpl_webform/dpl_webform.install
@@ -117,12 +117,10 @@ function dpl_webform_update_10004(): string {
  * prevent this in the future, we now set the default language to english.
  */
 function dpl_webform_update_10005(): string {
-  $feedback = [];
-
   \Drupal::configFactory()->getEditable('system.site')->set('langcode', 'en')->save();
   \Drupal::configFactory()->getEditable('system.site')->set('default_langcode', 'en')->save();
 
-  return implode("\n", $feedback);
+  return "The 'langcode' and 'default_language' has been set to english.";
 }
 
 /**
@@ -139,7 +137,7 @@ function dpl_webform_update_10006(): string {
   $ignored_configs = $config_ignore_auto_settings->get('ignored_config_entities');
 
   // Remove webform.settings from config ignore list.
-  if (($key = array_search('webform.settings', $ignored_configs)) !== FALSE) {
+  if (($key = array_search('webform.settings', $ignored_configs))) {
     unset($ignored_configs[$key]);
     $config_ignore_auto_settings->set('ignored_config_entities', $ignored_configs)->save();
     $feedback[] = "Removed 'webform.settings' from ignored_config_entities.";


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-785

#### Description

We have experiences problems with faulty translated webform configurations, such as wrong formatted yaml files and duplicate keys. This has been fixed for most libraries using update hooks in earlier PR's:
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1391
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1397

However it seems that the update hooks haven't been running successfully on all library sites. We have located 8 libraries where this is the case:
- Fredensborg
- Frederiksberg
- Halsnæs
- Horsens
- Næstved
- Norddjurs
- Tårnby
- Thisted

What they all have in common is that the language and default_language has been changed to danish instead of english. Furthermore webform.settings and webform.webform_options.* settings have been added to the ignored_config_entities list. 
The best guess for this is that the auto_ignore module has added them to the list, before we had the chance to restrict access to the specific configurations.

To solve the above issue, this PR adds 3 new webform update hooks:
1. Sets the langcode and default langcode back to english for websites who are currently set to danish. We do not want the langcode to be danish as it messes up the translation of configurations.

2. Removes unwanted webform configuration from ignored_config list. Specifically it removes webform.settings.yml and webform-webform_options.* from the ignore list. We don't want these config ignored, as it prevent us from fixing earlier configuration translation errors.

3. Reruns some of the earlier update hooks that fixes configuration translation errors. On some sites, they were not run successfully because of config ignore.
