### PR TITLE
Uninstall config_filter module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -14,7 +14,6 @@ module:
   ckeditor5: 0
   collation_fixer: 0
   color_field: 0
-  config_filter: 0
   config_ignore: 0
   config_ignore_auto: 0
   config_perms: 0

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -319,3 +319,10 @@ function dpl_update_update_10026(): string {
 function dpl_update_update_10027(): string {
   return _dpl_update_install_modules(['simple_oauth']);
 }
+
+/**
+ * Uninstall config_filter.
+ */
+function dpl_update_update_10028(): string {
+  return _dpl_update_uninstall_modules(['config_filter']);
+}


### PR DESCRIPTION
#### Description

It is no longer used so we should remove it to reduce our amount of third party modules we use.

After uninstalling it and releasing we should remove it from composer.json.

#### Screenshot of the result

Before:
<img width="1392" alt="Monosnap Status report | DPL CMS | Logged in 2024-11-26 10-11-20" src="https://github.com/user-attachments/assets/05fbf699-f7ad-4c38-ba08-1046a87cf0d8">
