### PR TITLE
DDFHER-98 - Event list jumps to top of page

### DIFF
--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -342,7 +342,7 @@ display:
           preserve_facet_query_args: false
           query_tags: {  }
       relationships: {  }
-      use_ajax: false
+      use_ajax: true
       header: {  }
       footer: {  }
       display_extenders: {  }

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -132,7 +132,7 @@ display:
           text_input_required_format: basic
           bef:
             general:
-              autosubmit: true
+              autosubmit: false
               autosubmit_exclude_textfield: false
               autosubmit_textfield_delay: 500
               autosubmit_hide: true
@@ -142,18 +142,20 @@ display:
               secondary_open: false
               reset_button_always_show: false
             filter:
-              event_categories:
+              search_api_fulltext:
                 plugin_id: default
                 advanced:
-                  sort_options: false
+                  placeholder_text: ''
                   rewrite:
                     filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
                   collapsible: false
+                  collapsible_disable_automatic_open: false
                   is_secondary: false
-                options_show_only_used: true
+                options_show_only_used: false
                 options_show_only_used_filtered: false
-                options_hide_when_empty: true
-                options_show_items_count: 0
+                options_hide_when_empty: false
+                options_show_items_count: false
       access:
         type: perm
         options:

--- a/web/themes/custom/novel/css/novel.css
+++ b/web/themes/custom/novel/css/novel.css
@@ -55,3 +55,10 @@
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
   margin-right: 6px;
 }
+
+/*
+Hide the submit button from the "full text search" formn in (Events and articles view)
+The button cannot be removed directly in the Drupal view */
+.search-full-text input[value="Apply"] {
+  display: none;
+}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-98
<s>https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/750</s>

#### Description

This pull request fixes the problem in the Event view where it scrolls to the top when navigating to the next page.

Because we use the infinite scroll module in Drupal, AJAX is needed for the view. We turned that off in a previous pull request when we added full-text search in [this commit](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1541/files).

The solution is to re-enable AJAX, turn off auto-submit, and hide the “Apply” button with CSS 


#### Test
https://varnish.pr-1678.dpl-cms.dplplat01.dpl.reload.dk/arrangementer