### PR TITLE
Patch core to not check file owner in update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -302,7 +302,8 @@
                 "3035578: Add details for AJAX response errors": "https://www.drupal.org/files/issues/2023-07-24/3035578-26.patch",
                 "3293926: Error decorating non-existent service when inner service's module not installed": "https://git.drupalcode.org/project/drupal/-/commit/a64662a3cea209c106b888ce9ef03cc1808f9ffe.patch",
                 "Always assume chmod succeeds": "patches/core-chmod-true.patch",
-                "Debug Form triggering element detection": "patches/form-triggering-element-detection-paragraphs-ee.patch"
+                "Debug Form triggering element detection": "patches/form-triggering-element-detection-paragraphs-ee.patch",
+                "Don't check for file owner in update": "patches/dont-check-fileowner.patch"
             },
             "drupal/date_range_formatter": {
                 "3309324: Fails when start and end date are identical": "https://www.drupal.org/files/issues/2023-12-22/date_range_formatter_3309324_1.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d89be314a09f03f216ca135be18c887d",
+    "content-hash": "481fcc3ed8fe3d47709e36439280a953",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/patches/dont-check-fileowner.patch
+++ b/patches/dont-check-fileowner.patch
@@ -1,0 +1,32 @@
+diff --git a/modules/update/update.manager.inc b/modules/update/update.manager.inc
+index 97333a0825..fe5ec5f02f 100644
+--- a/modules/update/update.manager.inc
++++ b/modules/update/update.manager.inc
+@@ -325,17 +325,14 @@ function update_manager_batch_project_get($project, $url, &$context) {
+  * @see install_check_requirements()
+  */
+ function update_manager_local_transfers_allowed() {
+-  $file_system = \Drupal::service('file_system');
+-  // Compare the owner of a webserver-created temporary file to the owner of
+-  // the configuration directory to determine if local transfers will be
+-  // allowed.
+-  $temporary_file = \Drupal::service('file_system')->tempnam('temporary://', 'update_');
+-  $site_path = \Drupal::getContainer()->getParameter('site.path');
+-  $local_transfers_allowed = fileowner($temporary_file) === fileowner($site_path);
+-
+-  // Clean up. If this fails, we can ignore it (since this is just a temporary
+-  // file anyway).
+-  @$file_system->unlink($temporary_file);
+-
+-  return $local_transfers_allowed;
++  // Patch for DPL. Normally this checks if a temporary file created is owned by
++  // the same user as `sites/<current site>`, but that's pretty simplistic and
++  // will fail in quite valid cases (for instance if the webserver has write
++  // access through group permissions). In our case, we know that uploaded
++  // modules can be moved to our `sites/default/files/modules_local` (which is
++  // symlinked from `modules/`), but we can't really fix this properly as this
++  // function doesn't know whether it's a module, theme or something else
++  // entirely that we're checking for. So rather than trying to cook up some
++  // generic solution that'll fail in some cases anyway, we just return true.
++  return TRUE;
+ }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFNEXT-655

#### Description

Core checks file owners of server created files and `sites/default` to determine if it can just move the files in place. This is wrong for so many reasons, so we just kill it with fire.
