### PR TITLE
Redirect legacy paths for library search and materials to new paths DDFFORM-978

### DIFF
--- a/lagoon/conf/nginx/server_append_drupal_rewrite_legacy_search_works.conf
+++ b/lagoon/conf/nginx/server_append_drupal_rewrite_legacy_search_works.conf
@@ -1,0 +1,31 @@
+# Redirect paths for library search and materials to new urls.
+#
+# For all redirects we:
+# - Use permanent redirects to ensure that the new urls are picked up properly
+#   by search engines.
+# - Strip all query parameters in the process as we do not have a reliable way
+#   to transform these.
+
+# Redirect search queries
+#
+# Legacy paths:
+# - /search/ting/harry potter
+# - /search/ting/harry%20potter?&facets%5B%5D=facet.category%3Avoksenmaterialer
+# - /search/ting/harry%20potter?page=1
+# New path:
+# - /search?q=harry%2520potter
+rewrite ^/search/ting/([^/?]+) /search?q=$1? permanent;
+
+# Redirect materials.
+# The legacy system had separate paths for works (collections) and
+# manifestations (objects). The current system only promoted works so redirect
+# both to the work url.
+# This only works because there currently is a simple translation from the
+# id (pid) of a manifestation to the id of the corresponding work.
+#
+# Legacy paths:
+# - /ting/collection/870970-basis%3A47086868
+# - /ting/object/870970-basis%3A47086868
+# New path:
+# - /work/work-of:870970-basis%3A47086868
+rewrite ^/ting/(object|collection)/([^/?]+) /work/work-of:$2? permanent;

--- a/lagoon/nginx.dockerfile
+++ b/lagoon/nginx.dockerfile
@@ -17,5 +17,8 @@ RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_modules_local.
 COPY lagoon/conf/nginx/server_append_drupal_rewrite_registration.conf /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_registration.conf
 RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_registration.conf
 
+COPY lagoon/conf/nginx/server_append_drupal_rewrite_legacy_search_works.conf /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_legacy_search_works.conf
+RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_legacy_search_works.conf
+
 # Define where the Drupal Root is located
 ENV WEBROOT=web


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-978

#### Description

Add NGINX configuration which sets up the redirects.

This has been implemented on the NGINX level as this part of the system already has a setup for modifying the default configuration and this should be a relatively efficient solution.

Alternate solutions would include:
- PHP: This would make the redirects computationally more expensive to execute as Drupal would need to be bootstrapped first and would occupy a FPM worker. With the right headers each redirect could be cached in Varnish.
- Varnish: This might make the redirects even faster but we do not have a setup for modifying the existing VCL.

#### Additional comments or questions

You can test this out by visiting some of the mentioned urls in the code on the PR environment:

- http://varnish.pr-1508.dpl-cms.dplplat01.dpl.reload.dk/search/ting/harry%20potter
- http://varnish.pr-1508.dpl-cms.dplplat01.dpl.reload.dk/search/ting/harry%20potter?&facets%5B%5D=facet.category%3Avoksenmaterialer
- http://varnish.pr-1508.dpl-cms.dplplat01.dpl.reload.dk/search/ting/harry%20potter?page=1
- http://varnish.pr-1508.dpl-cms.dplplat01.dpl.reload.dk/ting/collection/870970-basis%3A47086868
- http://varnish.pr-1508.dpl-cms.dplplat01.dpl.reload.dk/ting/object/870970-basis%3A47086868

This should be mirrored in the NGINX configuration in https://github.com/danskernesdigitalebibliotek/dpl-platform/tree/main/infrastructure/dpladm/env-repo-template/standard/lagoon so it can take effect on the production sites.