### PR TITLE
Add `retries` in `cypress.config`

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,6 +4,7 @@ module.exports = defineConfig({
   e2e: {
     // baseUrl is set using environment variables because it differs between
     // development and CI setups.
+    defaultCommandTimeout: 10000,
   },
   env: {
     // This is intentionally left empty.

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,7 +4,6 @@ module.exports = defineConfig({
   e2e: {
     // baseUrl is set using environment variables because it differs between
     // development and CI setups.
-    defaultCommandTimeout: 10000,
     retries: {
       runMode: 3,
       openMode: 0,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -5,6 +5,10 @@ module.exports = defineConfig({
     // baseUrl is set using environment variables because it differs between
     // development and CI setups.
     defaultCommandTimeout: 10000,
+    retries: {
+      runMode: 3,
+      openMode: 0,
+    },
   },
   env: {
     // This is intentionally left empty.

--- a/cypress/e2e/opening-hours-editor.cy.ts
+++ b/cypress/e2e/opening-hours-editor.cy.ts
@@ -175,6 +175,7 @@ const validateOpeningHoursPage = ({
   timeDuration: { start, end },
 }: OpeningHourFormType) => {
   cy.getBySel("opening-hours-week-list")
+    .scrollIntoView()
     .should("be.visible")
     .and("contain", openingHourCategory)
     .and("contain", `${start} - ${end}`);


### PR DESCRIPTION
#### Description

<s>I have increase `defaultCommandTimeout` to the `cypress.config` because we observed failing tests due to the React app not loading quickly enough. I have tested this across six runs, and it seems to resolve the issue. </s>


`defaultCommandTimeout` alone wasn't enough. Cypress in GitHub Actions tends to be flaky, so we need to add `retries` to avoid spending too much time trying to fix sporadic issues.


I have kept the`scrollIntoView` in the opening hour test because if the test fails again, it will make debugging easier.
I also retained the increased `defaultCommandTimeout` because it does help, although it wasn’t sufficient on its own.

#### Screenshot of the result

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/5152d8bd-ae0a-40ad-b333-07eda6d59df7">
