### PR TITLE
Add missing translation for "Switch to results for" - DDFHER-10

### DIFF
--- a/web/modules/custom/dpl_search/dpl_search.module
+++ b/web/modules/custom/dpl_search/dpl_search.module
@@ -90,7 +90,7 @@ function dpl_search_preprocess_views_view(array &$variables): void {
 
     $variables['header']['description'] = [
       '#prefix' => '<h2 class="content-list-page__subheading">' . t('Switch to results for the', [], ['context' => 'dpl_search']) . ' <a href="' . $material_url . '">',
-      '#suffix' => '</h2></a>',
+      '#suffix' => '</a></h2>',
       '#markup' => t('library materials.', [], ['context' => 'dpl_search']),
     ];
 

--- a/web/modules/custom/dpl_search/dpl_search.module
+++ b/web/modules/custom/dpl_search/dpl_search.module
@@ -89,7 +89,7 @@ function dpl_search_preprocess_views_view(array &$variables): void {
     $material_url = Url::fromRoute('dpl_react_apps.search_result', [], ['query' => [DplSearchSettings::MATERIAL_QUERY_KEY => $search_input]])->toString();
 
     $variables['header']['description'] = [
-      '#prefix' => '<h2 class="content-list-page__subheading">Switch to results for the <a href="' . $material_url . '">',
+      '#prefix' => '<h2 class="content-list-page__subheading">' . t('Switch to results for the', [], ['context' => 'dpl_search']) . ' <a href="' . $material_url . '">',
       '#suffix' => '</h2></a>',
       '#markup' => t('library materials.', [], ['context' => 'dpl_search']),
     ];


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-10

#### Description
This pull request addresses a missing translation and adjusts the suffix order in `$variables['header']['description']` to ensure correct display.