### PR TITLE
DDFHER-101- Allow retrieval of opening hours for multiple branches

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -709,8 +709,12 @@
           }, 
           {
             "name": "nid",
-            "type": "integer",
-            "description": "The (node) id of the node (Branch) that the opening hour applies to.",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "collectionFormat": "csv",
+            "description": "The id(s) of the branch(es) for which to retrieve opening hours. Can be a single id or a comma-separated list of ids.",
             "in": "query",
             "required": true
           }

--- a/web/modules/custom/dpl_opening_hours/src/Model/OpeningHoursRepository.php
+++ b/web/modules/custom/dpl_opening_hours/src/Model/OpeningHoursRepository.php
@@ -59,14 +59,25 @@ class OpeningHoursRepository {
   /**
    * Load a collection of opening hours.
    *
+   * @param int[] $branchIds
+   *   The branch ID or an array of branch IDs.
+   * @param \DateTimeInterface|null $fromDate
+   *   The start date.
+   * @param \DateTimeInterface|null $toDate
+   *   The end date.
+   * @param int|null $repetitionId
+   *   The repetition ID.
+   * @param int|null $categoryId
+   *   The category ID.
+   *
    * @return OpeningHoursInstance[]
    *   Opening hours instances which match the provided criteria.
    */
-  public function loadMultiple(int $branchId = NULL, \DateTimeInterface $fromDate = NULL, \DateTimeInterface $toDate = NULL, int $repetitionId = NULL, int $categoryId = NULL): array {
+  public function loadMultiple(array $branchIds = [], \DateTimeInterface $fromDate = NULL, \DateTimeInterface $toDate = NULL, int $repetitionId = NULL, int $categoryId = NULL): array {
     $query = $this->connection->select(self::INSTANCE_TABLE, self::INSTANCE_TABLE)
       ->fields(self::INSTANCE_TABLE);
-    if ($branchId) {
-      $query->condition('branch_nid', $branchId);
+    if ($branchIds) {
+      $query->condition('branch_nid', $branchIds, 'IN');
     }
     if ($fromDate) {
       $query->condition('date', $fromDate->format('Y-m-d'), '>=');

--- a/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResource.php
+++ b/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResource.php
@@ -89,7 +89,7 @@ final class OpeningHoursResource extends OpeningHoursResourceBase {
 
     try {
       $openingHoursInstances = $this->repository->loadMultiple(
-        $typedRequest->getInt('branch_id'),
+        $typedRequest->getInts('branch_id'),
         $typedRequest->getDateTime('from_date'),
         $typedRequest->getDateTime('to_date')
       );

--- a/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResource.php
+++ b/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResource.php
@@ -89,7 +89,7 @@ final class OpeningHoursResource extends OpeningHoursResourceBase {
 
     try {
       $openingHoursInstances = $this->repository->loadMultiple(
-        [$typedRequest->getInt('branch_id')],
+        $typedRequest->getInt('branch_id') ? [$typedRequest->getInt('branch_id')] : [],
         $typedRequest->getDateTime('from_date'),
         $typedRequest->getDateTime('to_date')
       );

--- a/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResource.php
+++ b/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResource.php
@@ -89,7 +89,7 @@ final class OpeningHoursResource extends OpeningHoursResourceBase {
 
     try {
       $openingHoursInstances = $this->repository->loadMultiple(
-        $typedRequest->getInts('branch_id'),
+        [$typedRequest->getInt('branch_id')],
         $typedRequest->getDateTime('from_date'),
         $typedRequest->getDateTime('to_date')
       );

--- a/web/modules/custom/dpl_redia_legacy/src/Plugin/rest/resource/OpeningHoursResource.php
+++ b/web/modules/custom/dpl_redia_legacy/src/Plugin/rest/resource/OpeningHoursResource.php
@@ -84,8 +84,12 @@ final class OpeningHoursResource extends OpeningHoursResourceBase {
             ],
             'nid' => [
               'name' => 'nid',
-              'type' => 'integer',
-              'description' => 'The (node) id of the node (Branch) that the opening hour applies to.',
+              'type' => 'array',
+              'items' => [
+                'type' => 'integer',
+              ],
+              'collectionFormat' => 'csv',
+              'description' => 'The id(s) of the branch(es) for which to retrieve opening hours. Can be a single id or a comma-separated list of ids.',
               'in' => 'query',
               'required' => TRUE,
             ],
@@ -118,8 +122,8 @@ final class OpeningHoursResource extends OpeningHoursResourceBase {
   public function get(Request $request): Response {
     $typedRequest = new RequestTyped($request);
 
-    $nid = $typedRequest->getInt('nid');
-    if ($nid === NULL) {
+    $nid = $typedRequest->getInts('nid');
+    if (empty($nid)) {
       throw new BadRequestHttpException("The 'nid' parameter is required.");
     }
     $fromDate = $typedRequest->getDateTime('from_date');

--- a/web/modules/custom/drupal_typed/src/RequestTyped.php
+++ b/web/modules/custom/drupal_typed/src/RequestTyped.php
@@ -87,7 +87,7 @@ class RequestTyped {
     if ($value === NULL) {
       return $default;
     }
-    $strings = \Safe\preg_split("/\s*{$separator}\s*/", $value, PREG_NO_ERROR);
+    $strings = \Safe\preg_split("/\s*{$separator}\s*/", $value, PREG_SPLIT_NO_EMPTY);
     return array_map(fn($value) => intval($value), $strings);
   }
 

--- a/web/modules/custom/drupal_typed/src/RequestTyped.php
+++ b/web/modules/custom/drupal_typed/src/RequestTyped.php
@@ -65,4 +65,30 @@ class RequestTyped {
     }
   }
 
+  /**
+   * Retrieve a list of values as integers.
+   *
+   * This method retrieves a string value from the request, splits it using the
+   * provided separator, and returns an array of integers. If the value is null,
+   * the default array will be returned.
+   *
+   * @param string $key
+   *   The key to retrieve from the request.
+   * @param int[] $default
+   *   The default array of integers to return if the key does not exist.
+   * @param string $separator
+   *   The separator used to split the string value. Defaults to a comma (",").
+   *
+   * @return int[]
+   *   An array of integers.
+   */
+  public function getInts(string $key, array $default = [], string $separator = ","): array {
+    $value = $this->request->get($key);
+    if ($value === NULL) {
+      return $default;
+    }
+    $strings = \Safe\preg_split("/\s*{$separator}\s*/", $value, PREG_NO_ERROR);
+    return array_map(fn($value) => intval($value), $strings);
+  }
+
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-101

#### Description

This pull request enhances the opening hours API (redia_legacy) by enabling clients to retrieve opening hours for multiple branches within a single request. Previously, the API allowed retrieval for only one branch at a time.

#### Test

**Redia** API (supports multiple branches):
- https://varnish.pr-1659.dpl-cms.dplplat01.dpl.reload.dk/opening_hours/instances?nid=10&from_date=2024-10-23&to_date=2024-10-23
- https://varnish.pr-1659.dpl-cms.dplplat01.dpl.reload.dk/opening_hours/instances?nid=18&from_date=2024-10-23&to_date=2024-10-23
- https://varnish.pr-1659.dpl-cms.dplplat01.dpl.reload.dk/opening_hours/instances?nid=10,18&from_date=2024-10-23&to_date=2024-10-23

**Cms API:** 
- https://varnish.pr-1659.dpl-cms.dplplat01.dpl.reload.dk/api/v1/opening_hours?branch_id=10&from_date=2024-10-23&to_date=2024-10-23
- https://varnish.pr-1659.dpl-cms.dplplat01.dpl.reload.dk/api/v1/opening_hours?branch_id=18&from_date=2024-10-23&to_date=2024-10-23