### PR TITLE
Support restoring Lagoon backup from other environments than main

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -233,7 +233,7 @@ tasks:
     desc: 'Restore database from db dump file. Only one sql should be present the "{{ .DIR_RESTORE_DATABASE }}" directory.'
     cmds:
       - task dev:cli -- drush sql:drop -y
-      - docker-compose exec -T {{ .MYSQL_CONTAINER }} mysql < {{ .SQL_FILE }}
+      - docker compose exec -T {{ .MYSQL_CONTAINER }} mysql < {{ .SQL_FILE }}
       - task dev:cache:clear:all
     preconditions:
       - sh: "[ {{ .SQL_FILES_COUNT }} -gt 0 ]"
@@ -252,7 +252,7 @@ tasks:
   dev:restore:files:
     desc: "Restore files by overwriting existing with the ones from the Lagoon backup package"
     cmds:
-      - docker-compose exec cli sh dev-scripts/cli-restore-lagoon-files.sh {{ .DIR_RESTORE_FILES }}
+      - docker compose exec cli sh dev-scripts/cli-restore-lagoon-files.sh {{ .DIR_RESTORE_FILES }}
       - task dev:cache:clear:all
 
   dev:cache:clear:all:

--- a/dev-scripts/lagoon-get-backup.sh
+++ b/dev-scripts/lagoon-get-backup.sh
@@ -2,19 +2,17 @@
 # Restore and download files from a Lagoon backup.
 set -eo pipefail
 
-LAGOON_PROJECT="$1"
 LAGOON_ENVIRONMENT="main"
-BACKUP_TYPE="$2"
-BACKUP_DESTINATION="$3"
 
 if [[ -z "${LAGOON_PROJECT}" || -z "${BACKUP_TYPE}" || -z "${BACKUP_DESTINATION}" ]]; then
-	echo "usage: $0 <LAGOON_PROJECT> <BACKUP_TYPE> <BACKUP_DESTINATION>" >&2
+	echo "usage: LAGOON_PROJECT=<LAGOON_PROJECT> BACKUP_TYPE=<BACKUP_TYPE> BACKUP_DESTINATION=<BACKUP_DESTINATION> $0" >&2
 	exit 1
 fi
 
 BACKUPS=$(lagoon list backups -p "${LAGOON_PROJECT}" -e ${LAGOON_ENVIRONMENT} --output-json);
 BACKUP_ID=$(echo "$BACKUPS" | jq -r ".data[] | select(.source == \"${BACKUP_TYPE}\") | .backupid" | head -n 1);
 BACKUP_URL="Error";
+echo -e "\nRetrieving ${BACKUP_TYPE} backup from ${LAGOON_PROJECT}\n\n";
 # Wait a while we wait for the backup to become available.
 # It must be retrieved before it can be downloaded.
 while [[ $BACKUP_URL == "Error"* ]]; do
@@ -24,5 +22,5 @@ while [[ $BACKUP_URL == "Error"* ]]; do
   # backup is not available for download yet.
   BACKUP_URL=$(lagoon get backup -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --backup-id "${BACKUP_ID}" 2>/dev/null) || true;
 done;
-echo -e "\nDownloading backup from ${BACKUP_URL}\n\n";
+echo -e "\nDownloading backup from ${BACKUP_URL} to ${BACKUP_DESTINATION}\n\n";
 curl -o "${BACKUP_DESTINATION}" "${BACKUP_URL}";

--- a/dev-scripts/lagoon-get-backup.sh
+++ b/dev-scripts/lagoon-get-backup.sh
@@ -2,17 +2,17 @@
 # Restore and download files from a Lagoon backup.
 set -eo pipefail
 
-LAGOON_ENVIRONMENT="main"
+LAGOON_ENVIRONMENT="${LAGOON_ENVIRONMENT:-main}"
 
 if [[ -z "${LAGOON_PROJECT}" || -z "${BACKUP_TYPE}" || -z "${BACKUP_DESTINATION}" ]]; then
 	echo "usage: LAGOON_PROJECT=<LAGOON_PROJECT> BACKUP_TYPE=<BACKUP_TYPE> BACKUP_DESTINATION=<BACKUP_DESTINATION> $0" >&2
 	exit 1
 fi
 
