### PR TITLE
Keep PHPStan at 1.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -191,6 +191,7 @@
         "php-mock/php-mock": "^2.3",
         "phpspec/prophecy-phpunit": "^2",
         "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan": "~1.11.11",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "9.5.10",
         "thecodingmachine/phpstan-safe-rule": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "148432ecd280b58c756f149b96f2a7ab",
+    "content-hash": "9f2341deebd897febff7cf9f70d01e06",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
#### Description

Currently PHPStan is an indirect dependency of the project through `mglaman/phpstan-drupal` and others.

However the version of PHPStan used directly affects the results of our CI pipeline and thus unintentional updates of the package performed through the update of other packages can result in CI errors. This notably happens via Dependabot. See #1549 .

To avoid this we move PHPStan to a direct dependency so updates for the package will also be managed directly.

We currently use version 1.11.11 and updates have yielded analysis errors so keep it at 1.11 for now.
