### PR TITLE
Update `drupal/openapi` to "2.2.0" and remove patch `3313521`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -335,9 +335,6 @@
             "drupal/jsonlog": {
                 "3251587: Change logging from stdout to stderr": "https://www.drupal.org/files/issues/2021-11-29/jsonlog-change-stdout-to-stderr-3251587-3.patch"
             },
-            "drupal/openapi": {
-                "3313521: OpenAPI security field does not validate": "https://git.drupalcode.org/project/openapi/-/commit/4964cf725242040ddfb0c591b6044ee1fa5912ef.patch"
-            },
             "drupal/openapi_rest": {
                 "3171530 + 3116760: Add support for parameter and response descriptions": "patches/openapi-parameter-response-descriptions-14-3.patch",
                 "3343816: Specification includes disabled resources": "https://git.drupalcode.org/project/openapi_rest/-/commit/6618157334feca93fad1041583375eed660b9085.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47bfbebceea8eb14f373649759c78e18",
+    "content-hash": "d3566bedfb999c8be1ee05efb82d09ce",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -5713,29 +5713,32 @@
         },
         {
             "name": "drupal/openapi",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/openapi.git",
-                "reference": "8.x-2.1"
+                "reference": "8.x-2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/openapi-8.x-2.1.zip",
-                "reference": "8.x-2.1",
-                "shasum": "c0ce4095f555dad31c442f2354453ee4f6e9fadc"
+                "url": "https://ftp.drupal.org/files/projects/openapi-8.x-2.2.zip",
+                "reference": "8.x-2.2",
+                "shasum": "27805fddef69f7720cd49d2272c0e247f18fc715"
             },
             "require": {
-                "drupal/core": "^8 || ^9 || ^10"
+                "drupal/core": "^10 || ^11"
             },
             "conflict": {
                 "drupal/core": "<8.7"
             },
+            "require-dev": {
+                "drupal/openapi_ui": "1.x-dev"
+            },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.1",
-                    "datestamp": "1669682974",
+                    "version": "8.x-2.2",
+                    "datestamp": "1720625199",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -19087,6 +19090,6 @@
     "platform": {
         "php": "8.1.*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/openapi.json
+++ b/openapi.json
@@ -16,7 +16,7 @@
       "type": "apiKey",
       "name": "X-CSRF-Token",
       "in": "header",
-      "x-tokenUrl": "http://varnish:8080/user/token"
+      "x-tokenUrl": "http://varnish:8080/session/token"
     }
   },
   "security": [


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-113

#### Description
The patch [3313521](https://www.drupal.org/node/3313521), contributed by Kasper Garnes, is now included in `openapi 2.2.0`. After installation, the specification is validated and downloaded to `openapi.json`. The change to `x-tokenUrl` will not cause any issues as we do not use it. Refer to `web/modules/custom/dpl_opening_hours/src/EventSubscriber/ApiRouteSubscriber.php` for details.