### PR TITLE
Fixing `develop` issues, due to drush being locked in `dpl_graphql`

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -44,7 +44,7 @@ module:
   dpl_fees: 0
   dpl_filter_paragraphs: 0
   dpl_footer: 0
-  dpl_graphql: 0
+  dpl_graphql2: 0
   dpl_instant_loan: 0
   dpl_library_agency: 0
   dpl_library_token: 0

--- a/web/modules/custom/dpl_graphql/dpl_graphql.info.yml
+++ b/web/modules/custom/dpl_graphql/dpl_graphql.info.yml
@@ -1,11 +1,7 @@
-name: 'DPL GraphQL'
+name: 'DPL GraphQL (UNUSED)'
 type: module
-description: 'Module used for handling graphql functionality.'
+description: |
+  This is an empty module, necessary to get around a temporary issue
+  in release 2024.48.0. See dpl_update.install for more info.'
 package: DPL
 core_version_requirement: ^10 || ^11
-dependencies:
-  - graphql:graphql
-  - graphql_compose:graphql_compose
-  - dpl_unilogin:dpl_unilogin
-  - simple_oauth:simple_oauth
-  - dpl_consumers:dpl_consumers

--- a/web/modules/custom/dpl_graphql/dpl_graphql.services.yml
+++ b/web/modules/custom/dpl_graphql/dpl_graphql.services.yml
@@ -1,4 +1,0 @@
-services:
-  dpl_graphql.page_cache_request_policy.disallow_oauth2_token_requests:
-    class: Drupal\dpl_graphql\PageCache\DplDisallowSimpleOauthRequests
-    decorates: simple_oauth.page_cache_request_policy.disallow_oauth2_token_requests

--- a/web/modules/custom/dpl_graphql2/dpl_graphql2.info.yml
+++ b/web/modules/custom/dpl_graphql2/dpl_graphql2.info.yml
@@ -1,0 +1,11 @@
+name: 'DPL GraphQL'
+type: module
+description: 'Module used for handling graphql functionality.'
+package: DPL
+core_version_requirement: ^10 || ^11
+dependencies:
+  - graphql:graphql
+  - graphql_compose:graphql_compose
+  - dpl_unilogin:dpl_unilogin
+  - simple_oauth:simple_oauth
+  - dpl_consumers:dpl_consumers

--- a/web/modules/custom/dpl_graphql2/dpl_graphql2.install
+++ b/web/modules/custom/dpl_graphql2/dpl_graphql2.install
@@ -19,8 +19,8 @@ use Drupal\simple_oauth\Service\KeyGeneratorService;
  * We want to run the dpl_graphql_update_10001 on both
  * new and existing sites.
  */
-function dpl_graphql_install(): string {
-  $messages[] = dpl_graphql_update_10001();
+function dpl_graphql2_install(): string {
+  $messages[] = dpl_graphql2_update_10001();
 
   return implode('\r\n', $messages);
 
@@ -29,7 +29,7 @@ function dpl_graphql_install(): string {
 /**
  * Generates public and private keys used for the simple_oauth module.
  */
-function dpl_graphql_update_10001(): string {
+function dpl_graphql2_update_10001(): string {
   $file_system = DrupalTyped::service(FileSystemInterface::class, 'file_system');
   $key_generator = DrupalTyped::service(KeyGeneratorService::class, 'simple_oauth.key.generator');
 

--- a/web/modules/custom/dpl_graphql2/dpl_graphql2.services.yml
+++ b/web/modules/custom/dpl_graphql2/dpl_graphql2.services.yml
@@ -1,0 +1,4 @@
+services:
+  dpl_graphql2.page_cache_request_policy.disallow_oauth2_token_requests:
+    class: Drupal\dpl_graphql2\PageCache\DplDisallowSimpleOauthRequests
+    decorates: simple_oauth.page_cache_request_policy.disallow_oauth2_token_requests

--- a/web/modules/custom/dpl_graphql2/src/PageCache/DplDisallowSimpleOauthRequests.php
+++ b/web/modules/custom/dpl_graphql2/src/PageCache/DplDisallowSimpleOauthRequests.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\dpl_graphql\PageCache;
+namespace Drupal\dpl_graphql2\PageCache;
 
 use Drupal\simple_oauth\PageCache\SimpleOauthRequestPolicyInterface;
 use Symfony\Component\HttpFoundation\Request;

--- a/web/modules/custom/dpl_graphql2/src/Plugin/GraphQL/SchemaExtension/DplConfigurationSchemaExtension.php
+++ b/web/modules/custom/dpl_graphql2/src/Plugin/GraphQL/SchemaExtension/DplConfigurationSchemaExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\dpl_graphql\Plugin\GraphQL\SchemaExtension;
+namespace Drupal\dpl_graphql2\Plugin\GraphQL\SchemaExtension;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;

--- a/web/modules/custom/dpl_graphql2/src/Plugin/GraphQLCompose/SchemaType/DplConfigurationType.php
+++ b/web/modules/custom/dpl_graphql2/src/Plugin/GraphQLCompose/SchemaType/DplConfigurationType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drupal\dpl_graphql\Plugin\GraphQLCompose\SchemaType;
+namespace Drupal\dpl_graphql2\Plugin\GraphQLCompose\SchemaType;
 
 use Drupal\graphql_compose\Plugin\GraphQLCompose\GraphQLComposeSchemaTypeBase;
 use GraphQL\Type\Definition\ObjectType;

--- a/web/modules/custom/dpl_graphql2/src/Plugin/GraphQLCompose/SchemaType/UniloginConfigurationType.php
+++ b/web/modules/custom/dpl_graphql2/src/Plugin/GraphQLCompose/SchemaType/UniloginConfigurationType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drupal\dpl_graphql\Plugin\GraphQLCompose\SchemaType;
+namespace Drupal\dpl_graphql2\Plugin\GraphQLCompose\SchemaType;
 
 use Drupal\graphql_compose\Plugin\GraphQLCompose\GraphQLComposeSchemaTypeBase;
 use GraphQL\Type\Definition\ObjectType;

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -289,7 +289,7 @@ function dpl_update_update_10022(): string {
  * Install dpl_graphql module.
  */
 function dpl_update_update_10023(): string {
-  return _dpl_update_install_modules(['dpl_graphql']);
+  return _dpl_update_install_modules(['dpl_graphql2']);
 }
 
 /**
@@ -325,4 +325,22 @@ function dpl_update_update_10027(): string {
  */
 function dpl_update_update_10028(): string {
   return _dpl_update_uninstall_modules(['config_filter']);
+}
+
+/**
+ * Quickfix: Replace dpl_graphql module with graphql2.
+ *
+ * This is necessary, as the original graphql module includes code that does
+ * not work without simple_oauth, which cannot be installed,
+ * due to the Drush command not being able to run.
+ * We get around this, by moving the code into a new module (graphql2),
+ * leaving the old module as an empty boilerplate.
+ * This gives drush a chance to actually enable the dependencies.
+ * In a future release, we should rename the module again.
+ */
+function dpl_update_update_10029(): string {
+  $return = _dpl_update_uninstall_modules(['dpl_graphql']);
+  $return .= _dpl_update_install_modules(['dpl_graphql2']);
+
+  return $return;
 }


### PR DESCRIPTION
Copying the `dpl_graphql` code to a seperate, new `dpl_graphql2` module. This is necessary, as the original graphql module includes code that does not work without simple_oauth, which cannot be installed, due to the Drush command not being able to run.
We get around this, by moving the code into a new module (graphql2), leaving the old module as an empty boilerplate.
This gives drush a chance to actually enable the dependencies. In a future release, we should rename the module again.
