### PR TITLE
Event API: Respect inheritance of eventinstance title.

### DIFF
--- a/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
+++ b/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
@@ -52,7 +52,7 @@ class EventRestMapper {
     $this->eventWrapper = new EventWrapper($this->event);
 
     return new EventsGET200ResponseInner([
-      'title' => $this->event->label(),
+      'title' => $this->getValue('title'),
       'uuid' => $this->event->uuid(),
       'url' => $this->event->toUrl()->setAbsolute(TRUE)->toString(TRUE)->getGeneratedUrl(),
       'ticketManagerRelevance' => !empty($this->getSeriesValue('field_relevant_ticket_manager')),


### PR DESCRIPTION
By using `->label()`, the title will never be overwritten when updating the instance level - this fixes that issue.
