### PR TITLE
Go login url + Graphql refactoring and new Lagoon route module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ GO_GRAPHQL_CONSUMER_USER_PASSWORD=oA8mqZFxmFubREH77T3qeApeoUxoNS7Y
 #OPENID_CLIENT_ID=some-client-id
 #OPENID_CLIENT_SECRET=some-client-secret
 #OPENID_AGENCY_ID=some-agency-id
+
+# GO domain (used for development)
+GO_DOMAIN=https://dapple-cms.docker:3000

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -44,8 +44,10 @@ module:
   dpl_fees: 0
   dpl_filter_paragraphs: 0
   dpl_footer: 0
+  dpl_go: 0
   dpl_graphql: 0
   dpl_instant_loan: 0
+  dpl_lagoon: 0
   dpl_library_agency: 0
   dpl_library_token: 0
   dpl_link: 0

--- a/web/modules/custom/dpl_go/dpl_go.info.yml
+++ b/web/modules/custom/dpl_go/dpl_go.info.yml
@@ -1,0 +1,9 @@
+name: 'DPL Go'
+type: module
+description: 'Module used for handling go specific functionality.'
+package: DPL
+core_version_requirement: ^10 || ^11
+dependencies:
+  - graphql:graphql
+  - dpl_unilogin:dpl_unilogin
+  - dpl_lagoon:dpl_lagoon

--- a/web/modules/custom/dpl_go/dpl_go.routing.yml
+++ b/web/modules/custom/dpl_go/dpl_go.routing.yml
@@ -1,0 +1,7 @@
+dpl_go.post_adgangsplatformen_login:
+  path: '/go-login'
+  defaults:
+    _controller: '\Drupal\dpl_go\Controller\GoController::postAdgangsplatformenLoginRoute'
+    _title: 'Post Go Adgangsplatformen Login Route'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
+++ b/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
@@ -1,0 +1,10 @@
+
+type GoLoginUrls {
+  adgangsplatformen: String
+}
+
+type GoConfiguration {
+  unilogin: UniloginConfiguration
+  loginUrls: GoLoginUrls
+}
+

--- a/web/modules/custom/dpl_go/graphql/dpl_go.extension.graphqls
+++ b/web/modules/custom/dpl_go/graphql/dpl_go.extension.graphqls
@@ -1,0 +1,4 @@
+
+extend type Query {
+  goConfiguration: GoConfiguration
+}

--- a/web/modules/custom/dpl_go/src/Controller/GoController.php
+++ b/web/modules/custom/dpl_go/src/Controller/GoController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\dpl_go\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\dpl_lagoon\Services\LagoonRouteResolver;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+use function Safe\parse_url;
+
+/**
+ * Controller for rendering full page DPL React apps.
+ */
+class GoController extends ControllerBase {
+
+  /**
+   * DdplReactAppsController constructor.
+   */
+  public function __construct(
+    protected LagoonRouteResolver $lagoonRouteResolver,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The Drupal service container.
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('dpl_lagoon.host_resolver'),
+    );
+  }
+
+  /**
+   * Redirects back to the external Go app after successful login.
+   */
+  public function postAdgangsplatformenLoginRoute(): TrustedRedirectResponse {
+    // @todo We should make it configurable which path to redirect to.
+    $externalGoUrl = sprintf('%s/user/profile', $this->getGoDomain());
+    $response = new TrustedRedirectResponse($externalGoUrl);
+
+    return $response;
+  }
+
+  /**
+   * Get the external Go domain.
+   */
+  protected function getGoDomain(): string {
+    // If the GO_DOMAIN environment variable is set,
+    // it will override anything else.
+    if ($goDomain = getenv('GO_DOMAIN') ?: NULL) {
+      return $goDomain;
+    }
+
+    if ($mainRoute = $this->lagoonRouteResolver->getMainRoute()) {
+      $urlParsed = parse_url($mainRoute);
+      if (!is_array($urlParsed)) {
+        throw new \RuntimeException('Could not determine the Go domain.');
+      }
+      $goDomain = sprintf('%s://go.%s%s', $urlParsed['scheme'], $urlParsed['host'], $urlParsed['path']);
+    }
+
+    if (!$goDomain) {
+      throw new \RuntimeException('Could not determine the Go domain.');
+    }
+
+    return $goDomain;
+  }
+
+}

