### PR TITLE
DDFFORM-66 - Add fulltext search to `articles` and `events` views

### DIFF
--- a/config/sync/search_api.index.content.yml
+++ b/config/sync/search_api.index.content.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.storage.node.field_branch
     - field.storage.node.field_categories
     - field.storage.node.field_publication_date
+    - field.storage.node.field_subtitle
+    - field.storage.node.field_teaser_text
     - search_api.server.db_search
   module:
     - node
@@ -47,6 +49,22 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_publication_date
+  field_subtitle:
+    label: Subtitle
+    datasource_id: 'entity:node'
+    property_path: field_subtitle
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_subtitle
+  field_teaser_text:
+    label: 'Teaser text'
+    datasource_id: 'entity:node'
+    property_path: field_teaser_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_teaser_text
   status:
     label: Published
     datasource_id: 'entity:node'
@@ -59,7 +77,7 @@ field_settings:
     label: Title
     datasource_id: 'entity:node'
     property_path: title
-    type: string
+    type: text
     dependencies:
       module:
         - node
@@ -84,6 +102,15 @@ processor_settings:
   aggregated_field: {  }
   custom_value: {  }
   entity_type: {  }
+  ignorecase:
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
+    all_fields: false
+    fields:
+      - field_subtitle
+      - title
+      - type
   language_with_fallback: {  }
   rendered_item: {  }
 tracker_settings:

--- a/config/sync/search_api.index.events.yml
+++ b/config/sync/search_api.index.events.yml
@@ -45,6 +45,14 @@ field_settings:
     dependencies:
       module:
         - field_inheritance
+  event_description:
+    label: 'Event description'
+    datasource_id: 'entity:eventinstance'
+    property_path: event_description
+    type: text
+    dependencies:
+      module:
+        - field_inheritance
   event_tags:
     label: 'Event tags'
     datasource_id: 'entity:eventinstance'
@@ -61,6 +69,14 @@ field_settings:
     dependencies:
       module:
         - recurring_events
+  title:
+    label: 'Event title'
+    datasource_id: 'entity:eventinstance'
+    property_path: title
+    type: text
+    dependencies:
+      module:
+        - field_inheritance
 datasource_settings:
   'entity:eventinstance':
     bundles:
@@ -74,6 +90,14 @@ processor_settings:
   aggregated_field: {  }
   custom_value: {  }
   entity_type: {  }
+  ignorecase:
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
+    all_fields: true
+    fields:
+      - event_description
+      - title
   language_with_fallback: {  }
   rendered_item: {  }
 tracker_settings:

--- a/config/sync/views.view.articles.yml
+++ b/config/sync/views.view.articles.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_branch
     - search_api.index.content
   module:
+    - better_exposed_filters
     - search_api
     - user
     - views_infinite_scroll
@@ -120,7 +121,7 @@ display:
             automatically_load_content: false
             initially_load_all_pages: true
       exposed_form:
-        type: basic
+        type: bef
         options:
           submit_button: Apply
           reset_button: false
@@ -129,6 +130,34 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: basic
+          bef:
+            general:
+              autosubmit: true
+              autosubmit_exclude_textfield: false
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: true
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+              reset_button_always_show: false
+            filter:
+              search_api_fulltext:
+                plugin_id: default
+                advanced:
+                  placeholder_text: ''
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: false
       access:
         type: perm
         options:
@@ -232,6 +261,58 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_content
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: and
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search_api_fulltext
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+            expose_fields: false
+            placeholder: Søg
+            searched_fields_id: search_api_fulltext_searched_fields
+            value_maxlength: 128
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields: {  }
       style:
         type: default
       row:
@@ -259,6 +340,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
@@ -279,6 +361,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions

--- a/config/sync/views.view.articles.yml
+++ b/config/sync/views.view.articles.yml
@@ -165,7 +165,20 @@ display:
       cache:
         type: none
         options: {  }
-      empty: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'Unfortunately, there were no results for your search. Try using a different search term.'
+            format: basic
+          tokenize: false
       sorts:
         field_publication_date:
           id: field_publication_date

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -261,6 +261,58 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_events
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: and
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search_api_fulltext
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+            expose_fields: false
+            placeholder: 'Søg'
+            searched_fields_id: search_api_fulltext_searched_fields
+            value_maxlength: 128
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields: {  }
       style:
         type: default
       row:
@@ -277,7 +329,7 @@ display:
           preserve_facet_query_args: false
           query_tags: {  }
       relationships: {  }
-      use_ajax: true
+      use_ajax: false
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -285,6 +337,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags:
@@ -305,6 +358,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url
         - url.query_args
         - user.permissions
       tags:

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -295,7 +295,7 @@ display:
               patron: '0'
               external_system: '0'
             expose_fields: false
-            placeholder: 'Søg'
+            placeholder: Søg
             searched_fields_id: search_api_fulltext_searched_fields
             value_maxlength: 128
           is_grouped: false

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -161,7 +161,20 @@ display:
       cache:
         type: none
         options: {  }
