### PR TITLE
Clarifying password management forms. DDFHER-149

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,6 +26,8 @@ parameters:
     - '#Function .*_theme_suggestions_.*\(\) has parameter .* with no value type specified in iterable type array\.#'
     # Drupal hook_page_attachments functions uses page array which we cannot provide more detailed typing of.
     - '#Function .*_page_attachments\(\) has parameter \$page with no value type specified in iterable type array\.#'
+    # Drupal hook_module_implements_alter functions uses implementations array which we cannot provide more detailed typing of.
+    - '#Function .*_module_implements_alter\(\) has parameter \$implementations with no value type specified in iterable type array\.#'
     # Drupal hook_requirements() implementation returns array which we cannot provide more detailed typing of.
     - '#Function .*_requirements\(\) return type has no value type specified in iterable type array\.#'
     # Drupal hook_schema() implementation returns array which we cannot provide more detailed typing of.

--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -177,6 +177,20 @@
 }
 
 /**
+  We use the password policy module, which shows it's own password restrictions.
+  We want to hide the standard drupal password suggestions, as they are
+  confusing, as they may give conflicting information.
+  We need to make sure that inline styling also gets overriden, hence [style]
+  and !important.
+ */
+.user-form {
+  .password-suggestions,
+  .password-suggestions[style] {
+    display: none !important;
+  }
+}
+
+/**
  Hide default action button on confirm form.
  Editors should focus on the date-related changes.
  Selector is convoluted due to Gin DOM structure.

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -216,8 +216,35 @@ function _dpl_admin_form_alter_node_page(array &$form, FormStateInterface $form_
     $form['field_hero_title']['#states']['invisible'] = $inactive_state;
     $form['field_subtitle']['#states']['invisible'] = $inactive_state;
   }
+}
 
 /**
+ * Implements hook_form_FORM_ID_alter() for the user add/edit form.
+ *
+ * Re-ordering the user edit form, to make the password demands clearer.
+ *
+ * @param array<mixed> $form
+ *   See the $form in dpl_admin_form_alter().
+ */
+function _dpl_admin_form_alter_user_form(array &$form, FormStateInterface $form_state, string $form_id): void {
+  $form['account']['current_pass']['#weight'] = 997;
+  $form['account']['pass']['#weight'] = 998;
+  $form['account']['password_policy_status']['#weight'] = 999;
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ *
+ * Make sure the dpl_admin form_alter happens last, after any other contrib
+ * modules. This is necessary for us to alter the password policy position.
+ */
+function dpl_admin_module_implements_alter(array &$implementations, string $hook): void {
+  if ($hook == 'form_alter') {
+    $group = $implementations['dpl_admin'];
+    unset($implementations['dpl_admin']);
+    $implementations['dpl_admin'] = $group;
+  }
+}
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -262,6 +289,10 @@ function dpl_admin_form_alter(array &$form, FormStateInterface $form_state, stri
 
   if (in_array($form_id, ['node_page_form', 'node_page_edit_form'])) {
     _dpl_admin_form_alter_node_page($form, $form_state, $form_id);
+  }
+
+  if (in_array($form_id, ['user_register_form', 'user_form'])) {
+    _dpl_admin_form_alter_user_form($form, $form_state, $form_id);
   }
 }
 

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -227,6 +227,8 @@ function _dpl_admin_form_alter_node_page(array &$form, FormStateInterface $form_
  *   See the $form in dpl_admin_form_alter().
  */
 function _dpl_admin_form_alter_user_form(array &$form, FormStateInterface $form_state, string $form_id): void {
+  // We're setting the numbers high, to make sure they show up last, in this
+  // order.
   $form['account']['current_pass']['#weight'] = 997;
   $form['account']['pass']['#weight'] = 998;
   $form['account']['password_policy_status']['#weight'] = 999;

--- a/web/modules/custom/dpl_admin/dpl_admin.module
+++ b/web/modules/custom/dpl_admin/dpl_admin.module
@@ -217,6 +217,26 @@ function _dpl_admin_form_alter_node_page(array &$form, FormStateInterface $form_
     $form['field_subtitle']['#states']['invisible'] = $inactive_state;
   }
 
+/**
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Add basic styling classes to the "reset password" page, as it does not
+ * have any Gin styling.
+ */
+function dpl_admin_form_user_pass_reset_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  $form['#attributes']['class'][] = 'rich-text';
+  $form['#attributes']['class'][] = 'dpl-form';
+  $form['title'] = [
+    '#type' => 'markup',
+    '#prefix' => '<h1>',
+    '#suffix' => '</h1>',
+    '#markup' => t('Reset password', [], ['context' => 'DPL admin']),
+    '#weight' => '-999',
+  ];
+
+  $form['actions']['submit']['#attributes']['class'] = ['btn-primary', 'btn-filled btn-small', 'dpl-button'];
 }
 
 /**


### PR DESCRIPTION
- Hide the core password suggestions, after password policy. DDFHER-149

The password policy module has it's own restrictions, and the core
password suggestions are very confusing.

- Add basic styling on "reset password" page. DDFHER-149

- Re-order the user edit form, clarifying password management. DDFHER-149