### PR TITLE
Add filter criteria for User Roles in `admin/user`

### DIFF
--- a/config/sync/views.view.user_admin_people.yml
+++ b/config/sync/views.view.user_admin_people.yml
@@ -10,6 +10,7 @@ dependencies:
     - user.role.local_administrator
     - user.role.mediator
   module:
+    - better_exposed_filters
     - user
 _core:
   default_config_hash: GbPVHdpSCucZ1MunS3Lai6FtyVVfmP9rJHk1GZ73JY0
@@ -562,7 +563,7 @@ display:
             offset_label: Offset
           quantity: 9
       exposed_form:
-        type: basic
+        type: bef
         options:
           submit_button: Filter
           reset_button: true
@@ -571,6 +572,76 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: basic
+          bef:
+            general:
+              autosubmit: false
+              autosubmit_exclude_textfield: false
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: false
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+              reset_button_always_show: false
+            filter:
+              combine:
+                plugin_id: default
+                advanced:
+                  placeholder_text: ''
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: false
+              status:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: false
+              roles_target_id:
+                plugin_id: bef
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: true
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                select_all_none: true
+                select_all_none_nested: false
+                display_inline: true
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: false
+              permission:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: false
       access:
         type: perm
         options:
@@ -716,7 +787,12 @@ display:
           admin_label: ''
           plugin_id: user_roles
           operator: or
-          value: {  }
+          value:
+            administrator: administrator
+            local_administrator: local_administrator
+            editor: editor
+            mediator: mediator
+            external_system: external_system
           group: 1
           exposed: true
           expose:
@@ -730,12 +806,17 @@ display:
             identifier: role
             required: false
             remember: false
-            multiple: false
+            multiple: true
             remember_roles:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            reduce: false
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+            reduce: true
           is_grouped: false
           group_info:
             label: ''
@@ -777,6 +858,11 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
             reduce: false
           is_grouped: false
           group_info:
@@ -831,53 +917,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        roles_target_id_2:
-          id: roles_target_id_2
-          table: user__roles
-          field: roles_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: user
-          entity_field: roles
-          plugin_id: user_roles
-          operator: or
-          value:
-            administrator: administrator
-            local_administrator: local_administrator
-            editor: editor
-            mediator: mediator
-            external_system: external_system
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
       filter_groups:
         operator: AND
         groups:

--- a/config/sync/views.view.user_admin_people.yml
+++ b/config/sync/views.view.user_admin_people.yml
@@ -4,7 +4,11 @@ status: true
 dependencies:
   config:
     - field.storage.user.field_author_name
-    - user.role.patron
+    - user.role.administrator
+    - user.role.editor
+    - user.role.external_system
+    - user.role.local_administrator
+    - user.role.mediator
   module:
     - user
 _core:
@@ -827,8 +831,8 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        roles_target_id_1:
-          id: roles_target_id_1
+        roles_target_id_2:
+          id: roles_target_id_2
           table: user__roles
           field: roles_target_id
           relationship: none
@@ -837,9 +841,13 @@ display:
           entity_type: user
           entity_field: roles
           plugin_id: user_roles
-          operator: not
+          operator: or
           value:
-            patron: patron
+            administrator: administrator
+            local_administrator: local_administrator
+            editor: editor
+            mediator: mediator
+            external_system: external_system
           group: 1
           exposed: false
           expose:

--- a/config/sync/views.view.user_admin_people.yml
+++ b/config/sync/views.view.user_admin_people.yml
@@ -9,6 +9,7 @@ dependencies:
     - user.role.external_system
     - user.role.local_administrator
     - user.role.mediator
+    - user.role.patron
   module:
     - better_exposed_filters
     - user
@@ -611,6 +612,20 @@ display:
                 options_show_only_used_filtered: false
                 options_hide_when_empty: false
                 options_show_items_count: false
+              permission:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: false
               roles_target_id:
                 plugin_id: bef
                 advanced:
