### PR TITLE
Adding a BNF login form for client sites.  DDFHER-165

### DIFF
--- a/web/modules/custom/bnf/bnf_client/bnf_client.links.menu.yml
+++ b/web/modules/custom/bnf/bnf_client/bnf_client.links.menu.yml
@@ -4,3 +4,8 @@ bnf_client.import_content:
   parent: system.admin_content
   route_name: bnf_client.import_form
   weight: 10
+bnf_client.login:
+  title: 'Login to BNF'
+  parent: system.admin_content
+  route_name: bnf_client.server_redirect
+  weight: 11

--- a/web/modules/custom/bnf/bnf_client/bnf_client.routing.yml
+++ b/web/modules/custom/bnf/bnf_client/bnf_client.routing.yml
@@ -14,3 +14,11 @@ bnf_client.import_confirm_form:
     _title: 'Confirm import'
   requirements:
     _permission: 'bnf client import nodes'
+
+bnf_client.server_redirect:
+  path: '/admin/bnf/login'
+  defaults:
+    _controller: '\Drupal\bnf_client\Controller\BnfRedirecter::login'
+    _title: 'Login to BNF'
+  requirements:
+    _permission: 'bnf client import nodes'

--- a/web/modules/custom/bnf/bnf_client/src/Controller/BnfRedirecter.php
+++ b/web/modules/custom/bnf/bnf_client/src/Controller/BnfRedirecter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\bnf_client\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Redirecting the editor to BNF.
+ */
+class BnfRedirecter extends ControllerBase {
+
+  /**
+   * Logging in the editor on BNF, allowing them to browse available content.
+   */
+  public function login(Request $request): TrustedRedirectResponse {
+    $bnfServer = (string) getenv('BNF_SERVER_BASE_ENDPOINT');
+    $loginUrl = "$bnfServer/bnf/login";
+
+    $url = Url::fromUri($loginUrl, [
+      'query' => [
+        'siteName' => $this->config('system.site')->get('name'),
+        'callbackUrl' => $request->getSchemeAndHttpHost(),
+      ],
+    ]);
+
+    $url->setAbsolute();
+
+    return new TrustedRedirectResponse($url->toString());
+  }
+
+}

--- a/web/modules/custom/bnf/bnf_server/bnf_server.routing.yml
+++ b/web/modules/custom/bnf/bnf_server/bnf_server.routing.yml
@@ -1,0 +1,9 @@
+---
+bnf_server.cookie_login:
+  path: '/bnf/login'
+  defaults:
+    _controller: '\Drupal\bnf_server\Controller\LoginController::login'
+  requirements:
+    _permission: 'access content'
+  options:
+    no_cache: true

--- a/web/modules/custom/bnf/bnf_server/src/Controller/LoginController.php
+++ b/web/modules/custom/bnf/bnf_server/src/Controller/LoginController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\bnf_server\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Recieving "login" information, used to display "import to my site" button.
+ *
+ * This endpoint is reached from library websites, when submitting the login
+ * form. It has data for where the user is coming from, so we can display
+ * a button for importing content.
+ */
+class LoginController extends ControllerBase {
+  const COOKIE_CALLBACK_URL = 'bnf_server_login_callback_url';
+  const COOKIE_SITE_NAME = 'bnf_server_login_site_name';
+
+  /**
+   * Receiving the login.
+   */
+  public function login(Request $request): RedirectResponse {
+    $queries = $request->query;
+    $url = (string) $queries->get('callbackUrl');
+    $name = (string) $queries->get('siteName');
+
+    if (empty($url)) {
+      throw new BadRequestHttpException('Callback URL cannot be empty.');
+    }
+
+    $response = new RedirectResponse('/');
+
+    $response->headers->setCookie(new Cookie(self::COOKIE_CALLBACK_URL, $url));
+    $response->headers->setCookie(new Cookie(self::COOKIE_SITE_NAME, $name));
+
+    return $response;
+  }
+
+}


### PR DESCRIPTION
A login redirect link, that shows up in the content menu

<img width="310" alt="Screenshot 2025-01-02 at 14 20 13" src="https://github.com/user-attachments/assets/9b53a2ac-cdbf-4bd8-a46f-3beb048b047c" />
