### PR TITLE
Make sure the Go node app is persistent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,9 +170,10 @@ services:
   node:
     image: ghcr.io/danskernesdigitalebibliotek/dpl-go-node:0.0.12
     labels:
-      lagoon.type: node
       provenance: false
-
+      lagoon.type: node-persistent
+      lagoon.persistent: /app/.next
+      lagoon.persistent.size: 500Mi
 volumes:
   projectroot:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,10 @@ services:
       provenance: false
       lagoon.type: node-persistent
       lagoon.persistent: /app/.next
+      # The size of the persistent storage for this service
+      # is based on some documentation in Lagoon about hosting a node service:
+      # https://docs.lagoon.sh/docker-images/nodejs/#docker-composeyml-snippet
+      # We could revise in the future if we need more space.
       lagoon.persistent.size: 500Mi
 volumes:
   projectroot:


### PR DESCRIPTION


#### Description

We have the experience from the Go Demo environment that having a persitent .next dir helps the build process and makes sure that k8s doesn't try to rebuild it again and again.
