### PR TITLE
DDFHER-121 - Update `drupal/paragraphs_ee` module to "10.0.5"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -342,8 +342,7 @@
                 "3343816: Specification includes disabled resources": "https://git.drupalcode.org/project/openapi_rest/-/commit/6618157334feca93fad1041583375eed660b9085.patch"
             },
             "drupal/paragraphs_ee": {
-                "3106254: Sorting paragraph list alphabetically in modal": "https://www.drupal.org/files/issues/2023-03-30/paragraphs_ee_sort.patch",
-                "3246408: Arrow buttons instead of drag n drop": "https://git.drupalcode.org/project/paragraphs_ee/-/commit/4e16e0d79386dcf13db901f5634f2e30f0814137.patch"
+                "3106254: Sorting paragraph list alphabetically in modal": "https://www.drupal.org/files/issues/2023-03-30/paragraphs_ee_sort.patch"
             },
             "drupal/potion": {
                 "3201365: Allow setting a default write mode when running potion:generate": "https://www.drupal.org/files/issues/2021-03-03/potion-allow_setting_a_default_write_mode-3201365-2.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "257ba7f8717d1f20ffec471eb80c349c",
+    "content-hash": "5daad98d22957dcbcf2971348cae68e9",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -6441,21 +6441,21 @@
         },
         {
             "name": "drupal/paragraphs_ee",
-            "version": "10.0.3",
+            "version": "10.0.5",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/paragraphs_ee.git",
-                "reference": "10.0.3"
+                "reference": "10.0.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs_ee-10.0.3.zip",
-                "reference": "10.0.3",
-                "shasum": "172c201a5c8f993a61665c011b5b45c0ceba1dc8"
+                "url": "https://ftp.drupal.org/files/projects/paragraphs_ee-10.0.5.zip",
+                "reference": "10.0.5",
+                "shasum": "a638c2a75804eb89e0934f159210a599267ee4a8"
             },
             "require": {
                 "drupal/core": ">=10.0",
-                "drupal/paragraphs_features": "^2.0@beta"
+                "drupal/paragraphs_features": "^2.0"
             },
             "require-dev": {
                 "drupal/paragraphs_sets": "*",
@@ -6465,8 +6465,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "10.0.3",
-                    "datestamp": "1701956434",
+                    "version": "10.0.5",
+                    "datestamp": "1729580104",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6492,17 +6492,17 @@
         },
         {
             "name": "drupal/paragraphs_features",
-            "version": "2.0.0-beta3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/paragraphs_features.git",
-                "reference": "2.0.0-beta3"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs_features-2.0.0-beta3.zip",
-                "reference": "2.0.0-beta3",
-                "shasum": "b040ba0048101f578752050bc55cc039939a649c"
+                "url": "https://ftp.drupal.org/files/projects/paragraphs_features-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "3f4856f2c6ade242855f5311ff26e8951b8a53a7"
             },
             "require": {
                 "drupal/core": "^9.2 || ^10",
@@ -6514,11 +6514,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-beta3",
-                    "datestamp": "1692697161",
+                    "version": "2.0.0",
+                    "datestamp": "1713956979",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -19503,6 +19503,6 @@
     "platform": {
         "php": "8.1.*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -156,17 +156,20 @@ content:
       features:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
+        convert: '0'
         duplicate: duplicate
     third_party_settings:
-      paragraphs_ee:
-        paragraphs_ee:
-          dialog_off_canvas: false
-          dialog_style: tiles
       paragraphs_features:
         add_in_between: true
         add_in_between_link_count: 0
         delete_confirmation: true
         show_drag_and_drop: true
+        show_collapse_all: true
+      paragraphs_ee:
+        paragraphs_ee:
+          dialog_off_canvas: false
+          dialog_style: tiles
+          drag_drop: true
   field_publication_date:
     type: datetime_default
     weight: 7

--- a/config/sync/core.entity_form_display.node.branch.default.yml
+++ b/config/sync/core.entity_form_display.node.branch.default.yml
@@ -86,6 +86,7 @@ content:
       features:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
+        convert: '0'
         duplicate: duplicate
     third_party_settings:
       paragraphs_features:
@@ -93,10 +94,12 @@ content:
         add_in_between_link_count: 0
         delete_confirmation: true
         show_drag_and_drop: true
+        show_collapse_all: true
       paragraphs_ee:
         paragraphs_ee:
           dialog_off_canvas: false
           dialog_style: tiles
+          drag_drop: true
   field_phone:
     type: telephone_default
     weight: 12

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -116,17 +116,20 @@ content:
       features:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
+        convert: '0'
         duplicate: duplicate
     third_party_settings:
-      paragraphs_ee:
-        paragraphs_ee:
-          dialog_off_canvas: false
-          dialog_style: tiles
       paragraphs_features:
         add_in_between: true
         add_in_between_link_count: 0
         delete_confirmation: true
         show_drag_and_drop: true
+        show_collapse_all: true
+      paragraphs_ee:
+        paragraphs_ee:
+          dialog_off_canvas: false
+          dialog_style: tiles
+          drag_drop: true
   field_publication_date:
     type: datetime_default
     weight: 8


### PR DESCRIPTION
#### Link to Issue
https://reload.atlassian.net/browse/DDFHER-121

#### Description
This update introduces arrows to move paragraphs up and down, which can be enabled through "Manage form display" by selecting the "Show arrows for drag & drop" setting for the paragraphs field. Therefore, I have removed patch `3246408`