### PR TITLE
Update `dev:restore:database` to prevent cache clearing

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -234,7 +234,7 @@ tasks:
     cmds:
       - task dev:cli -- drush sql:drop -y
       - docker compose exec -T {{ .MYSQL_CONTAINER }} mysql < {{ .SQL_FILE }}
-      - task dev:cache:clear:all
+      - task dev:cli -- drush deploy
     preconditions:
       - sh: "[ {{ .SQL_FILES_COUNT }} -gt 0 ]"
         msg: "There are no sql files in {{ .DIR_RESTORE_DATABASE }}/. Cannot continue."


### PR DESCRIPTION
#### Description

If we have a newer local version, clearing the cache causes an error. Running `drush deploy` ensures the system is properly updated.