### PR TITLE
DDFBRA-236 - Logged in user can go from digital loans to material to listen read

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
                 "version": "0.0.0-dev",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/branch-DDFBRA-183-anonymous-and-logged-in-user-can-try-ebook/dist-ddfbra-183-anonymous-and-logged-in-user-can-try-ebook.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/branch-DDFBRA-236-logged-in-user-can-go-from-digital-loans-to-material-to-listen-read/dist-ddfbra-236-logged-in-user-can-go-from-digital-loans-to-material-to-listen-read.zip",
                     "type": "zip"
                 },
                 "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "997459f511e1355cabc9e817644449f9",
+    "content-hash": "db4be95fa82e1c8b214e8644a314b435",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1178,7 +1178,7 @@
             "version": "0.0.0-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/branch-DDFBRA-183-anonymous-and-logged-in-user-can-try-ebook/dist-ddfbra-183-anonymous-and-logged-in-user-can-try-ebook.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/branch-DDFBRA-236-logged-in-user-can-go-from-digital-loans-to-material-to-listen-read/dist-ddfbra-236-logged-in-user-can-go-from-digital-loans-to-material-to-listen-read.zip"
             },
             "require": {
                 "composer/installers": "^1.2.0"

--- a/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
+++ b/web/modules/custom/dpl_loans/src/Plugin/Block/LoanListBlock.php
@@ -76,7 +76,6 @@ class LoanListBlock extends BlockBase implements ContainerFactoryPluginInterface
       "expiration-warning-days-before-config" => $generalSettings->get('expiration_warning_days_before_config') ?? GeneralSettings::EXPIRATION_WARNING_DAYS_BEFORE_CONFIG,
 
       // Urls.
-      'ereolen-my-page-url' => dpl_react_apps_format_app_url($generalSettings->get('ereolen_my_page_url'), GeneralSettings::EREOLEN_MY_PAGE_URL),
       'material-overdue-url' => Url::fromRoute('dpl_loans.list', [], ['absolute' => TRUE])->toString(),
 
       // Texts.

--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -160,7 +160,7 @@ function dpl_react_apps_texts(): array {
     'material-by-author' => t("By", [], ['context' => 'Global']),
     'material-details-close-modal-aria-label' => t('Close material details modal', [], ['context' => 'Global']),
     'material-details-digital-due-date-label' => t("Expires", [], ['context' => 'Global']),
-    'material-details-go-to-ereolen' => t("Go to eReolen", [], ['context' => 'Global']),
+    'material-details-go-to-material' => t('Go to material', [], ['context' => 'Global']),
     'material-details-link-to-page-with-fees' => t('Read more about fees', [], ['context' => 'Global']),
     'material-details-loan-date-label' => t('Loan date', [], ['context' => 'Global']),
     'material-details-material-number-label' => t('Material Item Number', [], ['context' => 'Global']),


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-236
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1814

#### Description

Update and remove the necessary translations for this pull request:
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1565

#### Test
If you have an online loan, you can view it under the “Digital Loans” section. The button, which was previously labeled “Go to eReolen” and linked to eReolen, has been updated to now correctly link to the work with the appropriate type selected.

https://varnish.pr-1814.dpl-cms.dplplat01.dpl.reload.dk/user/me/loans


https://github.com/user-attachments/assets/8e1940fc-f05a-476f-a561-598f46e6a4f4