### PR TITLE
Pin Node 20 image used for CI to version 24.7.0

### DIFF
--- a/docker/node-chromium.dockerfile
+++ b/docker/node-chromium.dockerfile
@@ -1,4 +1,4 @@
-FROM uselagoon/node-20-builder
+FROM uselagoon/node-20-builder:24.7.0
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true


### PR DESCRIPTION
#### Description

We have started seeing different errors related to Chrome in our CI the last three days. This corresponds to the release of version 24.8.0 of the uselagoon/node-20-builder which we use for this purpose.

Pin the image to the previous release to see if this fixes the issue.

#### Additional comments or questions

Examples of failing PRs include:

- https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1516
- https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1522

With Lighthouse the error is usually:

```
Runtime error encountered: Waiting for DevTools protocol response has exceeded the allotted time. (Method: Network.emulateNetworkConditions)
LHError: PROTOCOL_TIMEOUT
    at Timeout.<anonymous> (/app/node_modules/lighthouse/lighthouse-core/gather/driver.js:322:21)
    at listOnTimeout (node:internal/timers:581:17)
    at process.processTimers (node:internal/timers:519:7)
```

[According to the Lagoon release notes one of the significant updates in 24.8.0 is the update of the base image to Alpine 3.2.0](https://github.com/uselagoon/lagoon-images/releases/tag/24.8.0). This might be the root cause of our problems. We will have to find a way to address this going forward to keep our stack up to date - either by fixing the issue or switching to a different image.