### PR TITLE
Display 'import to my site' button on BNF server. DDFHER-181

### DIFF
--- a/web/modules/custom/bnf/bnf_server/bnf_server.module
+++ b/web/modules/custom/bnf/bnf_server/bnf_server.module
@@ -1,0 +1,45 @@
+<?php
+
+use Drupal\bnf_server\Controller\LoginController;
+use Drupal\node\Entity\Node;
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Displaying the "import content to my site" button on nodes, if the user
+ * has logged in and has the callback cookie context.
+ */
+function bnf_server_preprocess_page(array &$variables): void {
+  $node = $variables['node'] ?? NULL;
+  $cookies = \Drupal::request()->cookies;
+  $url = $cookies->get(LoginController::COOKIE_CALLBACK_URL);
+  $name = $cookies->get(LoginController::COOKIE_SITE_NAME);
+  $allowed_cts = ['article'];
+
+  if (!$url || !($node instanceof Node) || !in_array($node->bundle(), $allowed_cts)) {
+    return;
+  }
+
+  $variables['page']['content']['import_link'] = [
+    '#theme' => 'bnf_server_import_link',
+    '#label' => $node->label(),
+    '#name' => $name ?? t('my site', [], ['context' => 'BNF']),
+    '#url' => "$url/admin/bnf/import/{$node->uuid()}",
+    '#cache' => ['max-age' => 0],
+  ];
+}
+
+/**
+ * Implements hook_theme().
+ */
+function bnf_server_theme(): array {
+  return [
+    'bnf_server_import_link' => [
+      'variables' => [
+        'url' => NULL,
+        'name' => NULL,
+        'label' => NULL,
+      ],
+    ],
+  ];
+}

--- a/web/modules/custom/bnf/bnf_server/templates/bnf-server-import-link.html.twig
+++ b/web/modules/custom/bnf/bnf_server/templates/bnf-server-import-link.html.twig
@@ -1,0 +1,15 @@
+{# Super simple styling, placing the button fixed on the screen. #}
+<style>
+  .bnf-import-link {
+    position: fixed;
+    right: 1em;
+    bottom: 1em;
+    z-index: 999;
+  }
+</style>
+
+<div class="bnf-import-link">
+  <a class="btn-primary btn-filled btn-large" href="{{ url }}">
+    {{ 'Import "@label" to @name'|trans({'@label': label, '@name': name}, {"context": "BNF"}) }}
+  </a>
+</div>


### PR DESCRIPTION
If the editor has been redirected to the server from the BNF login, the context from the site they come from, has been saved to a cookie. If that is the case, we show a floating (fixed) button on nodes, that links back to the original site, along with the UUID. If the article has already been imported, the original site will display a warning.


<img width="1066" alt="Screenshot 2025-01-02 at 14 22 40" src="https://github.com/user-attachments/assets/3f2b6cab-5f4b-4443-bc00-6425e34a65e8" />
