### PR TITLE
Cache event views based on time and cache tags 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -359,6 +359,9 @@
                 "3451613: Start date of weekly reccurring event jumps incorrectly": "https://git.drupalcode.org/project/recurring_events/-/commit/581c53dd1b0b067a8b6454d76cc0187887f7b187.patch",
                 "3461740: Fatal error when using 'Event series start date' filter in views": "https://www.drupal.org/files/issues/2024-07-16/reccuring_events_event_start_date.patch"
             },
+            "drupal/search_api": {
+                "3414725: Tag- and time-based views cache plugin": "https://git.drupalcode.org/issue/search_api-3414725/-/commit/d84c193ab35991464e77423d0ec33f2623f24f0d.patch"
+            },
             "drupal/theme_permission": {
                 "3105637: Edit, install and uninstall permission": "https://www.drupal.org/files/issues/2024-02-01/theme-permission-edit-install-uninstall-3105637-7.patch",
                 "3458263: WSOD error fails on Drupal 10.3+": "https://www.drupal.org/files/issues/2024-07-01/theme_permssion-d10_3_d11.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "866e32c1241163882e64b92d29697b2b",
+    "content-hash": "b04b6c0b6d892f724e16d8037374c333",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -159,8 +159,12 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: none
-        options: {  }
+        type: search_api_time_tag
+        options:
+          results_lifespan: '3600'
+          results_lifespan_custom: '0'
+          output_lifespan: '3600'
+          output_lifespan_custom: '0'
       empty: {  }
       sorts:
         date:
@@ -308,6 +312,8 @@ display:
         - url.query_args
         - user.permissions
       tags:
+        - 'config:facets.facet.branch'
+        - 'config:facets.facet.event_categories'
         - 'config:search_api.index.events'
         - 'search_api_list:events'
   related:


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-876

#### Description

Currently events views do not use caching. This is because we usually
do not want to show events which have occurred (and are thus less
relevant) *and* we want editorial changes to take effect as quickly
as possible.

Handling the relative time of event occurrence and the editorial
changes (which is usually related to cache tags) has not been
possible.

To address this situation we have added a patch for Search API views.
This adds a cache plugin which supports both.

Configure this new cache plugin for our event based views with a
maximum of 1 hour cache lifetime.

This should ensure that the event list gets cached to reduce resource
usage and produce faster responses and that cached results are updated
relatively frequently so we do not show outdated responses even if
there are no editorial changes.

Results should be cached both in Varnish which targets anonymous users
and in the Drupal Dynamic Cache which targets patrons and editorial
users.

#### Screenshot of the result

Cache headers on the evens list for anonymous and authenticated users.

Before:

<img width="2554" alt="Monosnap Events | DPL CMS — Privat browsing 2024-08-20 13-51-17" src="https://github.com/user-attachments/assets/5978c6fa-1895-43a6-a7d2-0b572726e548">

After:

<img width="2551" alt="Monosnap Events | DPL CMS 2024-08-20 13-35-58" src="https://github.com/user-attachments/assets/52a65a2a-e6ba-4de3-952b-ab0f2294537d">
