### PR TITLE
Logging custom DDF events, such as updates to users. DDFHER-150

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -50,6 +50,7 @@ module:
   dpl_library_token: 0
   dpl_link: 0
   dpl_loans: 0
+  dpl_logging: 0
   dpl_login: 0
   dpl_mail: 0
   dpl_mapp: 0

--- a/web/modules/custom/dpl_logging/dpl_logging.info.yml
+++ b/web/modules/custom/dpl_logging/dpl_logging.info.yml
@@ -1,0 +1,6 @@
+---
+name: DPL logging
+description: Logging custom DDF events, such as updates to users.
+package: DPL
+type: module
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/dpl_logging/dpl_logging.module
+++ b/web/modules/custom/dpl_logging/dpl_logging.module
@@ -1,0 +1,112 @@
+<?php
+
+use Drupal\Component\Utility\DiffArray;
+use Drupal\user\Entity\User;
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ *
+ * When updating a user, we want to log the changes done - this is part of
+ * a security policy by DDF.
+ * For most fields, the old and new value gets logged, but others may be
+ * ignored, or declared on a meta-level (such as password).
+ */
+function dpl_logging_user_presave(User $user): void {
+  $original_user = $user->original;
+
+  if (!($original_user instanceof User)) {
+    return;
+  }
+
+  $original_values = $original_user->toArray();
+  $values = $user->toArray();
+  $updates = DiffArray::diffAssocRecursive($values, $original_values);
+
+  // Some fields are so meta that we do not need to log their changes.
+  $ignored_updates = ['changed', 'metatag', 'field_password_expiration'];
+  $diffs = [];
+
+  foreach ($updates as $key => $value) {
+    if (in_array($key, $ignored_updates)) {
+      continue;
+    }
+
+    if ($key === 'roles') {
+      $original_roles = $original_user->getRoles();
+      $new_roles = $user->getRoles();
+
+      // This results in the machine names of the roles.
+      // We could also do a look up, to find the translated labels also,
+      // but it is probably overkill for what this log will be used for.
+      $added_roles = array_diff($new_roles, $original_roles);
+      $removed_roles = array_diff($original_roles, $new_roles);
+
+      if (!empty($added_roles)) {
+        $diffs['roles_added'] = t(
+          'New roles added to user: @roles',
+          ['@roles' => implode(', ', $added_roles)],
+          ['context' => 'DPL logging']
+        )->render();
+      }
+
+      if (!empty($removed_roles)) {
+        $diffs['roles_removed'] = t(
+          'Old roles removed from user: @roles',
+          ['@roles' => implode(', ', $removed_roles)],
+          ['context' => 'DPL logging']
+        )->render();
+      }
+
+      continue;
+    }
+
+    if ($key === 'pass') {
+      // The password always shows up, but it does not always have an actual
+      // value inserted - in that case, we'll filter it out.
+      if (!empty(array_filter($value[0]))) {
+        // We don't want to log the actual password change. It is useless as
+        // it is hashed regardless.
+        $diffs[$key] = t(
+          'Password was updated',
+          [],
+          ['context' => 'DPL logging']
+        )->render();
+      }
+
+      continue;
+    }
+
+    // Getting human-readable label, with machine name as fallback.
+    $label = $user->getFieldDefinition($key)?->getLabel() ?? $key;
+
+    // Make sure the label is a string. Sometimes getLabel returns translation.
+    $label = (string) $label;
+
+    $original_value = $original_values[$key] ?? NULL;
+
+    $diffs[$key] = t(
+      '@label (@key): @original_value changed to @value',
+      [
+        '@label' => $label,
+        '@key' => $key,
+        '@original_value' => $original_value[0]['value'],
+        '@value' => $value[0]['value'] ?? NULL,
+      ],
+      ['context' => 'DPL logging']
+    )->render();
+  }
+
+  if (empty($diffs)) {
+    return;
+  }
+
+  $values_string = implode("\r\n | ", $diffs);
+
+  $logger = \Drupal::logger('dpl_logging');
+
+  $logger->notice('User @name (@id) has been updated with the following values: @values', [
+    '@name' => $user->getAccountName(),
+    '@id' => $user->id(),
+    '@values' => $values_string,
+  ]);
+}

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -326,3 +326,10 @@ function dpl_update_update_10027(): string {
 function dpl_update_update_10028(): string {
   return _dpl_update_uninstall_modules(['config_filter']);
 }
+
+/**
+ * Installing dpl_logging.
+ */
+function dpl_update_update_10029(): string {
+  return _dpl_update_install_modules(['dpl_logging']);
+}


### PR DESCRIPTION
When updating a user, we want to log the changes done - this is part of a security policy by DDF.
For most fields, the old and new value gets logged, but others may be ignored, or declared on a meta-level (such as password).

#### Link to issue

https://reload.atlassian.net/browse/DDFHER-150

An example of how the logging looks like:


User account updated: local_administrator3 (6) has been updated with the following values: Foretrukken sprogkode (preferred_langcode): en changed to da | Foretrukken sprogkode til administration (preferred_admin_langcode): da changed to en | Name (name): local_administrator2 changed to local_administrator3 | Password was updated | E-mail (mail): test2@test.dk changed to test3@test.dk | New roles added to user: local_administrator | Old roles removed from user: external_system | Author name (field_author_name): test2 changed to test3