### PR TITLE
Add from date query argument to API response for event lists

### DIFF
--- a/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
+++ b/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
@@ -310,6 +310,7 @@ final class EventsResource extends EventResourceBase {
 
     // Create cache metadata.
     $cache_metadata = new CacheableMetadata();
+    $cache_metadata->setCacheContexts(['url.query_args:from_date']);
     $cache_metadata->setCacheTags(['eventinstance_list', 'eventseries_list']);
 
     // Add cache metadata to the response.


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFHER-175

#### Description

Add from date query argument to API response for event lists.  Without this callers would get the last cached response no matter what from_date is provided. This applies the same query argument as is retrieved from the request further up in the processing.

#### Additional comments or questions

I have tried to check other places in the application where we build `CacheableResponse` object and provide `CacheableMetadata`. Most places we not not apply additional filtering of data based on the request. The only place that we do is in the OpeningHours API. [Here we vary by the entire url which includes url parameters](https://github.com/danskernesdigitalebibliotek/dpl-cms/blob/9369134572006a7ac233aadc0868fd62f7e7217b/web/modules/custom/dpl_opening_hours/src/Plugin/rest/resource/v1/OpeningHoursResourceBase.php#L189-L189). 