### PR TITLE
DDFBRA-396 - Added update hook for installing "graphql_compose_routes" module.

### DIFF
--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -113,6 +113,7 @@ function dpl_update_install(): string {
   $messages[] = dpl_update_update_10029();
   $messages[] = dpl_update_update_10030();
   $messages[] = dpl_update_update_10031();
+  $messages[] = dpl_update_update_10034();
 
   return implode('\r\n', $messages);
 }
@@ -375,4 +376,11 @@ function dpl_update_update_10033(): string {
   // @see https://git.drupalcode.org/project/purge_queues/-/blob/2.0.x/src/Plugin/Purge/Queue/AltDatabaseQueue.php?ref_type=heads#L12
   \Drupal::configFactory()->getEditable('purge.plugins')->set('queue', 'database_alt')->save();
   return 'Configured purge queue to use database_alt.';
+}
+
+/**
+ * Installing graphql_compose_routes.
+ */
+function dpl_update_update_10034(): string {
+  return _dpl_update_install_modules(['graphql_compose_routes']);
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-396

#### Description

Added update hook for installing "graphql_compose_routes" module.

The module was enabled in config core.extensions.yml in a previous [PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1968).
