### PR TITLE
DDFBRA-215 - Updated 'drupal/honeypot' from version '2.1.4' to '2.2.0'.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,7 @@
         "drupal/graphql_compose": "^2.2",
         "drupal/handy_cache_tags": "^1.4",
         "drupal/health_check": "^3.1",
-        "drupal/honeypot": "^2.1",
+        "drupal/honeypot": "^2.2",
         "drupal/job_scheduler": "^4.0",
         "drupal/jsnlog": "^1.3",
         "drupal/jsonlog": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a27955d341f5c1f5d99f8546fb74e3d",
+    "content-hash": "31748b3ae85529d4eeda3f89fa968175",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -4961,29 +4961,29 @@
         },
         {
             "name": "drupal/honeypot",
-            "version": "2.1.4",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/honeypot.git",
-                "reference": "2.1.4"
+                "reference": "2.2.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.4.zip",
-                "reference": "2.1.4",
-                "shasum": "adf76c3520c0e458177dbe6d638aa2d6ae40a95b"
+                "url": "https://ftp.drupal.org/files/projects/honeypot-2.2.0.zip",
+                "reference": "2.2.0",
+                "shasum": "56397c3779ebac1526cce9ecd39385017ee9a837"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^10.3 || ^11"
             },
             "require-dev": {
-                "drupal/rules": "^3.x-dev"
+                "drupal/rules": "^4.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.1.4",
-                    "datestamp": "1723489062",
+                    "version": "2.2.0",
+                    "datestamp": "1723761042",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5001,11 +5001,11 @@
                     "email": "geerlingguy@mac.com"
                 },
                 {
-                    "name": "Manuel Garcia",
+                    "name": "manuel garcia",
                     "homepage": "https://www.drupal.org/user/213194"
                 },
                 {
-                    "name": "TR",
+                    "name": "tr",
                     "homepage": "https://www.drupal.org/user/202830"
                 },
                 {


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-215

#### Description

This PR updates `drupal/honeypot` module from `2.1.4` to `2.2.0`. 

I went through the [release notes](https://www.drupal.org/project/honeypot/releases/2.2.0) and [issue queue](https://www.drupal.org/project/issues/honeypot?text=&status=Open&priorities=All&categories=All&version=2.2.0&component=All).

The only issue I found was that upgrading to `2.2.0` gives problems, if you are not upgrading to `2.1.4` beforehand. We were already using `2.1.4` so this was no issue for us.

Tested the standard contact webform on `/kontakt` to see if the Honeypot was still working as intended.  
