### PR TITLE
DDFNEXT-645 - Update `drupal/metatag` from 2.0.2 to 2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "drupal/libraries": "^4.0",
         "drupal/linkit": "^6.1.2",
         "drupal/media_library_edit": "^3.0",
-        "drupal/metatag": "^2.0",
+        "drupal/metatag": "^2.1",
         "drupal/multiple_fields_remove_button": "^2.2",
         "drupal/multivalue_form_element": "^1.0@beta",
         "drupal/openapi": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0bdc90b08d1a49530e0b5f783b2e267",
+    "content-hash": "269af6794ea38ceed3eb2b4ced4857ed",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -5830,17 +5830,17 @@
         },
         {
             "name": "drupal/metatag",
-            "version": "2.0.2",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/metatag.git",
-                "reference": "2.0.2"
+                "reference": "2.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/metatag-2.0.2.zip",
-                "reference": "2.0.2",
-                "shasum": "748013c50a0ed5e10359413bb3481392a0bf0d3f"
+                "url": "https://ftp.drupal.org/files/projects/metatag-2.1.0.zip",
+                "reference": "2.1.0",
+                "shasum": "c28fe2fdac68a9370a6af6cbafff4425dd5148f3"
             },
             "require": {
                 "drupal/core": "^9.4 || ^10 || ^11",
@@ -5848,6 +5848,7 @@
                 "php": ">=8.0"
             },
             "require-dev": {
+                "drupal/forum": "*",
                 "drupal/hal": "^1 || ^2 || ^9",
                 "drupal/metatag_dc": "*",
                 "drupal/metatag_open_graph": "*",
@@ -5859,8 +5860,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.2",
-                    "datestamp": "1722869772",
+                    "version": "2.1.0",
+                    "datestamp": "1731004042",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5882,7 +5883,7 @@
                     "role": "Developer"
                 },
                 {
-                    "name": "Dave Reid",
+                    "name": "dave reid",
                     "homepage": "https://www.drupal.org/user/53892"
                 }
             ],
@@ -7885,11 +7886,11 @@
             ],
             "authors": [
                 {
-                    "name": "Berdir",
+                    "name": "berdir",
                     "homepage": "https://www.drupal.org/user/214652"
                 },
                 {
-                    "name": "Dave Reid",
+                    "name": "dave reid",
                     "homepage": "https://www.drupal.org/user/53892"
                 },
                 {

--- a/config/sync/metatag.settings.yml
+++ b/config/sync/metatag.settings.yml
@@ -3,6 +3,7 @@ _core:
 entity_type_groups: {  }
 separator: ''
 tag_trim_method: beforeValue
+use_maxlength: true
 tag_trim_maxlength: {  }
 tag_scroll_max_height: ''
-use_maxlength: true
+tag_trim_end: '|.,-:;/+&([{"'''


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFNEXT-645 /
https://reload.atlassian.net/browse/DDFBRA-308

#### Description
This update introduces a new required setting: `Trimming options`.
The update sets this option to `Trim the Meta Tag before the word on the given value` by default and adds the following characters as delimiters: `|.,-:;/+&([{"'`.

<img width="689" alt="Skærmbillede 2025-01-02 kl  13 25 49" src="https://github.com/user-attachments/assets/92dc14d3-eda7-447e-a6dc-5d2214218343" />

#### Test
https://varnish.pr-1903.dpl-cms.dplplat01.dpl.reload.dk/admin/config/search/metatag/settings
