### PR TITLE
Disable `Tags` autocomplete to display all tags

### DIFF
--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -73,7 +73,6 @@ third_party_settings:
       children:
         - field_event_image
         - field_event_state
-        - field_relevant_ticket_manager
         - field_external_admin_link
       label: 'Event details'
       region: content
@@ -225,7 +224,7 @@ content:
     region: content
     settings:
       width: 100%
-      autocomplete: true
+      autocomplete: false
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -228,7 +228,7 @@ content:
     region: content
     settings:
       width: 100%
-      autocomplete: true
+      autocomplete: false
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -194,7 +194,7 @@ content:
     region: content
     settings:
       width: 100%
-      autocomplete: true
+      autocomplete: false
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.paragraph.card_grid_automatic.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.card_grid_automatic.default.yml
@@ -77,7 +77,7 @@ content:
     region: content
     settings:
       width: 100%
-      autocomplete: true
+      autocomplete: false
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.paragraph.content_slider_automatic.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.content_slider_automatic.default.yml
@@ -77,7 +77,7 @@ content:
     region: content
     settings:
       width: 100%
-      autocomplete: true
+      autocomplete: false
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.paragraph.filtered_event_list.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.filtered_event_list.default.yml
@@ -70,7 +70,7 @@ content:
     region: content
     settings:
       width: 100%
-      autocomplete: true
+      autocomplete: false
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-35

#### Description
This pull request disables the autocomplete functionality for `Tags`, ensuring that all tags are visible to users for the `event` and `article` content types. 

Additionally, it makes all tags available for the following paragraph types:
`card grid automatic`
`slider automatic`
`event list automatic`

https://github.com/user-attachments/assets/09eb02aa-9ae9-4856-98bd-041cacc062fa


### Test
https://varnish.pr-1555.dpl-cms.dplplat01.dpl.reload.dk/node/add/article
https://varnish.pr-1555.dpl-cms.dplplat01.dpl.reload.dk/events/add/default