### PR TITLE
DDFHER-99 - Fix issue caused by preserved opening hours referencing deleted branches

### DIFF
--- a/web/modules/custom/dpl_opening_hours/src/Model/OpeningHoursRepository.php
+++ b/web/modules/custom/dpl_opening_hours/src/Model/OpeningHoursRepository.php
@@ -93,7 +93,10 @@ class OpeningHoursRepository {
       }
     }, $result->fetchAll(\PDO::FETCH_ASSOC));
 
-    return array_filter($possible_objects);
+    // Using array_values to reindex the array after filtering out NULL values.
+    // This is necessary because we don't handle the deletion of opening hour
+    // instances that reference a branch which has been deleted.
+    return array_values(array_filter($possible_objects));
   }
 
   /**


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-99

#### Description
This fix addresses a problem where preserved opening hours with references to deleted branches caused `array_filter` to process invalid values.

The `loadMultiple` method has been updated to reindex array keys after filtering out `NULL` values. Without this update, `array_filter` retained the original keys, which resulted in the array being treated as an object.