### PR TITLE
Also create deployments when PRs are synchronized

### DIFF
--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -27,7 +27,7 @@ jobs:
   CreateDeployment:
     name: Creating deployment
     runs-on: ubuntu-latest
-    if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
+    if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' }}
     steps:
       - run: |
           LAGOON_DEPLOYS_LOG_URL=$(echo "https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-${{ env.LAGOON_ENVIRONMENT }}/deployments")

--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -25,7 +25,7 @@ jobs:
 
   # Creating the deployment that Lagoon will look for, and add status to.
   CreateDeployment:
-    name: Creating deployment
+    name: Create deployment
     runs-on: ubuntu-latest
     if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' }}
     steps:

--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -28,6 +28,7 @@ jobs:
     name: Create deployment
     runs-on: ubuntu-latest
     if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' }}
+    needs: [BranchNameLength]
     steps:
       - run: |
           LAGOON_DEPLOYS_LOG_URL=$(echo "https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-${{ env.LAGOON_ENVIRONMENT }}/deployments")
@@ -49,6 +50,7 @@ jobs:
     name: Close environment
     runs-on: ubuntu-latest
     if: ${{ github.event.action == 'closed' }}
+    needs: [BranchNameLength]
     steps:
       - run: gh api --method DELETE "/repos/${{ env.OWNER }}/${{ env.REPO }}/environments/${{ env.LAGOON_ENVIRONMENT }}"
 


### PR DESCRIPTION
#### Description

Currently we only create deployments when pull requests are created or reopened. As a result the environment will be shown as outdated if there are additional commits pushed to the branch.

Update the workflow to also run on synchronisation to address this.

This was the same approach as used previously.

#### Screenshot of the result

Before:

![dpl-cms 2024-10-22 22-34-56](https://github.com/user-attachments/assets/6bf5b026-0990-4222-8251-a44da852ee9e)

After: See the deployments of this PR.