### PR TITLE
DDFHER-126 - Update `thecodingmachine/safe` to "^2.5.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -184,7 +184,7 @@
         "spatie/color": "^1.5",
         "symfony/property-access": "^6.2",
         "symfony/property-info": "^6.2",
-        "thecodingmachine/safe": "^1.3",
+        "thecodingmachine/safe": "^2.5.0",
         "zaporylie/composer-drupal-optimizations": "1.2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b232f453ba900422d39f9f2e62c84a66",
+    "content-hash": "bdc470efbab9b26f6676301c24108fb8",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -14773,39 +14773,46 @@
         },
         {
             "name": "thecodingmachine/safe",
-            "version": "v1.3.3",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thecodingmachine/safe.git",
-                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc"
+                "reference": "3115ecd6b4391662b4931daac4eba6b07a2ac1f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
-                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/3115ecd6b4391662b4931daac4eba6b07a2ac1f0",
+                "reference": "3115ecd6b4391662b4931daac4eba6b07a2ac1f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": "^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan": "^1.5",
+                "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.2",
-                "thecodingmachine/phpstan-strict-rules": "^0.12"
+                "thecodingmachine/phpstan-strict-rules": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.1-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
                 "files": [
                     "deprecated/apc.php",
+                    "deprecated/array.php",
+                    "deprecated/datetime.php",
                     "deprecated/libevent.php",
+                    "deprecated/misc.php",
+                    "deprecated/password.php",
                     "deprecated/mssql.php",
                     "deprecated/stats.php",
+                    "deprecated/strings.php",
                     "lib/special_cases.php",
+                    "deprecated/mysqli.php",
                     "generated/apache.php",
                     "generated/apcu.php",
                     "generated/array.php",
@@ -14826,6 +14833,7 @@
                     "generated/fpm.php",
                     "generated/ftp.php",
                     "generated/funchand.php",
+                    "generated/gettext.php",
                     "generated/gmp.php",
                     "generated/gnupg.php",
                     "generated/hash.php",
@@ -14835,7 +14843,6 @@
                     "generated/image.php",
                     "generated/imap.php",
                     "generated/info.php",
-                    "generated/ingres-ii.php",
                     "generated/inotify.php",
                     "generated/json.php",
                     "generated/ldap.php",
@@ -14844,20 +14851,14 @@
                     "generated/mailparse.php",
                     "generated/mbstring.php",
                     "generated/misc.php",
-                    "generated/msql.php",
                     "generated/mysql.php",
-                    "generated/mysqli.php",
-                    "generated/mysqlndMs.php",
-                    "generated/mysqlndQc.php",
                     "generated/network.php",
                     "generated/oci8.php",
                     "generated/opcache.php",
                     "generated/openssl.php",
                     "generated/outcontrol.php",
-                    "generated/password.php",
                     "generated/pcntl.php",
                     "generated/pcre.php",
-                    "generated/pdf.php",
                     "generated/pgsql.php",
                     "generated/posix.php",
                     "generated/ps.php",
@@ -14868,7 +14869,6 @@
                     "generated/sem.php",
                     "generated/session.php",
                     "generated/shmop.php",
-                    "generated/simplexml.php",
                     "generated/sockets.php",
                     "generated/sodium.php",
                     "generated/solr.php",
@@ -14891,13 +14891,13 @@
                     "generated/zip.php",
                     "generated/zlib.php"
                 ],
-                "psr-4": {
-                    "Safe\\": [
-                        "lib/",
-                        "deprecated/",
-                        "generated/"
-                    ]
-                }
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "deprecated/Exceptions/",
+                    "generated/Exceptions/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -14906,9 +14906,9 @@
             "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
             "support": {
                 "issues": "https://github.com/thecodingmachine/safe/issues",
-                "source": "https://github.com/thecodingmachine/safe/tree/v1.3.3"
+                "source": "https://github.com/thecodingmachine/safe/tree/v2.5.0"
             },
-            "time": "2020-10-28T17:51:34+00:00"
+            "time": "2023-04-05T11:54:14+00:00"
         },
         {
             "name": "twig/twig",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -70,10 +70,6 @@ parameters:
       path: web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
     # Ignore options for Drush commands. These are specified using specialized annotations.
     - '#Method Drupal\\.*\Commands\\.* has parameter \$options with no value type specified in iterable type array\.#'
-    # Ignore safe check for collation_fixer. We plan to upstream it and do not want to add this dependency.
-    -
-      message: "#thecodingmachine\/safe#"
-      path: web/modules/custom/collation_fixer
 
   scanFiles:
     # Needed to make locale_translation_batch_fetch_finished() discoverable.

--- a/web/modules/custom/dpl_campaign/src/Plugin/rest/resource/MatchResource.php
+++ b/web/modules/custom/dpl_campaign/src/Plugin/rest/resource/MatchResource.php
@@ -15,7 +15,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
-use function Safe\usort as usort;
 
 // Descriptions quickly become long and Doctrine annotations have no good way
 // of handling multiline strings.

--- a/web/modules/custom/dpl_event/src/Form/SettingsForm.php
+++ b/web/modules/custom/dpl_event/src/Form/SettingsForm.php
@@ -10,7 +10,6 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\dpl_event\Workflows\UnpublishSchedule;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use function Safe\array_combine as array_combine;
 
 /**
  * Configure Event settings for this site.

--- a/web/modules/custom/dpl_event/src/PriceFormatter.php
+++ b/web/modules/custom/dpl_event/src/PriceFormatter.php
@@ -6,7 +6,6 @@ use Brick\Math\BigDecimal;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\dpl_event\Form\SettingsForm;
-use function Safe\sort;
 
 /**
  * Formats prices according to local rules.

--- a/web/modules/custom/dpl_fbi/dpl_fbi.install
+++ b/web/modules/custom/dpl_fbi/dpl_fbi.install
@@ -2,7 +2,6 @@
 
 use Drupal\Core\Database\Database;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
-use function Safe\sprintf as sprintf;
 
 /**
  * Adds 'material_type' column to 'dpl_fbi_work_id' field storage.

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -16,7 +16,6 @@ use Drupal\dpl_library_agency\ReservationSettings;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use function Safe\array_combine as array_combine;
 use function Safe\preg_match as preg_match;
-use function Safe\usort as usort;
 
 /**
  * General Settings form for a library agency.

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -14,7 +14,6 @@ use Drupal\dpl_library_agency\FbiProfileType;
 use Drupal\dpl_library_agency\GeneralSettings;
 use Drupal\dpl_library_agency\ReservationSettings;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use function Safe\array_combine as array_combine;
 use function Safe\preg_match as preg_match;
 
 /**

--- a/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
@@ -8,7 +8,6 @@ use Drupal\dpl_login\Adgangsplatformen\Config;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Log\LogLevel;
-use function Safe\sprintf;
 
 /**
  * Library Token Handler Service.

--- a/web/modules/custom/dpl_login/src/Adgangsplatformen/Config.php
+++ b/web/modules/custom/dpl_login/src/Adgangsplatformen/Config.php
@@ -4,7 +4,6 @@ namespace Drupal\dpl_login\Adgangsplatformen;
 
 use Drupal\dpl_login\Exception\MissingConfigurationException;
 use Drupal\dpl_react\DplReactConfigBase;
-use function Safe\sprintf as sprintf;
 
 /**
  * Structured access to configuration for Adgangsplatformen.

--- a/web/modules/custom/dpl_login/src/Controller/DplLoginController.php
+++ b/web/modules/custom/dpl_login/src/Controller/DplLoginController.php
@@ -15,7 +15,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use function Safe\sprintf;
 
 /**
  * DPL React Controller.

--- a/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
+++ b/web/modules/custom/dpl_login/src/OpenIdUserInfoService.php
@@ -4,8 +4,6 @@ namespace Drupal\dpl_login;
 
 use Drupal\Core\Site\Settings;
 
-use function Safe\sprintf;
-
 /**
  * OpenIdUserInfoService.
  *

--- a/web/modules/custom/dpl_opening_hours/src/Model/OpeningHoursInstance.php
+++ b/web/modules/custom/dpl_opening_hours/src/Model/OpeningHoursInstance.php
@@ -6,7 +6,6 @@ use Drupal\dpl_opening_hours\Model\Repetition\NoRepetition;
 use Drupal\dpl_opening_hours\Model\Repetition\Repetition;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
-use function Safe\sprintf as sprintf;
 
 /**
  * Value object which defines a single time period where a branch is open.

--- a/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
+++ b/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
@@ -69,12 +69,7 @@ function dpl_paragraphs_preprocess_paragraph__links(array &$variables): void {
 
       // Get the normalized path. If null, default to an empty string.
       $parsed_url = parse_url($url->toString(), PHP_URL_PATH);
-
-      if (!is_string($parsed_url)) {
-        $parsed_url = '';
-      }
-
-      $normalized_path = rtrim($parsed_url, '/');
+      $normalized_path = (is_string($parsed_url)) ? rtrim($parsed_url, '/') : '';
 
       $link_type = 'internal';
 

--- a/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
+++ b/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
@@ -69,7 +69,12 @@ function dpl_paragraphs_preprocess_paragraph__links(array &$variables): void {
 
       // Get the normalized path. If null, default to an empty string.
       $parsed_url = parse_url($url->toString(), PHP_URL_PATH);
-      $normalized_path = is_null($parsed_url) ? '' : rtrim($parsed_url, '/');
+
+      if (!is_string($parsed_url)) {
+        $parsed_url = '';
+      }
+
+      $normalized_path = rtrim($parsed_url, '/');
 
       $link_type = 'internal';
 

--- a/web/modules/custom/dpl_po/src/Commands/DplPoCommands.php
+++ b/web/modules/custom/dpl_po/src/Commands/DplPoCommands.php
@@ -18,7 +18,6 @@ use Drush\Commands\DrushCommands;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\TransferException;
 use function Safe\preg_match;
-use function Safe\sprintf;
 
 /**
  * A Drush commandfile.

--- a/web/modules/custom/dpl_react/dpl_react.module
+++ b/web/modules/custom/dpl_react/dpl_react.module
@@ -13,7 +13,6 @@ use Drupal\dpl_react\DplReactInterface;
 
 use function Safe\file_get_contents as file_get_contents;
 use function Safe\json_encode;
-use function Safe\sprintf as sprintf;
 
 /**
  * Implements hook_library_info_alter().

--- a/web/modules/custom/dpl_react/src/Controller/DplReactController.php
+++ b/web/modules/custom/dpl_react/src/Controller/DplReactController.php
@@ -9,7 +9,6 @@ use Drupal\dpl_login\AccessTokenType;
 use Drupal\dpl_login\UserTokens;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use function Safe\sprintf;
 
 /**
  * DDB React Controller.

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -15,7 +15,6 @@ use Drupal\dpl_library_agency\ReservationSettings;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use function Safe\json_encode as json_encode;
 use function Safe\preg_replace as preg_replace;
-use function Safe\sprintf as sprintf;
 
 /**
  * Controller for rendering full page DPL React apps.

--- a/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
+++ b/web/modules/custom/dpl_url_proxy/src/Form/ProxyUrlConfigurationForm.php
@@ -7,7 +7,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\dpl_url_proxy\DplUrlProxyInterface;
-use function Safe\sprintf;
 
 /**
  * The administration form for handling the configuration of the DPL URL Proxy.

--- a/web/themes/custom/novel/novel.theme
+++ b/web/themes/custom/novel/novel.theme
@@ -11,7 +11,6 @@ use Drupal\recurring_events\Entity\EventInstance;
 use Spatie\Color\Hex;
 use Spatie\Color\Hsl;
 use function Safe\file_get_contents;
-use function Safe\sprintf;
 
 /**
  * Implements hook_theme().


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-126

#### Description

This pull request updates the `thecodingmachine/safe` package to version ^2.5.0.

The following functions, previously part of `thecodingmachine/safe`, are now included in PHP 8.0 and later versions:
	•	usort
	•	array_combine
	•	sprintf
	•	sort

Please review the changes in this commit: [7bb9890](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1732/commits/7bb9890ec7c311fde7779b19aea78aa9b5d2c29b). I ensured that if the value is not a string, it is converted to an empty string. However, I am unsure whether I should handle arrays in this context.