### PR TITLE
DDFBRA-295 - Update `drupal/default_content` to version `2.0.0-alpha3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -311,7 +311,7 @@
                 "3309324: Fails when start and end date are identical": "https://www.drupal.org/files/issues/2023-12-22/date_range_formatter_3309324_1.patch"
             },
             "drupal/default_content": {
-                "3200212: Overwrite files on import": "https://www.drupal.org/files/issues/2021-12-08/default_content-3200212.patch"
+                "3200212: Overwrite files on import": "https://git.drupalcode.org/project/default_content/-/commit/52a8827e43ebe1e4cbfd99b3f2c896c20122c220.patch"
             },
             "drupal/dynamic_entity_reference": {
                 "3396393: Entity with a dynamic entity reference field can't be cloned using entity_clone": "https://www.drupal.org/files/issues/2023-10-24/3396393-2.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "394bdee51200e855bc01eb7c80c7f709",
+    "content-hash": "2e35d3d09d72b791eabc2a326db33816",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -3837,30 +3837,30 @@
         },
         {
             "name": "drupal/default_content",
-            "version": "2.0.0-alpha2",
+            "version": "2.0.0-alpha3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/default_content.git",
-                "reference": "2.0.0-alpha2"
+                "reference": "2.0.0-alpha3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/default_content-2.0.0-alpha2.zip",
-                "reference": "2.0.0-alpha2",
-                "shasum": "5c365ea21b0be63dc00ec2db50179291d6fb3d89"
+                "url": "https://ftp.drupal.org/files/projects/default_content-2.0.0-alpha3.zip",
+                "reference": "2.0.0-alpha3",
+                "shasum": "fdd90c70bd91896835f6ba5ec42c260c1a144a2b"
             },
             "require": {
-                "drupal/core": "^9.1 || ^10"
+                "drupal/core": "^9.1 || ^10 || ^11"
             },
             "require-dev": {
-                "drupal/hal": " ^9 || ^1 || ^2",
+                "drupal/hal": "^1 || ^2",
                 "drupal/paragraphs": "^1"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-alpha2",
-                    "datestamp": "1659466706",
+                    "version": "2.0.0-alpha3",
+                    "datestamp": "1724492420",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -3868,7 +3868,7 @@
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9 || ^10 || ^11"
+                        "drush.services.yml": "^9 || ^10 || ^11 || ^12"
                     }
                 }
             },
@@ -3886,7 +3886,7 @@
                     "homepage": "https://www.drupal.org/user/1852732"
                 },
                 {
-                    "name": "Berdir",
+                    "name": "berdir",
                     "homepage": "https://www.drupal.org/user/214652"
                 },
                 {
@@ -3902,7 +3902,7 @@
                     "homepage": "https://www.drupal.org/user/395439"
                 },
                 {
-                    "name": "Sam152",
+                    "name": "sam152",
                     "homepage": "https://www.drupal.org/user/1485048"
                 }
             ],


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFNEXT-666
https://reload.atlassian.net/browse/DDFBRA-295

#### Description
This pull request update `drupal/default_content` to version `2.0.0-alpha3`
Patch `3200212` updates the module to support `2.0.0-alpha3`, by including only commit `52a8827e43ebe1e4cbfd99b3f2c896c20122c220` from 
https://git.drupalcode.org/project/default_content/-/merge_requests/54


#### Test
https://varnish.pr-1881.dpl-cms.dplplat01.dpl.reload.dk/admin/content