### PR TITLE
Ignore decorating invalid service in DPL GraphQL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -301,6 +301,7 @@
                 "2280639: Add the FieldStorageDefinition class to define field storage definitions in hook_entity_field_storage_info()": "https://www.drupal.org/files/issues/2023-09-05/2280639-d10-reroll-156.patch",
                 "3402656: Toolbar causes a Javascript error if the subtrees content changes between page loads": "https://git.drupalcode.org/issue/drupal-3402656/-/commit/61ac007a84014f54a07825f8f92bb6bc0dfbd170.patch",
                 "3035578: Add details for AJAX response errors": "https://www.drupal.org/files/issues/2023-07-24/3035578-26.patch",
+                "3293926: Error decorating non-existent service when inner service's module not installed": "https://git.drupalcode.org/project/drupal/-/commit/a64662a3cea209c106b888ce9ef03cc1808f9ffe.patch",
                 "Always assume chmod succeeds": "patches/core-chmod-true.patch",
                 "Debug Form triggering element detection": "patches/form-triggering-element-detection-paragraphs-ee.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c6bcf01202e178b75670b1e19d7c825",
+    "content-hash": "1582c53564a21b16f4705872d78831d7",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -20192,6 +20192,6 @@
     "platform": {
         "php": "8.1.*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/web/modules/custom/dpl_graphql/dpl_graphql.services.yml
+++ b/web/modules/custom/dpl_graphql/dpl_graphql.services.yml
@@ -2,3 +2,4 @@ services:
   dpl_graphql.page_cache_request_policy.disallow_oauth2_token_requests:
     class: Drupal\dpl_graphql\PageCache\DplDisallowSimpleOauthRequests
     decorates: simple_oauth.page_cache_request_policy.disallow_oauth2_token_requests
+    decoration_on_invalid: ignore


### PR DESCRIPTION
#### Description

Patch Drupal Core to prevent errors when decorating non-existent services.

We currently have an issue with our `dpl_graph` module referring to a service provided by the `simple_oauth` module. We would normally enable this module using an update hook (or config import) but it is not possible to do so as Drush will error out befure runninng anything.

To address this we patch Drupal Core to add support for the Symfony `decoration_on_invalid` property.

This patch has been accepted for Drupal 10.4.x and 11.x so it should be safe to merge.

Ignore decorating the oath token request policy if not available. 

See https://symfony.com/doc/current/service_container/service_decoration.html#control-the-behavior-when-the-decorated-service-does-not-exist

#### Additional comments or questions

This is an alternate take to the solution suggested in #1799. I think it in many ways is a cleaner take to the take problem - both in regards to the project codebase and in avoiding the error while we wait for Drupal 10.4.