### PR TITLE
DDFHER-116 - Refactor `getInts` to explicitly set split `Limit` in `preg_split`

### DIFF
--- a/web/modules/custom/drupal_typed/src/RequestTyped.php
+++ b/web/modules/custom/drupal_typed/src/RequestTyped.php
@@ -87,7 +87,7 @@ class RequestTyped {
     if ($value === NULL) {
       return $default;
     }
-    $strings = \Safe\preg_split("/\s*{$separator}\s*/", $value, PREG_SPLIT_NO_EMPTY);
+    $strings = \Safe\preg_split("/\s*{$separator}\s*/", $value, -1, PREG_SPLIT_NO_EMPTY);
     return array_map(fn($value) => intval($value), $strings);
   }
 


### PR DESCRIPTION
#### Link to Issue
https://reload.atlassian.net/browse/DDFHER-116

#### Description
This pull request fixes an issue where only the opening hours for a single branch were returned.

- Updated the `getInts` method to set `-1` as the limit in `preg_split`, ensuring that no split limit is applied. 

According to [W3Schools documentation](https://www.w3schools.com/php/func_regex_preg_split.asp), `-1` is the default limit, but explicitly specifying it fix the issue.

I also considered using `explode` for simplicity but retained `preg_split` for its whitespace-trimming capability. This choice ensures accurate handling of branch IDs that may include extra spaces around separators (e.g., "18 , 24").

#### Test
http://varnish.pr-1713.dpl-cms.dplplat01.dpl.reload.dk/opening_hours/instances?from_date=2024-11-01&to_date=2024-11-20&nid=18

http://varnish.pr-1713.dpl-cms.dplplat01.dpl.reload.dk/opening_hours/instances?from_date=2024-11-01&to_date=2024-11-20&nid=25

**Both branches 18 and 25**
http://varnish.pr-1713.dpl-cms.dplplat01.dpl.reload.dk/opening_hours/instances?from_date=2024-11-01&to_date=2024-11-20&nid=18,25
