### PR TITLE
DDFBRA-348 - Fix event visibility in `Event list - automatic`+ Premature "expiration" label on events

### DIFF
--- a/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
+++ b/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
@@ -97,6 +97,7 @@ class ReoccurringDateFormatter {
    */
   public function getUpcomingEventIds(EventSeries $event_series): array {
     $date = new DrupalDateTime();
+    $date->setTimezone(new \DateTimezone(DateTimeItemInterface::STORAGE_TIMEZONE));
     $formatted = $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
 
     // Find the next upcoming eventinstance in this series - e.g., the

--- a/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
+++ b/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
@@ -454,7 +454,7 @@ class RelatedContent {
       return [];
     }
 
-    $date = new DrupalDateTime('today');
+    $date = new DrupalDateTime('now');
     $date->setTimezone(new \DateTimezone(DateTimeItemInterface::STORAGE_TIMEZONE));
     $formatted_date = $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
 
@@ -479,7 +479,7 @@ class RelatedContent {
     $query->condition('eid.status', 1);
 
     // We only want events in the future (e.g. - active events).
-    $query->condition('eid.date__value', $formatted_date, '>=');
+    $query->condition('eid.date__end_value', $formatted_date, '>=');
     $query->orderBy('eid.date__value', 'ASC');
     // We know that we will never need more than the maximum items,
     // so we will limit the query to this.


### PR DESCRIPTION
#### Link to issue  
https://reload.atlassian.net/browse/DDFBRA-348

#### Description  
Fixed an issue where active events (with future end dates) were not properly displayed in the `Event list - automatic` paragraph.  

Also corrected a bug where events were marked as "expired" prematurely.

#### Test
https://varnish.pr-1987.dpl-cms.dplplat01.dpl.reload.dk/test-eventlist-dans

<img width="1054" alt="image" src="https://github.com/user-attachments/assets/115af2ae-4c0a-475c-8ca0-8ba110f4efa5" />

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/827fcc0f-509f-49fd-bd18-d6db03170eb1" />
