### PR TITLE
Display branch address on series level. DDFHER-38

### DIFF
--- a/web/modules/custom/dpl_event/src/EventWrapper.php
+++ b/web/modules/custom/dpl_event/src/EventWrapper.php
@@ -4,7 +4,6 @@ namespace Drupal\dpl_event;
 
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\drupal_typed\DrupalTyped;
-use Drupal\node\NodeInterface;
 use Drupal\recurring_events\Entity\EventInstance;
 use Psr\Log\LoggerInterface;
 use Safe\DateTimeImmutable;
@@ -84,33 +83,6 @@ class EventWrapper {
     // Drupal stores dates in UTC by default but if no timezone is specified
     // then the default timezone will be assumed.
     return new DateTimeImmutable($event_date_values[$value], new \DateTimeZone('UTC'));
-  }
-
-  /**
-   * Load an eventinstance address - either from the series/instance or branch.
-   */
-  public function getAddressField(): ?FieldItemListInterface {
-    $instance_field = $this->getField('event_address');
-
-    if ($instance_field instanceof FieldItemListInterface) {
-      return $instance_field;
-    }
-
-    // Could not find data - look up address from branch instead.
-    $branch_field = $this->getField('branch');
-
-    if (!$branch_field instanceof FieldItemListInterface) {
-      return NULL;
-    }
-
-    $branch_address_field = 'field_address';
-    $branch = $branch_field->referencedEntities()[0] ?? NULL;
-
-    if (!($branch instanceof NodeInterface) || !$branch->hasField($branch_address_field)) {
-      return NULL;
-    }
-
-    return $branch->get($branch_address_field);
   }
 
   /**

--- a/web/modules/custom/dpl_event/src/Plugin/Field/FieldFormatter/BranchAddressFormatter.php
+++ b/web/modules/custom/dpl_event/src/Plugin/Field/FieldFormatter/BranchAddressFormatter.php
@@ -4,8 +4,9 @@ namespace Drupal\dpl_event\Plugin\Field\FieldFormatter;
 
 use Drupal\address\Plugin\Field\FieldFormatter\AddressDefaultFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\dpl_event\EventWrapper;
+use Drupal\node\NodeInterface;
 use Drupal\recurring_events\Entity\EventInstance;
+use Drupal\recurring_events\Entity\EventSeries;
 
 /**
  * A custom address field formatter: Get fallback address from branch.
@@ -46,18 +47,65 @@ class BranchAddressFormatter extends AddressDefaultFormatter {
 
     $entity = $items->getEntity();
 
-    if (!($entity instanceof EventInstance)) {
+    if (!($entity instanceof EventInstance) && !($entity instanceof EventSeries)) {
       return $default_return;
     }
 
-    $wrapper = new EventWrapper($entity);
-    $field = $wrapper->getAddressField();
+    $field = $this->getAddressField($entity);
 
     if (!$field instanceof FieldItemListInterface) {
       return $default_return;
     }
 
     return $field->view();
+  }
+
+  /**
+   * Loading the field if it exists.
+   */
+  private function getField(EventSeries|EventInstance $event, string $field_name): ?FieldItemListInterface {
+    // First, let's look up the custom field - does it already have a value?
+    if ($event->hasField($field_name)) {
+      $field = $event->get($field_name);
+
+      if (!$field->isEmpty()) {
+        return $field;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Load an event address - either from the series/instance or branch.
+   */
+  private function getAddressField(EventSeries|EventInstance $event): ?FieldItemListInterface {
+    $address_field_name = ($event instanceof EventSeries) ?
+      'field_event_address' : 'event_address';
+    $branch_field_name = ($event instanceof EventSeries) ?
+      'field_branch' : 'branch';
+
+    $field = $this->getField($event, $address_field_name);
+
+    if ($field instanceof FieldItemListInterface) {
+      return $field;
+    }
+
+    // Could not find data - look up address from branch instead.
+    $branch_field = $this->getField($event, $branch_field_name);
+
+    if (!$branch_field instanceof FieldItemListInterface) {
+      return NULL;
+    }
+
+    $branch_address_field = 'field_address';
+    $branch = $branch_field->referencedEntities()[0] ?? NULL;
+
+    if (!($branch instanceof NodeInterface) || !$branch->hasField($branch_address_field)) {
+      return NULL;
+    }
+
+    return $branch->get($branch_address_field);
   }
 
 }

--- a/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/eventseries--full.html.twig
@@ -16,10 +16,12 @@
     "event_state": content.field_event_state,
     "event_ticket_categories": content.field_ticket_categories,
     "event_tags": content.field_tags,
-    "event_branch": content.field_branch,
+    "event_partners": content.field_event_partners,
+    "branch": content.field_branch,
     "event_teaser_text": content.field_teaser_text,
   }
 %}
+
 {% include '@novel/layout/eventinstance--full.html.twig' with {
     content: content|merge(instancelike_content)
 } %}


### PR DESCRIPTION
We have a custom field formatter for the address field, that pulls the address of the branch if no alternative is set.
However, the code only worked for eventinstances, and not eventseries. I've fixed it, so now, it happens for both.
This also meant moving some code from the `EventWrapper`, as that also only works with EventInstances.
..And that meant that I had to update the Rest API, to use the field formatter, rather than pulling data directly

#### Link to issue

https://reload.atlassian.net/browse/DDFHER-38