### PR TITLE
Revert "Bump drupal/redis from 1.7.0 to 1.8.0"

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6588,20 +6588,20 @@
         },
         {
             "name": "drupal/redis",
-            "version": "1.8.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/redis.git",
-                "reference": "8.x-1.8"
+                "reference": "8.x-1.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/redis-8.x-1.8.zip",
-                "reference": "8.x-1.8",
-                "shasum": "6de73086d29de3b041594bae97c74401cbf05c3d"
+                "url": "https://ftp.drupal.org/files/projects/redis-8.x-1.7.zip",
+                "reference": "8.x-1.7",
+                "shasum": "602043bdad62ff047321121edcfde8abf3638c7c"
             },
             "require": {
-                "drupal/core": "^9.3 || ^10 || ^11"
+                "drupal/core": "^9.3 || ^10"
             },
             "suggest": {
                 "ext-redis": "Required to use the PhpRedis as redis driver (^4.0|^5.0).",
@@ -6611,8 +6611,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.8",
-                    "datestamp": "1723934771",
+                    "version": "8.x-1.7",
+                    "datestamp": "1686175620",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6630,7 +6630,7 @@
             ],
             "authors": [
                 {
-                    "name": "berdir",
+                    "name": "Berdir",
                     "homepage": "https://www.drupal.org/user/214652"
                 },
                 {


### PR DESCRIPTION
Reverts danskernesdigitalebibliotek/dpl-cms#1533

Updating Redis causes a problem running an update hook during deployments to existing sites:

```
[notice] Update started: redis_post_update_add_report_permission          
   [error]  Adding non-existent permissions to a role is not allowed. The incorrect permissions are "Administer maintenance mode".                      
   [error]  Update failed: redis_post_update_add_report_permission           
   [error]  Update aborted by: redis_post_update_add_report_permission   
 ```  
 
 This is likely a problem with `drupal/config_perms`.