### PR TITLE
Fix cache render array entry names for related content

### DIFF
--- a/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
+++ b/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
@@ -254,8 +254,8 @@ class RelatedContent {
       // cache tags, and even a time-based cache.
       '#cache' => [
         // Max age of 12 hours.
-        '#max-age' => (60 * 60 * 12),
-        '#tags' => ['eventinstance_list', 'eventseries_list', 'node_list'],
+        'max-age' => (60 * 60 * 12),
+        'tags' => ['eventinstance_list', 'eventseries_list', 'node_list'],
       ],
     ];
   }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-971

#### Description

We want to ensure that cached related content is purged appropriately
by providing cache configuration entries in the render array.

The current cache configuration entries are prefixed with #. According
to the documentation they should not be.

Consequently related content lists are cached more aggressively than
they should be.

Remove the prefix to address this.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

This change merely fixes the render array cache entry. I wonder if the current value of 12 hours  is to lax for up to date event lists. #1498 sets a lifetime of 1 hour. We could do the same here - or change the value in #1498 to 12 hours.