--- a/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLoginUrlProducer.php
+++ b/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLoginUrlProducer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\dpl_go\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\GeneratedUrl;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Resolves the Go login url for Adgangsplatformen.
+ *
+ * Eg. wellknown url and client id and secret.
+ *
+ * @DataProducer(
+ *   id = "go_adgangsplatformen_login_url",
+ *   name = "Adgangsplatformen Url Producer",
+ *   description = "Provides the Adgangsplatformen login url for Go.",
+ *   produces = @ContextDefinition("any",
+ *     label = "Request Response"
+ *   )
+ * )
+ */
+class AdgangsplatformenLoginUrlProducer extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('url_generator')
+     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    string $pluginId,
+    mixed $pluginDefinition,
+    protected UrlGeneratorInterface $urlGenerator,
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+  }
+
+  /**
+   * Resolves the unilogin info.
+   */
+  public function resolve(): GeneratedUrl | string {
+    return $this->urlGenerator->generateFromRoute(
+        'dpl_login.login',
+        [
+          'current-path' => $this->urlGenerator->generateFromRoute(
+            'dpl_go.post_adgangsplatformen_login'
+          ),
+        ],
+        ['absolute' => TRUE]
+      );
+  }
+
+}

--- a/web/modules/custom/dpl_go/src/Plugin/GraphQL/SchemaExtension/GoConfigurationExtension.php
+++ b/web/modules/custom/dpl_go/src/Plugin/GraphQL/SchemaExtension/GoConfigurationExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\dpl_go\Plugin\GraphQL\SchemaExtension;
+
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql\GraphQL\ResolverRegistryInterface;
+use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
+
+/**
+ * Go Configuration.
+ *
+ * @SchemaExtension(
+ *   id = "dpl_go",
+ *   name = "Go configuration extension",
+ *   description = "Go related configuration",
+ *   schema = "graphql_compose"
+ * )
+ */
+class GoConfigurationExtension extends SdlSchemaExtensionPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function registerResolvers(ResolverRegistryInterface $registry): void {
+    $builder = new ResolverBuilder();
+    $registry->addFieldResolver('Query', 'goConfiguration', $builder->callback(fn () => TRUE));
+    $registry->addFieldResolver('GoConfiguration', 'adgangsplatformen', $builder->callback(fn () => TRUE));
+
+    $registry->addFieldResolver('GoConfiguration', 'unilogin',
+      $builder->produce('unilogin_info_producer')
+    );
+
+    $registry->addFieldResolver('GoConfiguration', 'loginUrls', $builder->callback(fn () => TRUE));
+    $registry->addFieldResolver('GoLoginUrls', 'adgangsplatformen',
+      $builder->produce('go_adgangsplatformen_login_url')
+    );
+  }
+
+}

--- a/web/modules/custom/dpl_lagoon/dpl_lagoon.info.yml
+++ b/web/modules/custom/dpl_lagoon/dpl_lagoon.info.yml
@@ -1,0 +1,6 @@
+name: DPL Lagoon related functionality
+description: Handles Lagoon related functionality, eg. resolving host names
+package: DPL
+
+type: module
+core_version_requirement: ^9 || ^10

--- a/web/modules/custom/dpl_lagoon/dpl_lagoon.services.yml
+++ b/web/modules/custom/dpl_lagoon/dpl_lagoon.services.yml
@@ -1,0 +1,3 @@
+services:
+  dpl_lagoon.host_resolver:
+    class: Drupal\dpl_lagoon\Services\LagoonRouteResolver

