### PR TITLE
Increase size of NGINX persistent storage to 10Gi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
     labels:
       lagoon.type: nginx-php-persistent
       lagoon.persistent: /app/web/sites/default/files/ # define where the persistent storage should be mounted too
+      lagoon.persistent.size: 10Gi
 
   php: # php-fpm server that executes php requests.
     # https://docs.lagoon.sh/lagoon/docker-images/php-fpm


### PR DESCRIPTION
#### Description

Increase size of NGINX persistent storage to 10Gi.

This mirrors a change introduced for the site templates in dpl-platform.

While most core sites will not need the additional storage increasing the storage limit will not introduce additional costs. Having the same limit as production sites ensures that we avoid hitting the limit if we need to synchronise data from a production site to a PR site.

#### Additional comments or questions

See https://github.com/danskernesdigitalebibliotek/dpl-platform/pull/566