### PR TITLE
Add go app version 0.0.10 (unilogin) for demo use

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,11 @@ services:
     environment:
       << : *default-environment
 
+  node:
+    image: ghcr.io/danskernesdigitalebibliotek/dpl-go-node:0.0.12
+    labels:
+      lagoon.type: node
+
 volumes:
   projectroot:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,7 @@ services:
     image: ghcr.io/danskernesdigitalebibliotek/dpl-go-node:0.0.12
     labels:
       lagoon.type: node
+      provenance: false
 
 volumes:
   projectroot:


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-135

#### Description

This is partly for demoing Unilogin - but also to get the first version of adding a node app to the Lagoon services.