--- a/web/modules/custom/dpl_lagoon/src/Services/LagoonRouteResolver.php
+++ b/web/modules/custom/dpl_lagoon/src/Services/LagoonRouteResolver.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\dpl_lagoon\Services;
+
+/**
+ * Lagoon route resolver.
+ */
+class LagoonRouteResolver {
+
+  /**
+   * All available Lagoon routes.
+   *
+   * @var mixed[]
+   */
+  protected $routes;
+
+  /**
+   * Get all available Lagoon routes.
+   *
+   * @return mixed[]
+   *   All available Lagoon routes.
+   */
+  protected function getRoutes(): array {
+    if ($this->routes) {
+      return $this->routes;
+    }
+
+    $this->routes = explode(',', getenv('LAGOON_ROUTES') ?: '');
+    return $this->routes;
+  }
+
+  /**
+   * Get the main Lagoon route.
+   */
+  public function getMainRoute(): string | null {
+    $routes = $this->getRoutes();
+    // We take for granted that the first route is the main route.
+    // Could be that we need to change this in the future.
+    return $routes[0] ?? NULL;
+  }
+
+}

--- a/web/modules/custom/dpl_library_token/graphql/dpl_library_token.extension.graphqls
+++ b/web/modules/custom/dpl_library_token/graphql/dpl_library_token.extension.graphqls
@@ -1,3 +1,3 @@
-extend type Adgangsplatformen {
+extend type AdgangsplatformenToken {
   library: String
 }

--- a/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/SchemaExtension/DplLibraryTokenExtension.php
+++ b/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/SchemaExtension/DplLibraryTokenExtension.php
@@ -23,7 +23,7 @@ class DplLibraryTokenExtension extends SdlSchemaExtensionPluginBase {
    */
   public function registerResolvers(ResolverRegistryInterface $registry): void {
     $builder = new ResolverBuilder();
-    $registry->addFieldResolver('Adgangsplatformen', 'library',
+    $registry->addFieldResolver('AdgangsplatformenToken', 'library',
       $builder->produce('adgangsplatformen_library_token_producer')
     );
   }

--- a/web/modules/custom/dpl_login/graphql/dpl_tokens.base.graphqls
+++ b/web/modules/custom/dpl_login/graphql/dpl_tokens.base.graphqls
@@ -1,8 +1,8 @@
 
-type Adgangsplatformen {
+type AdgangsplatformenToken {
   user: String
 }
 
 type DplTokens {
-  adgangsplatformen: Adgangsplatformen
+  adgangsplatformen: AdgangsplatformenToken
 }

--- a/web/modules/custom/dpl_login/src/Plugin/GraphQL/SchemaExtension/DplTokensExtension.php
+++ b/web/modules/custom/dpl_login/src/Plugin/GraphQL/SchemaExtension/DplTokensExtension.php
@@ -25,7 +25,7 @@ class DplTokensExtension extends SdlSchemaExtensionPluginBase {
     $builder = new ResolverBuilder();
     $registry->addFieldResolver('Query', 'dplTokens', $builder->callback(fn () => TRUE));
     $registry->addFieldResolver('DplTokens', 'adgangsplatformen', $builder->callback(fn () => TRUE));
-    $registry->addFieldResolver('Adgangsplatformen', 'user',
+    $registry->addFieldResolver('AdgangsplatformenToken', 'user',
     $builder->produce('adgangsplatformen_user_token_producer')
     );
 

--- a/web/modules/custom/dpl_unilogin/dpl_unilogin.routing.yml
+++ b/web/modules/custom/dpl_unilogin/dpl_unilogin.routing.yml
@@ -4,6 +4,6 @@ dpl_unilogin.settings:
     _form: '\Drupal\dpl_unilogin\Form\UniloginConfigurationForm'
     _title: 'Unilogin configuration'
   requirements:
-    _permission: 'aadminister unilogin settings'
+    _permission: 'administer unilogin settings'
   options:
     _admin_route: TRUE

--- a/web/modules/custom/dpl_unilogin/graphql/dpl_unilogin.base.graphqls
+++ b/web/modules/custom/dpl_unilogin/graphql/dpl_unilogin.base.graphqls
@@ -1,0 +1,16 @@
+type UniloginConfiguration {
+ unilogin_api_url: String
+ unilogin_api_wellknown_url: String
+ unilogin_api_client_id: String
+ unilogin_api_client_secret: String
+}
+
+type AdgangsplatformenConfiguration {
+  goLoginUrl: String
+}
+
+type DplConfiguration {
+  unilogin: UniloginConfiguration
+  adgangsplatformen: AdgangsplatformenConfiguration
+}
+

--- a/web/modules/custom/dpl_unilogin/src/Plugin/GraphQL/DataProducer/UnilogInfoProducer.php
+++ b/web/modules/custom/dpl_unilogin/src/Plugin/GraphQL/DataProducer/UnilogInfoProducer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\dpl_unilogin\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\dpl_unilogin\UniloginConfiguration;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Exposes Unilogin information.
+ *
+ * Eg. wellknown url and client id and secret.
+ *
+ * @DataProducer(
+ *   id = "unilogin_info_producer",
+ *   name = "Unilogin Info Producer",
+ *   description = "Exposes access tokens.",
+ *   produces = @ContextDefinition("any",
+ *     label = "Request Response"
+ *   )
+ * )
+ */
+class UnilogInfoProducer extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('dpl_unilogin.settings')
+     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    string $pluginId,
+    mixed $pluginDefinition,
+    protected UniloginConfiguration $uniloginConfiguration,
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+  }
+
+  /**
+   * Resolves the Unilogin info.
+   *
+   * @return mixed[]|null
+   *   The Unilogin configuration.
+   */
+  public function resolve(): array | null {
+    $unilogin_config = [
+      'unilogin_api_url' => $this->uniloginConfiguration->getUniloginApiEndpoint(),
+      'unilogin_api_wellknown_url' => $this->uniloginConfiguration->getUniloginApiWellknownEndpoint(),
+      'unilogin_api_client_id' => $this->uniloginConfiguration->getUniloginApiClientId(),
+      'unilogin_api_client_secret' => $this->uniloginConfiguration->getUniloginApiClientSecret(),
+    ];
+
+    // Check if UniLogin configuration is empty, and return NULL if it is.
+    $unilogin_config_is_empty = (bool) array_filter(array_values($unilogin_config));
+    return $unilogin_config_is_empty ? $unilogin_config : NULL;
+  }
+
+}

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -114,6 +114,7 @@ function dpl_update_install(): string {
   $messages[] = dpl_update_update_10030();
   $messages[] = dpl_update_update_10031();
   $messages[] = dpl_update_update_10034();
+  $messages[] = dpl_update_update_10035();
 
   return implode('\r\n', $messages);
 }
@@ -383,4 +384,11 @@ function dpl_update_update_10033(): string {
  */
 function dpl_update_update_10034(): string {
   return _dpl_update_install_modules(['graphql_compose_routes']);
+}
+
+/**
+ * Introducing a two module for the Go project and Lagoon handling.
+ */
+function dpl_update_update_10035(): string {
+  return _dpl_update_install_modules(['dpl_go', 'dpl_lagoon']);
 }


### PR DESCRIPTION
#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description
This PR's main purpose is producing a Go login url and providing a redirect to the Go app coming back from Adgangsplatformen.

**The PR:**
Separates Unilogin and Go graphql information

Adds Adgangsplatformen login url.
And introduces concept of resolving lagoon routes.

**Two new modules are added:**
+ dpl_go - For Go specific functionality. First case is the go login url.
+ dpl_lagoon - For Lagoon related functionality. First: Route handling.
