### PR TITLE
DDFBRA-138 - Create task for fetching UUID of the graphql_consumer

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -382,10 +382,10 @@ tasks:
     cmds:
       - cmd: task dev:cli -- drush default-content:export-module dpl_example_content
 
-  dev:dpl-go:get-graphql-credentials:
-    desc: Get the GraphQL credentials from the site
+  dev:go:graphql-credentials:
+    desc: Get the GraphQL consumer credentials
     cmds:
-      - cmd: task dev:cli -- drush php-eval "dpl_consumers_print_consumer_credentials()"
+      - cmd: task dev:cli -- drush dpl_consumers:consumer-credentials
 
   ci:reset:
     desc: Create CI setup in a clean state

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -382,6 +382,11 @@ tasks:
     cmds:
       - cmd: task dev:cli -- drush default-content:export-module dpl_example_content
 
+  dev:dpl-go:get-graphql-credentials:
+    desc: Get the GraphQL credentials from the site
+    cmds:
+      - cmd: task dev:cli -- drush php-eval "dpl_consumers_print_consumer_credentials()"
+
   ci:reset:
     desc: Create CI setup in a clean state
     cmds:

--- a/web/modules/custom/dpl_consumers/dpl_consumers.module
+++ b/web/modules/custom/dpl_consumers/dpl_consumers.module
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * DPL consumers module.
+ */
+
+use Drupal\dpl_consumers\DplGraphqlConsumersConstants;
+
+/**
+ * Function is used for printing out the consumer credentials to the console.
+ */
+function dpl_consumers_print_consumer_credentials(): void {
+  $graphql_consumer_client_id = DplGraphqlConsumersConstants::GRAPHQL_CONSUMER_CLIENT_ID;
+  $consumer_uuid = dpl_consumers_get_consumer_uuid($graphql_consumer_client_id);
+  print_r('Consumer UUID: ' . $consumer_uuid);
+}
+
+/**
+ * Get consumer by Client ID.
+ *
+ * @return string
+ *   The consumer UUID.
+ */
+function dpl_consumers_get_consumer_uuid(string $client_id): string {
+  try {
+    $consumer = \Drupal::entityTypeManager()
+      ->getStorage('consumer')
+      ->loadByProperties(['client_id' => $client_id]);
+
+    if (!empty($consumer)) {
+      $consumer = reset($consumer);
+      $uuid = $consumer->uuid();
+      return $uuid ?? 'Consumer UUID not found.';
+    }
+    else {
+      return 'Consumer not found.';
+    }
+  }
+  catch (\Exception $e) {
+    \Drupal::logger('dpl_consumers')->error($e->getMessage());
+    return 'Error fetching consumer.';
+  }
+}

--- a/web/modules/custom/dpl_consumers/dpl_consumers.module
+++ b/web/modules/custom/dpl_consumers/dpl_consumers.module
@@ -10,6 +10,8 @@
  *
  * @return string
  *   The consumer UUID.
+ *
+ * @throws \Exception
  */
 function dpl_consumers_get_consumer_uuid(string $client_id): string {
   try {
@@ -17,17 +19,18 @@ function dpl_consumers_get_consumer_uuid(string $client_id): string {
       ->getStorage('consumer')
       ->loadByProperties(['client_id' => $client_id]);
 
+    // We assume that there is only one consumer with the given client ID
+    // as it is used an as unique identifier (machine name).
     if (!empty($consumer)) {
       $consumer = reset($consumer);
-      $uuid = $consumer->uuid();
-      return $uuid ?? 'Consumer UUID not found.';
+
+      return $consumer->uuid() ?? throw new \Exception('UUID not found.');
     }
     else {
-      return 'Consumer not found.';
+      throw new \Exception('Consumer not found.');
     }
   }
   catch (\Exception $e) {
-    \Drupal::logger('dpl_consumers')->error($e->getMessage());
-    return 'Error fetching consumer.';
+    throw new \Exception($e->getMessage());
   }
 }

--- a/web/modules/custom/dpl_consumers/dpl_consumers.module
+++ b/web/modules/custom/dpl_consumers/dpl_consumers.module
@@ -5,17 +5,6 @@
  * DPL consumers module.
  */
 
-use Drupal\dpl_consumers\DplGraphqlConsumersConstants;
-
-/**
- * Function is used for printing out the consumer credentials to the console.
- */
-function dpl_consumers_print_consumer_credentials(): void {
-  $graphql_consumer_client_id = DplGraphqlConsumersConstants::GRAPHQL_CONSUMER_CLIENT_ID;
-  $consumer_uuid = dpl_consumers_get_consumer_uuid($graphql_consumer_client_id);
-  print_r('Consumer UUID: ' . $consumer_uuid);
-}
-
 /**
  * Get consumer by Client ID.
  *

--- a/web/modules/custom/dpl_consumers/drush.services.yml
+++ b/web/modules/custom/dpl_consumers/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+  dpl_consumer.commands:
+    class: \Drupal\dpl_consumers\Commands\DplConsumersCommands
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/dpl_consumers/src/Commands/DplConsumersCommands.php
+++ b/web/modules/custom/dpl_consumers/src/Commands/DplConsumersCommands.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\dpl_consumers\Commands;
+
+use Drupal\dpl_consumers\DplGraphqlConsumersConstants;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush commands for DPL consumers.
+ */
+final class DplConsumersCommands extends DrushCommands {
+
+  /**
+   * Function is used for printing out the consumer credentials to the console.
+   *
+   * @command dpl_consumers:consumer-credentials
+   */
+  public function getConsumerCredentials(): void {
+    $graphql_consumer_client_id = DplGraphqlConsumersConstants::GRAPHQL_CONSUMER_CLIENT_ID;
+    $consumer_uuid = dpl_consumers_get_consumer_uuid($graphql_consumer_client_id);
+    $this->output()->writeln('Consumer UUID: ' . $consumer_uuid);
+  }
+
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-138

#### Description

Added a new task for fetching the UUID of the graphql_consumer. This UUID is used while calling the GraphQL API.

The task is:

`task dev:dpl-go:get-graphql-credentials` 

It fetches the UUID which should be set in the request headers as X-Consumer-ID 