-BACKUPS=$(lagoon list backups -p "${LAGOON_PROJECT}" -e ${LAGOON_ENVIRONMENT} --output-json);
+BACKUPS=$(lagoon list backups -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --output-json);
 BACKUP_ID=$(echo "$BACKUPS" | jq -r ".data[] | select(.source == \"${BACKUP_TYPE}\") | .backupid" | head -n 1);
 BACKUP_URL="Error";
-echo -e "\nRetrieving ${BACKUP_TYPE} backup from ${LAGOON_PROJECT}\n\n";
+echo -e "\nRetrieving ${BACKUP_TYPE} backup from ${LAGOON_ENVIRONMENT} environment of ${LAGOON_PROJECT} project \n\n";
 # Wait a while we wait for the backup to become available.
 # It must be retrieved before it can be downloaded.
 while [[ $BACKUP_URL == "Error"* ]]; do

--- a/task/Taskfile.lagoon.yml
+++ b/task/Taskfile.lagoon.yml
@@ -16,12 +16,15 @@ tasks:
     vars:
       LAGOON_ENVIRONMENT: main
     cmds:
-      - ./dev-scripts/lagoon-get-backup.sh ${LAGOON_PROJECT} mariadb {{.DIR_RESTORE_DATABASE}}/${LAGOON_PROJECT}-backup.tar.gz;
+      - ./dev-scripts/lagoon-get-backup.sh
       -  cd ./restore/database/ && tar -xvzf ${LAGOON_PROJECT}-backup.tar.gz;
       - task dev:restore:database
     preconditions:
       - sh: "[ -v LAGOON_PROJECT ]"
         msg: Please provide a LAGOON_PROJECT environment variable with the name of the Lagoon project to use
+    env:
+      BACKUP_TYPE: "mariadb"
+      BACKUP_DESTINATION: "{{.DIR_RESTORE_DATABASE}}/{{.LAGOON_PROJECT}}-backup.tar.gz"
 
   backup:restore:files:
     desc: Restore the latest backup of the files from a Lagoon project
@@ -29,11 +32,14 @@ tasks:
     vars:
       LAGOON_ENVIRONMENT: main
     cmds:
-      - ./dev-scripts/lagoon-get-backup.sh ${LAGOON_PROJECT} nginx {{.DIR_RESTORE_FILES}}/${LAGOON_PROJECT}-backup.tar.gz;
+      - ./dev-scripts/lagoon-get-backup.sh
       - task dev:restore:files
     preconditions:
       - sh: "[ -v LAGOON_PROJECT ]"
         msg: Please provide a LAGOON_PROJECT environment variable with the name of the Lagoon project to use
+    env:
+      BACKUP_TYPE: "nginx"
+      BACKUP_DESTINATION: "{{.DIR_RESTORE_FILES}}/{{.LAGOON_PROJECT}}-backup.tar.gz"
 
   drush:uli:
     desc: Get an Drupal one-time user login link for a Lagoon environment through Drush

--- a/task/Taskfile.lagoon.yml
+++ b/task/Taskfile.lagoon.yml
@@ -13,8 +13,6 @@ tasks:
   backup:restore:database:
     desc: Restore the latest backup of the database from a Lagoon project
     deps: [deps:lagoon, deps:jq, login]
-    vars:
-      LAGOON_ENVIRONMENT: main
     cmds:
       - ./dev-scripts/lagoon-get-backup.sh
       -  cd ./restore/database/ && tar -xvzf ${LAGOON_PROJECT}-backup.tar.gz;
@@ -29,8 +27,6 @@ tasks:
   backup:restore:files:
     desc: Restore the latest backup of the files from a Lagoon project
     deps: [deps:lagoon, deps:jq, login]
-    vars:
-      LAGOON_ENVIRONMENT: main
     cmds:
       - ./dev-scripts/lagoon-get-backup.sh
       - task dev:restore:files


### PR DESCRIPTION
#### Description

Having `main` as a default is reasonable but it is nice to be able to
restore from a `moduletest` environment as well.

Now you can do so through
`LAGOON_PROJECT=customizable-canary LAGOON_ENVIRONMENT=moduletest task lagoon:backup:restore`

#### Additional comments or questions

Please go through commit by commit for a couple additional related changes and commentary.