### PR TITLE
Revert changing event reoccurence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,7 +151,7 @@
         "drupal/pathauto": "^1.12",
         "drupal/potion": "dev-2.x#e48d6ee336d960b9d2efb5d88e68402db6d229a6",
         "drupal/purge": "^3.6",
-        "drupal/recurring_events": "^2",
+        "drupal/recurring_events": "^2.0@RC",
         "drupal/redirect": "^1.9",
         "drupal/redis": "^1.7",
         "drupal/restui": "^1.21",
@@ -358,11 +358,10 @@
                 "3462078: Disabling late runtime processor when using CLI": "https://git.drupalcode.org/project/purge/-/commit/14c09e0ec4f1f46df0f19876ad6b3e8c93921e00.patch"
             },
             "drupal/recurring_events": {
-                "3461740: Fatal error when using 'Event series start date' filter in views": "https://www.drupal.org/files/issues/2024-07-16/reccuring_events_event_start_date.patch",
-                "3468521: (1/4) When changing recurrance, identical date combinations should not be deleted and recreated": "https://git.drupalcode.org/project/recurring_events/-/commit/67261f4ac34546f2c9514199d9febb6dcce6fd10.patch",
-                "3468521: (2/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/603d34936b97535f66e11429dcc9a2c61fc7cb40.patch",
-                "3468521: (3/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad8a4294b1ffb754a338bb2cfa0146f203aa6fc1.patch",
-                "3468521: (4/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad99ae79f5c55fc2db17427e9936ab141314609d.patch"
+                "3178696: Make compatible with Scheduler": "https://git.drupalcode.org/project/recurring_events/-/commit/35045cb17c7bbd1184553f83771939047175bc24.patch",
+                "3416436: Avoid array conversion warning when daily events are disabled": "https://git.drupalcode.org/project/recurring_events/-/commit/832ae52f135dd3f205eb74acf2d3715fb443e759.patch",
+                "3451613: Start date of weekly reccurring event jumps incorrectly": "https://git.drupalcode.org/project/recurring_events/-/commit/581c53dd1b0b067a8b6454d76cc0187887f7b187.patch",
+                "3461740: Fatal error when using 'Event series start date' filter in views": "https://www.drupal.org/files/issues/2024-07-16/reccuring_events_event_start_date.patch"
             },
             "drupal/theme_permission": {
                 "3105637: Edit, install and uninstall permission": "https://www.drupal.org/files/issues/2024-02-01/theme-permission-edit-install-uninstall-3105637-7.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45ae185b86cdc631039c7bef1170a20c",
+    "content-hash": "1643f03442e2f646da90965e93bb157c",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -6474,17 +6474,17 @@
         },
         {
             "name": "drupal/recurring_events",
-            "version": "2.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/recurring_events.git",
-                "reference": "2.0.2"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/recurring_events-2.0.2.zip",
-                "reference": "2.0.2",
-                "shasum": "97f9ccda4fc424ea4f2adc40fa499b0ec33e1842"
+                "url": "https://ftp.drupal.org/files/projects/recurring_events-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "7bc7a42b18c02d88aaaa12b35ac6434140f9f432"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10",
@@ -6498,8 +6498,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.2",
-                    "datestamp": "1718917018",
+                    "version": "2.0.0",
+                    "datestamp": "1706902867",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6511,10 +6511,6 @@
                 "GPL-2.0-or-later"
             ],
             "authors": [
-                {
-                    "name": "Lullabot",
-                    "homepage": "https://www.drupal.org/user/3815489"
-                },
                 {
                     "name": "owenbush",
                     "homepage": "https://www.drupal.org/user/2765259"
@@ -19075,7 +19071,8 @@
         "drupal/gin_toolbar": 5,
         "drupal/multivalue_form_element": 10,
         "drupal/openapi_rest": 5,
-        "drupal/potion": 20
+        "drupal/potion": 20,
+        "drupal/recurring_events": 5
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFHER-16

#### Description

This reverts  #1500.

When rolling out these changes to existing sites this causes problems
during the configuration import part when running drush deploy:

```
> Error: Call to a member function getLabel() on null in /app/web/modules/contrib/scheduler/src/SchedulerManager.php on line 1171 #0 /app/web/modules/contrib/scheduler/scheduler.module(1450): Drupal\scheduler\SchedulerManager->entityUpdate()
> https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1 /app/web/core/lib/Drupal/Core/Config/ConfigImporter.php(574): _scheduler_config_import_process_entity_definitions()
> https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2 /app/vendor/drush/drush/src/Commands/config/ConfigImportCommands.php(259): Drupal\Core\Config\ConfigImporter->doSyncStep()
```

git bisect has traced the error back to this change. Reverting it
removes the problem.

Based on this we cannot tell if it is the update of the module
which was introduced as a part of the updated event reoccurrence
handling which causes the problem or the actual event reoccurrence
handling.
