### PR TITLE
Temporarily disable the RSS feed for exposing events to Redia

### DIFF
--- a/web/modules/custom/dpl_redia_legacy/src/Controller/RssFeeds/EventsController.php
+++ b/web/modules/custom/dpl_redia_legacy/src/Controller/RssFeeds/EventsController.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\dpl_redia_legacy\Controller\RssFeeds;
 
-use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\CacheableResponse;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Datetime\DateFormatterInterface;
@@ -11,6 +10,7 @@ use Drupal\Core\Url;
 use Drupal\dpl_redia_legacy\RediaEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use function Safe\strtotime;
 
 /**
@@ -40,6 +40,9 @@ class EventsController extends ControllerBase {
    * Getting the RSS/XML feed of the items.
    */
   public function getFeed(Request $request): CacheableResponse {
+    // Disable the feed while we wait for validation by Redia.
+    return new CacheableResponse("Feed disabled temporarily", Response::HTTP_NOT_FOUND);
+    /*
     $items = $this->getItems();
 
     $rss_content = $this->buildRss($items, $request);
@@ -56,6 +59,7 @@ class EventsController extends ControllerBase {
 
     $response->headers->set('Content-Type', 'application/rss+xml');
     return $response;
+     */
   }
 
   /**
@@ -64,7 +68,7 @@ class EventsController extends ControllerBase {
    * @return \Drupal\dpl_redia_legacy\RediaEvent[]
    *   An array of necessary item fields, used in buildRss().
    */
-  private function getItems(): array {
+  protected function getItems(): array {
 
     $storage = $this->entityTypeManager()->getStorage('eventinstance');
     $query = $storage->getQuery()
@@ -94,7 +98,7 @@ class EventsController extends ControllerBase {
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The request, for looking up the current site info.
    */
-  private function buildRss(array $items, Request $request): string {
+  protected function buildRss(array $items, Request $request): string {
     $config = $this->config('system.site');
     $site_title = $config->get('name');
     $site_url = $request->getSchemeAndHttpHost();


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFHER-127

#### Description

Problems with the current feed has led to events appearing in problematic ways e.g. by being listed as free to attend but actually having non-free ticket categories registered.

To avoid this we temporarily disable the feed to avoid exposing data.

Provide a cacheable response with a HTTP error code stating that the feed is not available currently.

404 seems like an appropriate error code given the situation even though this is strictly not a client issue. 503 indicates a problem which is more temporary than is the case there. 501 indicates problems with the HTTP method which is not the case.

#### Additional comments or questions

You can test this locally by trying to access `/ding-redia-rss/event`. It should return a 404.