### PR TITLE
Patch entity_reference_revisions to break loop when updating event

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,6 +118,7 @@
         "drupal/dynamic_entity_reference": "^3.1",
         "drupal/editor_advanced_link": "^2.2",
         "drupal/entity_clone_template": "^2.0",
+        "drupal/entity_reference_revisions": "^1.11.0",
         "drupal/enum_field": "^1.0",
         "drupal/facets": "^2.0",
         "drupal/field_group": "^3.4",
@@ -315,6 +316,9 @@
             },
             "drupal/entity_clone_template": {
                 "3424597: Fix error when creating entity of type without templates": "https://git.drupalcode.org/project/entity_clone_template/-/commit/ad4964dd51f7f5e814111fcb73e6e472eefccf5c.patch"
+            },
+            "drupal/entity_reference_revisions": {
+                "3039442: Circular dependencies in EntityReferenceRevisionsFieldItemList::hasAffectingChanges()": "https://www.drupal.org/files/issues/2023-11-20/entity_reference_revisions-fix_infinite_loop-3039442-8.patch"
             },
             "drupal/field_inheritance": {
                 "3454350: Create seperate permission for adding field inheritance": "https://www.drupal.org/files/issues/2024-06-13/field_inheritance_permission.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ef474525d222039727484711e755b63",
+    "content-hash": "5419d7dcb8226a058a4c12cc0a3b11da",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFHER-74

#### Description

We see PHP running out of memory when running a deploy hook, `dpl_update_deploy_field_relevant_ticket_manager()`, on a specific site, for a specific eventseries.

It turns out this event series has instances where each instance has a paragraph which references other instances within the series. This creates a circular dependency.

To break this we patch `drupal/entity_reference_revisions`.

`drupal/entity_reference_revisions` is currently an implicit dependency through `drupal/paragraphs`. To avoid it moving without our explicit consent and patches thus not applying we add
`drupal/entity_reference_revisions` as an explicit dependency. We use the same version as is currently used within the project.

#### Additional comments or questions

I can recreate the problem without this change using a backup from the failing site. With this change the problem no longer occurs.