### PR TITLE
Display metadata on eventseries, about related eventinstances. KBHBIB-47

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,7 +167,7 @@ services:
       << : *default-environment
 
   node:
-    image: ghcr.io/danskernesdigitalebibliotek/dpl-go-node:0.0.12
+    image: ghcr.io/danskernesdigitalebibliotek/dpl-go-node:0.13.3
     labels:
       provenance: false
       lagoon.type: node-persistent

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -19,6 +19,7 @@ use Drupal\dpl_event\Workflows\OccurredSchedule;
 use Drupal\dpl_event\Workflows\UnpublishSchedule;
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\recurring_events\Entity\EventSeries;
+use function Safe\json_encode;
 
 /**
  * Implements hook_entity_bundle_info_alter().
@@ -350,4 +351,65 @@ function dpl_event_form_alter(array &$form, FormStateInterface $form_state, stri
   }
 
   $form['field_screen_names']['#access'] = FALSE;
+}
+
+/**
+ * Implements theme_preprocess_html().
+ *
+ * Display metadata on eventseries, about related eventinstances.
+ * We use LD json to display related eventinstances in a format that Cludo
+ * (and others) can use to index correctly.
+ */
+function dpl_event_preprocess_html(array &$variables): void {
+  $route = \Drupal::routeMatch();
+  $series = $route->getParameter('eventseries');
+
+  if ($route->getRouteName() !== 'entity.eventseries.canonical' || !($series instanceof EventSeries)) {
+    return;
+  }
+
+  $service = DrupalTyped::service(ReoccurringDateFormatter::class, 'dpl_event.reoccurring_date_formatter');
+
+  $instances = $service->getUpcomingEvents($series);
+  $url = $series->toUrl();
+
+  $info = [
+    "@context" => "https://schema.org",
+    "@type" => "EventSeries",
+    "name" => $series->label(),
+    'uri' => $url->toString(),
+    'url' => $url->setAbsolute()->toString(),
+    "events" => [],
+  ];
+
+  $instance_first = reset($instances);
+  $instance_last = end($instances);
+
+  if ($instance_first && $instance_last) {
+    $info['startDate'] = $instance_first->getStartDate()->format('c');
+    $info['endDate'] = $instance_last->getEndDate()->format('c');
+  }
+
+  foreach ($instances as $instance) {
+    $url = $instance->toUrl();
+
+    $info['events'][] = [
+      '@type' => 'EventInstance',
+      'name' => $instance->label(),
+      'uri' => $url->toString(),
+      'url' => $url->setAbsolute()->toString(),
+      'startDate' => $instance->getStartDate()->format('c'),
+      'endDate' => $instance->getEndDate()->format('c'),
+    ];
+  }
+
+  $script = [
+    '#tag' => 'script',
+    '#value' => json_encode($info),
+    '#attributes' => [
+      'type' => 'application/ld+json',
+    ],
+  ];
+
+  $variables['page']['#attached']['html_head'][] = [$script, 'event-series-json-ld'];
 }

--- a/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
+++ b/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
@@ -7,7 +7,7 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
-use Drupal\recurring_events\Entity\EventInstance;
+use Drupal\dpl_event\Entity\EventInstance;
 use Drupal\recurring_events\Entity\EventSeries;
 
 /**
@@ -112,6 +112,22 @@ class ReoccurringDateFormatter {
       ->execute();
 
     return $upcoming_ids;
+  }
+
+  /**
+   * GetUpcomingEvents.
+   *
+   * @return array<EventInstance>
+   *   An array of matching eventinstances.
+   */
+  public function getUpcomingEvents(EventSeries $event_series): array {
+    $ids = $this->getUpcomingEventIds($event_series);
+    $storage = $this->entityTypeManager->getStorage('eventinstance');
+
+    /** @var \Drupal\dpl_event\Entity\EventInstance[] $instances */
+    $instances = $storage->loadMultiple($ids);
+
+    return $instances;
   }
 
   /**


### PR DESCRIPTION
We use LD json to display related eventinstances in a format that Cludo (and others) can use to index correctly.
It gets added as a `<script>` tag on the HTML `<head>` element, following schema as defined by https://json-ld.org/

#### Link to issue

https://reload.atlassian.net/browse/KBHBIB-47