### PR TITLE
Disabled 'devel_generate' by removing it from core.extension.yml and

### DIFF
--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -39,6 +39,7 @@ $settings['config_exclude_modules'] = [
   'dpl_example_content',
   'dpl_example_breadcrumb',
   'devel',
+  'devel_generate',
   'field_ui',
   'purge_ui',
   'views_ui',

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -28,7 +28,6 @@ module:
   datetime_range: 0
   dblog: 0
   default_content: 0
-  devel_generate: 0
   dpl_admin: 0
   dpl_article: 0
   dpl_breadcrumb: 0

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -30,6 +30,21 @@ function _dpl_update_install_modules(array $modules): string {
 }
 
 /**
+ * Helper function to uninstall modules.
+ *
+ * @param string[] $modules
+ *   The modules to install.
+ *
+ * @return string
+ *   The feedback message.
+ */
+function _dpl_update_uninstall_modules(array $modules): string {
+  DrupalTyped::service(ModuleInstallerInterface::class, 'module_installer')->uninstall($modules);
+  $modules_string = implode(', ', $modules);
+  return "Uninstalled modules: {$modules_string}.";
+}
+
+/**
  * Helper function, for adding translations.
  *
  * Generally speaking, this should be avoided, as it is DDF's responsibility
@@ -84,6 +99,7 @@ function dpl_update_install(): string {
   $messages[] = dpl_update_update_10017();
   $messages[] = dpl_update_update_10018();
   $messages[] = dpl_update_update_10019();
+  $messages[] = dpl_update_update_10020();
 
   return implode('\r\n', $messages);
 }
@@ -238,4 +254,11 @@ function dpl_update_update_10019(): string {
   );
 
   return $return;
+}
+
+/**
+ * Uninstall devel_generate module.
+ */
+function dpl_update_update_10020(): string {
+  return _dpl_update_uninstall_modules(['devel_generate']);
 }


### PR DESCRIPTION
Disabled 'devel_generate' by removing it from core.extension.yml and creating a new update hook for uninstalling the module.

We also added the module to all.settings.php 'config_exclude_modules' list.