### PR TITLE
Enable Reset Button for Event Series View

### DIFF
--- a/config/sync/views.view.event_series_admin.yml
+++ b/config/sync/views.view.event_series_admin.yml
@@ -475,7 +475,7 @@ display:
         type: basic
         options:
           submit_button: Apply
-          reset_button: false
+          reset_button: true
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
           expose_sort_order: true


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-69

#### Description

This update adds a reset button that appears when any filters are applied on the event series view


#### Test
https://varnish.pr-1551.dpl-cms.dplplat01.dpl.reload.dk/admin/content/eventseries


https://github.com/user-attachments/assets/c3c01c7e-0203-4c0e-b31b-82c46bea5f99

