### PR TITLE
BNF: Set BNF details on BNF server. 

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -53,6 +53,11 @@ tasks:
             if [[ "$LAGOON_PROJECT" == "dpl-bnf" ]]; then
               # Enable the server module on environments in the BNF project.
               drush pm:enable -y bnf_server
+              drush config:set --yes system.site name "BNF test"
+              drush config:set --yes novel.settings logo_title "BNF"
+              drush config:set --yes novel.settings logo_place "test"
+              drush config:set --yes novel.settings logo_img_enable "0"
+
             elif [[ ${LAGOON_PR_TITLE,,} =~ ^bnf: ]]; then
               # Or configure the client if there's a BNF environment.
               drush config:set --yes bnf_client.settings base_url https://varnish.$LAGOON_ENVIRONMENT.dpl-bnf.dplplat01.dpl.reload.dk/

--- a/config/sync/config_ignore_auto.settings.yml
+++ b/config/sync/config_ignore_auto.settings.yml
@@ -10,6 +10,7 @@ whitelist_config_entities:
   - user.role.external_system
   - user.role.mediator
   - user.role.patron
+  - bnf_client.settings.yml
 direction_operations:
   - import_create
   - import_update

--- a/config/sync/novel.settings.yml
+++ b/config/sync/novel.settings.yml
@@ -4,7 +4,10 @@ features:
   comment_user_verification: true
   favicon: 1
 logo:
-  use_default: 1
+  use_default: 0
+  logo: "public://2024-07/logoeksempelbib.png"
+logo_title: "Eksempel Biblioteket"
+logo_place: "Eksempelvej Bib"
 favicon:
   use_default: 1
   mimetype: image/vnd.microsoft.icon

--- a/config/sync/novel.settings.yml
+++ b/config/sync/novel.settings.yml
@@ -5,9 +5,9 @@ features:
   favicon: 1
 logo:
   use_default: 0
-  logo: "public://2024-07/logoeksempelbib.png"
-logo_title: "Eksempel Biblioteket"
-logo_place: "Eksempelvej Bib"
+  logo: 'public://2024-07/logoeksempelbib.png'
+logo_title: 'Eksempel Biblioteket'
+logo_place: 'Eksempelvej Bib'
 favicon:
   use_default: 1
   mimetype: image/vnd.microsoft.icon

--- a/web/modules/custom/dpl_example_content/dpl_example_content.module
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.module
@@ -69,17 +69,4 @@ function dpl_example_content_modules_installed(array $modules) : void {
   $new_front_page = '/frontpage';
   $config_site->set('page.front', '/frontpage')->save();
   $logger->info("Update frontpage link to {$new_front_page}, as part of example content installation.");
-
-  // Set example logo.
-  $config_novel = \Drupal::configFactory()->getEditable('novel.settings');
-  $logo_path = 'public://2024-07/logoeksempelbib.png';
-
-  $config_novel->set('logo_title', 'Eksempel Biblioteket')
-    ->set('logo_place', 'Eksempelvej Bib')
-    ->set('logo.use_default', FALSE)
-    ->set('logo.path', $logo_path)
-    ->save();
-
-  $logger->notice('Updated theme settings for novel theme.');
-
 }


### PR DESCRIPTION


Setting the BNF details on the bnf_server, so it is easier to discern the client from server.

Also fixes an issue, so pushing to an existing BNF site doesnt cause a deploy fail when the module is not enabled.
