### PR TITLE
Fix newline issue as separator for aggregated fields in combined index

### DIFF
--- a/config/sync/search_api.index.content_events.yml
+++ b/config/sync/search_api.index.content_events.yml
@@ -26,14 +26,7 @@ field_settings:
     type: string
     configuration:
       type: union
-      separator: |+
-
-
-
-
-
-
-
+      separator: '-not used-'
       fields:
         - 'entity:eventseries/field_categories'
         - 'entity:node/field_categories'
@@ -100,14 +93,7 @@ field_settings:
     type: string
     configuration:
       type: union
-      separator: |+
-
-
-
-
-
-
-
+      separator: '-not used-'
       fields:
         - 'entity:eventseries/field_tags'
         - 'entity:node/field_tags'


### PR DESCRIPTION
#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Currently we have newlines set as separators for aggregated fields for tags and categories in the combined content and events index.

For whatever reason this adds even more newlines for the separator when configuration is exported again.

It turns out the separator is only used for the "concatenation" aggregation type. We use the "union" aggregation type. With this in mind the separator value is actually not used for our use case.

To work around the issue we change the separator value to a simple string with a value showing that it is not in used.

See https://www.drupal.org/project/search_api/issues/3425506#comment-15490163