-      empty: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'Unfortunately, there were no results for your search. Try using a different search term.'
+            format: basic
+          tokenize: false
       sorts:
         date:
           id: date

--- a/web/modules/custom/dpl_search/templates/dpl-search-header.html.twig
+++ b/web/modules/custom/dpl_search/templates/dpl-search-header.html.twig
@@ -2,7 +2,7 @@
   <form class="header__menu-search" action="{{ url(form_route) }}">
     <label class="hide-visually">{{ 'Search content'|trans }}</label>
     <input required value="{{ default_input }}" name="search" class="header__menu-search-input text-body-medium-regular" type="text" placeholder="{{ 'Search the website'|trans }}" aria-label="{{ 'Search the website'|trans }}" aria-activedescendant aria-expanded="false" autocomplete="off">
-    <input alt="{{ 'Search button'|trans }}" class="header__menu-search-icon"
+    <input alt="{{ 'Search'|trans }}" class="header__menu-search-icon"
       type="image" src="data:image/svg+xml,%3csvg width='24' height='24' viewBox='-2 -2 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.5 0C13.1944 0 17 3.80558 17 8.5C17 10.5772 16.2549 12.4804 15.0173 13.9569L19.5303 18.4697C19.8232 18.7626 19.8232 19.2374 19.5303 19.5303C19.2641 19.7966 18.8474 19.8208 18.5538 19.6029L18.4697 19.5303L13.9569 15.0173C12.4804 16.2549 10.5772 17 8.5 17C3.80558 17 0 13.1944 0 8.5C0 3.80558 3.80558 0 8.5 0ZM8.5 1.5C4.63401 1.5 1.5 4.63401 1.5 8.5C1.5 12.366 4.63401 15.5 8.5 15.5C12.366 15.5 15.5 12.366 15.5 8.5C15.5 4.63401 12.366 1.5 8.5 1.5Z' fill='black'/%3e %3c/svg%3e">
   </form>
 </div>

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -294,6 +294,39 @@ function novel_theme_suggestions_select_alter(array &$suggestions, array $variab
 }
 
 /**
+ * Implements hook_theme_suggestions_form_alter().
+ */
+function novel_theme_suggestions_form_alter(array &$suggestions, array $variables): void {
+  $form_id = $variables['element']['#form_id'] ?? NULL;
+
+  if ($form_id) {
+    $suggestions[] = "form__$form_id";
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_form_element_alter().
+ */
+function novel_theme_suggestions_form_element_alter(array &$suggestions, array $variables): void {
+  $name = $variables['element']['#name'] ?? NULL;
+
+  if ($name) {
+    $suggestions[] = "form_element__$name";
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_input_alter().
+ */
+function novel_theme_suggestions_input_alter(array &$suggestions, array $variables): void {
+  $name = $variables['element']['#name'] ?? NULL;
+
+  if ($name) {
+    $suggestions[] = "input__$name";
+  }
+}
+
+/**
  * Preprocesses rows in a Drupal view to handle the display of event instances.
  *
  * Introduces an 'shouldBeStacked' attribute for event items to specify whether

--- a/web/themes/custom/novel/templates/views/facets-item-list--dropdown.html.twig
+++ b/web/themes/custom/novel/templates/views/facets-item-list--dropdown.html.twig
@@ -16,10 +16,10 @@
 {%- endif %}
 
 <label class="input-label" id="facet_{{ facet.id }}_label">{{ facet.label }}</label>
-<div class="dropdown">
+<div class="dropdown dropdown--grey-borders">
   {% if items or empty %}
     {%- if items -%}
-      <{{ list_type }}{{ attributes.addClass("dropdown__select") }}>
+      <{{ list_type }}{{ attributes.addClass(['dropdown__select', 'dropdown__select--grey']) }}>
       {%- for item in items -%}
         <li{{ item.attributes }}>{{ item.value }}</li>
       {%- endfor -%}

--- a/web/themes/custom/novel/templates/views/form--views-exposed-form.html.twig
+++ b/web/themes/custom/novel/templates/views/form--views-exposed-form.html.twig
@@ -1,6 +1,6 @@
 {# web/core/themes/stable9/templates/form/form.html.twig #}
 <li class="content-list-page__filter content-list-page__filter--right">
-  <label class="input-label" id="{{ element['#id'] }}">{{ element.search_api_fulltext['#title'] }}</label>
+  <label class="input-label">{{ element.search_api_fulltext['#title'] }}</label>
   <form{{ attributes.addClass('search-full-text') }}>
     {{ children }}
   </form>

--- a/web/themes/custom/novel/templates/views/form--views-exposed-form.html.twig
+++ b/web/themes/custom/novel/templates/views/form--views-exposed-form.html.twig
@@ -1,4 +1,4 @@
-{# web/core/themes/stable9/templates/form/form.html.twig #}
+{# tweaked version from web/core/themes/stable9/templates/form/form.html.twig #}
 <li class="content-list-page__filter content-list-page__filter--right">
   <label class="input-label">{{ element.search_api_fulltext['#title'] }}</label>
   <form{{ attributes.addClass('search-full-text') }}>

--- a/web/themes/custom/novel/templates/views/form--views-exposed-form.html.twig
+++ b/web/themes/custom/novel/templates/views/form--views-exposed-form.html.twig
@@ -1,0 +1,7 @@
+{# web/core/themes/stable9/templates/form/form.html.twig #}
+<li class="content-list-page__filter content-list-page__filter--right">
+  <label class="input-label" id="{{ element['#id'] }}">{{ element.search_api_fulltext['#title'] }}</label>
+  <form{{ attributes.addClass('search-full-text') }}>
+    {{ children }}
+  </form>
+</li>

--- a/web/themes/custom/novel/templates/views/form-element--search-api-fulltext.html.twig
+++ b/web/themes/custom/novel/templates/views/form-element--search-api-fulltext.html.twig
@@ -1,0 +1,7 @@
+{# web/core/themes/stable9/templates/form/form-element.html.twig #}
+{{ children }}
+{% if errors %}
+  <div class="form-item--error-message">
+    {{ errors }}
+  </div>
+{% endif %}

--- a/web/themes/custom/novel/templates/views/form-element--search-api-fulltext.html.twig
+++ b/web/themes/custom/novel/templates/views/form-element--search-api-fulltext.html.twig
@@ -1,4 +1,4 @@
-{# web/core/themes/stable9/templates/form/form-element.html.twig #}
+{# tweaked version from web/core/themes/stable9/templates/form/form-element.html.twig #}
 {{ children }}
 {% if errors %}
   <div class="form-item--error-message">

--- a/web/themes/custom/novel/templates/views/input--search-api-fulltext.html.twig
+++ b/web/themes/custom/novel/templates/views/input--search-api-fulltext.html.twig
@@ -1,0 +1,3 @@
+{# web/core/themes/stable9/templates/form/input.html.twig #}
+<input{{ attributes.addClass('search-full-text__input') }} />
+<input type="image" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-search.svg" alt="Søgeknap">

--- a/web/themes/custom/novel/templates/views/input--search-api-fulltext.html.twig
+++ b/web/themes/custom/novel/templates/views/input--search-api-fulltext.html.twig
@@ -1,3 +1,3 @@
-{# web/core/themes/stable9/templates/form/input.html.twig #}
+{# tweaked version from web/core/themes/stable9/templates/form/input.html.twig #}
 <input{{ attributes.addClass('search-full-text__input') }} />
 <input type="image" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-search.svg" alt="{{ 'Search button'|trans }}">

--- a/web/themes/custom/novel/templates/views/input--search-api-fulltext.html.twig
+++ b/web/themes/custom/novel/templates/views/input--search-api-fulltext.html.twig
@@ -1,3 +1,3 @@
 {# web/core/themes/stable9/templates/form/input.html.twig #}
 <input{{ attributes.addClass('search-full-text__input') }} />
-<input type="image" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-search.svg" alt="Søgeknap">
+<input type="image" src="/themes/custom/novel/assets/dpl-design-system/icons/basic/icon-search.svg" alt="{{ 'Search button'|trans }}">

--- a/web/themes/custom/novel/templates/views/views-view--content-list-page.html.twig
+++ b/web/themes/custom/novel/templates/views/views-view--content-list-page.html.twig
@@ -25,7 +25,9 @@
   {% if rows -%}
     {{ rows }}
   {% elseif empty -%}
-    {{ empty }}
+    <div class="empty-view">
+      {{ empty }}
+    </div>
   {% endif %}
 
   {{ pager }}

--- a/web/themes/custom/novel/templates/views/views-view--content-list-page.html.twig
+++ b/web/themes/custom/novel/templates/views/views-view--content-list-page.html.twig
@@ -14,10 +14,10 @@
   {{ header }}
 
   <ul class="content-list-page__filters">
-    {{ exposed }}
-
     {% block facets %}
     {% endblock %}
+
+    {{ exposed }}
   </ul>
 
   {{ attachment_before }}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-66

#### Description
This pull request implements a full-text search filter for the `articles` and `events` views, allowing users to perform searches across the `title`, `description`, and `teaser` fields. The search API has been enhanced to index these fields, and case sensitivity has been disabled to make the search more user-friendly.


<img width="1160" alt="image" src="https://github.com/user-attachments/assets/eea26b1a-f211-4d66-a18f-02a962a968a9">
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/9bc5a556-a67b-465b-97d5-8d28fbb8242e">

<img width="1160" alt="image" src="https://github.com/user-attachments/assets/13944d8b-83ab-4be8-94b1-194b967db5bc">
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/0fb69fb8-d8d4-4227-aafe-b25eef809cca">




#### Test
https://varnish.pr-1541.dpl-cms.dplplat01.dpl.reload.dk/artikler
https://varnish.pr-1541.dpl-cms.dplplat01.dpl.reload.dk/arrangementer