@@ -618,17 +633,17 @@ display:
                   rewrite:
                     filter_rewrite_values: ''
                     filter_rewrite_values_key: false
-                  collapsible: true
+                  collapsible: false
                   collapsible_disable_automatic_open: false
                   is_secondary: false
-                select_all_none: true
+                select_all_none: false
                 select_all_none_nested: false
                 display_inline: true
                 options_show_only_used: false
                 options_show_only_used_filtered: false
                 options_hide_when_empty: false
                 options_show_items_count: false
-              permission:
+              roles_target_id_1:
                 plugin_id: default
                 advanced:
                   sort_options: false
@@ -778,6 +793,222 @@ display:
                 title: Blocked
                 operator: '='
                 value: '0'
+        permission:
+          id: permission
+          table: user__roles
+          field: permission
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: user_permissions
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: permission_op
+            label: Permission
+            description: ''
+            use_operator: false
+            operator: permission_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: permission
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        roles_target_id_1:
+          id: roles_target_id_1
+          table: user__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: roles
+          plugin_id: user_roles
+          operator: not
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: roles_target_id_1_op
+            label: 'Has no role'
+            description: ''
+            use_operator: false
+            operator: roles_target_id_1_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: no_roles
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+            reduce: false
+          is_grouped: true
+          group_info:
+            label: 'Has role'
+            description: ''
+            identifier: has_role
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: '2'
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'Has no role'
+                operator: not
+                value:
+                  administrator: administrator
+                  local_administrator: local_administrator
+                  editor: editor
+                  mediator: mediator
+                  patron: patron
+                  external_system: external_system
+              2:
+                title: 'Has role'
+                operator: or
+                value:
+                  administrator: administrator
+                  local_administrator: local_administrator
+                  editor: editor
+                  mediator: mediator
+                  patron: patron
+                  external_system: external_system
+          reduce_duplicates: false
+        roles_target_id_2:
+          id: roles_target_id_2
+          table: user__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: roles
+          plugin_id: user_roles
+          operator: or
+          value:
+            patron: patron
+          group: 1
+          exposed: true
+          expose:
+            operator_id: roles_target_id_2_op
+            label: 'Include patron'
+            description: ''
+            use_operator: false
+            operator: roles_target_id_2_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: patron
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+            reduce: false
+          is_grouped: true
+          group_info:
+            label: 'Include patron'
+            description: ''
+            identifier: roles_target_id_2
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: '2'
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'Include patrons'
+                operator: or
+                value:
+                  patron: patron
+              2:
+                title: 'Exclude patrons'
+                operator: not
+                value:
+                  patron: patron
+          reduce_duplicates: false
+        default_langcode:
+          id: default_langcode
+          table: users_field_data
+          field: default_langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: default_langcode
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         roles_target_id:
           id: roles_target_id
           table: user__roles
@@ -830,93 +1061,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-        permission:
-          id: permission
-          table: user__roles
-          field: permission
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: user_permissions
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: permission_op
-            label: Permission
-            description: ''
-            use_operator: false
-            operator: permission_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: permission
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              local_administrator: '0'
-              editor: '0'
-              mediator: '0'
-              patron: '0'
-              external_system: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-        default_langcode:
-          id: default_langcode
-          table: users_field_data
-          field: default_langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: user
-          entity_field: default_langcode
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -1001,7 +1145,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       css_class: ''


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-34

#### Description
This pull request updates `admin/user` to hide users without an approved role.

Users are filtered out unless they have one of the following roles:
  - External System
  - Local Administrator
  - Mediator
  - Administrator
  - Editor

The super admin is also excluded, but it is also not relevant for libraries. 
Patron users remain hidden.


https://github.com/user-attachments/assets/eaa90789-c70a-4bc8-825c-c6481b67a552



https://github.com/user-attachments/assets/dd7123eb-e97b-4ea6-8e2c-72d99f6bd0f0


#### Test
https://varnish.pr-1550.dpl-cms.dplplat01.dpl.reload.dk/

