### PR TITLE
Add category term name as notice in opening hours legacy API

### DIFF
--- a/web/modules/custom/dpl_redia_legacy/src/Plugin/rest/resource/OpeningHoursResource.php
+++ b/web/modules/custom/dpl_redia_legacy/src/Plugin/rest/resource/OpeningHoursResource.php
@@ -174,11 +174,15 @@ final class OpeningHoursResource extends OpeningHoursResourceBase {
   public function toLegacyResponse(OpeningHoursInstance $instance) : OpeningHoursLegacyResponse {
     return (new OpeningHoursLegacyResponse())
       ->setNid(intval($instance->branch->id()))
-      ->setCategoryTid(intval($instance->categoryTerm->id()))
       ->setDate(new DateTime($instance->startTime->format('Y-m-d')))
       ->setStartTime($instance->startTime->format("H:i"))
       ->setEndTime($instance->endTime->format('H:i'))
-      ->setNotice(NULL);
+      // The Redia app will display the notice as the title of opening hours
+      // if defined regardless of the category. This is a simple way to show the
+      // right title instead of providing a separate API exposing categories
+      // with ids and titles.
+      ->setCategoryTid(intval($instance->categoryTerm->id()))
+      ->setNotice($instance->categoryTerm->getName());
   }
 
   /**


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFHER-177

#### Description

The Redia app requires opening hours to have a category for them to be displayed. Currently we only return the category id. However new categories are not likely to be the same as previously. Also we do not provide an API for exposing categories with their ids and titles.

To address this in a simple way we add the category name as a notice for each instance.

It turns out that the Redia app will display opening hours with the notice if the notice is defined no matter what the category id is. Consequently this is a rather simple way to communicate the information.