### PR TITLE
Patch reccurring_events to avoid WSOD when eventinstance has wrong state

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -365,7 +365,8 @@
                 "3468521: (2/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/603d34936b97535f66e11429dcc9a2c61fc7cb40.patch",
                 "3468521: (3/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad8a4294b1ffb754a338bb2cfa0146f203aa6fc1.patch",
                 "3468521: (4/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad99ae79f5c55fc2db17427e9936ab141314609d.patch",
-                "3468300: Update EventSeriesSettings to use datetime form element.": "https://git.drupalcode.org/project/recurring_events/-/commit/5d9bc3b1cf7c00972f053f3d14873012b1ad7140.patch"
+                "3468300: Update EventSeriesSettings to use datetime form element.": "https://git.drupalcode.org/project/recurring_events/-/commit/5d9bc3b1cf7c00972f053f3d14873012b1ad7140.patch",
+                "3487412: Fix WSOD when EventInstance has invalid translation.": "https://git.drupalcode.org/project/recurring_events/-/commit/996052eeb7518ce591df968a0bb12c4819fb4edf.patch"
             },
             "drupal/theme_permission": {
                 "3105637: Edit, install and uninstall permission": "https://www.drupal.org/files/issues/2024-02-01/theme-permission-edit-install-uninstall-3105637-7.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a27955d341f5c1f5d99f8546fb74e3d",
+    "content-hash": "8f22ab27f889ae1b41d8d1fdf12fa7bc",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
Horsens have a problem, where an eventinstance has somehow ended up in a wrong translation state.
That means that now, they're stuck - unable to edit, delete nor view the eventseries.

I cant even use "drush entity:delete" as it fails:

InvalidArgumentException: Invalid translation language (da) specified. in Drupal\Core\Entity\ContentEntityBase->getTranslation() (line 903 of core/lib/Drupal/Core/Entity/ContentEntityBase.php).

I've debugged my way to /src/Plugin/ComputedField/EventInstances.php where I can see that we use ->getTranslation without checking if it exists. This is what the patch does, that i've posted upstream

As a quickfix, I'll manually fix the faulty event on horsens until this gets merged.
