### PR TITLE
Encode event descriptions in Redia RSS feed

### DIFF
--- a/web/modules/custom/dpl_redia_legacy/src/RediaEvent.php
+++ b/web/modules/custom/dpl_redia_legacy/src/RediaEvent.php
@@ -54,7 +54,9 @@ class RediaEvent extends ControllerBase {
     }
 
     $this->title = $event_instance->label();
-    $this->description = $event_wrapper->getDescription();
+    // The description for an event may contain HTML tags which are not allowed
+    // in an RSS/XML feed. Encode them.
+    $this->description = htmlspecialchars($event_wrapper->getDescription() ?? "");
     $this->author = $event_instance->getOwner()->get('field_author_name')->getString();
     $this->id = $event_instance->id();
     $this->date = $changed_date->format('r');


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFHER-60

#### Description

The description main contain HTML tags which are not allowed in the RSS/XML. Encode them accordingly.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

