### PR TITLE
Revert "Cache event views based on time and cache tags "

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -359,9 +359,6 @@
                 "3451613: Start date of weekly reccurring event jumps incorrectly": "https://git.drupalcode.org/project/recurring_events/-/commit/581c53dd1b0b067a8b6454d76cc0187887f7b187.patch",
                 "3461740: Fatal error when using 'Event series start date' filter in views": "https://www.drupal.org/files/issues/2024-07-16/reccuring_events_event_start_date.patch"
             },
-            "drupal/search_api": {
-                "3414725: Tag- and time-based views cache plugin": "https://git.drupalcode.org/issue/search_api-3414725/-/commit/d84c193ab35991464e77423d0ec33f2623f24f0d.patch"
-            },
             "drupal/theme_permission": {
                 "3105637: Edit, install and uninstall permission": "https://www.drupal.org/files/issues/2024-02-01/theme-permission-edit-install-uninstall-3105637-7.patch",
                 "3458263: WSOD error fails on Drupal 10.3+": "https://www.drupal.org/files/issues/2024-07-01/theme_permssion-d10_3_d11.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b04b6c0b6d892f724e16d8037374c333",
+    "content-hash": "866e32c1241163882e64b92d29697b2b",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -159,12 +159,8 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: search_api_time_tag
-        options:
-          results_lifespan: '3600'
-          results_lifespan_custom: '0'
-          output_lifespan: '3600'
-          output_lifespan_custom: '0'
+        type: none
+        options: {  }
       empty: {  }
       sorts:
         date:
@@ -312,8 +308,6 @@ display:
         - url.query_args
         - user.permissions
       tags:
-        - 'config:facets.facet.branch'
-        - 'config:facets.facet.event_categories'
         - 'config:search_api.index.events'
         - 'search_api_list:events'
   related:


### PR DESCRIPTION
Reverts danskernesdigitalebibliotek/dpl-cms#1498

According to https://www.drupal.org/project/search_api/issues/3414725#comment-15742253 the provided change does not work. The configured max age is added but none of the cache tags.

Using the updated patch provided by the maintainer requires us to update Search API as well so for now we just revert.