### PR TITLE
DDFBRA-349 -  Add access control check for node type links in the admin page (`/admin/content/add`)

### DIFF
--- a/web/modules/custom/dpl_admin/src/Controller/AdminPages.php
+++ b/web/modules/custom/dpl_admin/src/Controller/AdminPages.php
@@ -56,9 +56,14 @@ class AdminPages extends ControllerBase {
 
     // Adding a link to each node type.
     foreach ($node_types as $node_type) {
+      $node_type_id = (string) $node_type->id();
+      $access = $this->entityTypeManager()->getAccessControlHandler('node')->createAccess($node_type_id, NULL, [], TRUE);
+      if (!$access->isAllowed()) {
+        continue;
+      }
       $create_links[] = [
         'title' => $node_type->label(),
-        'url' => Url::fromRoute('node.add', ['node_type' => $node_type->id()]),
+        'url' => Url::fromRoute('node.add', ['node_type' => $node_type_id]),
         'description' => $node_type->getDescription(),
       ];
     }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-349

#### Description
This pull request ensures that only content types the user has access to are displayed.

The logic is inspired by the core implementation in `web/core/modules/node/src/Controller/NodeController.php` for `/admin/content/add`, which has been overridden in `web/modules/custom/dpl_admin/dpl_admin.routing.yml`.

**Super Admin**
<img width="1840" alt="Skærmbillede 2025-01-15 kl  14 08 59" src="https://github.com/user-attachments/assets/91823582-b39e-4c63-b986-571f7d35bebf" />

**Editor:**
<img width="1840" alt="Skærmbillede 2025-01-15 kl  14 09 17" src="https://github.com/user-attachments/assets/5635f428-561b-4a24-994f-6fe794d060ce" />

