### PR TITLE
Fix URL and title field on GO Video paragraph

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.go_video.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.go_video.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.go_video.field_embed_video
     - field.field.paragraph.go_video.field_go_video_title
+    - field.field.paragraph.go_video.field_url
     - paragraphs.paragraphs_type.go_video
   module:
     - media_library
@@ -28,7 +29,14 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_url:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
 hidden:
   created: true
-  field_url: true
   status: true

--- a/config/sync/core.entity_view_display.paragraph.go_video.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.go_video.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.go_video.field_embed_video
     - field.field.paragraph.go_video.field_go_video_title
+    - field.field.paragraph.go_video.field_url
     - paragraphs.paragraphs_type.go_video
 id: paragraph.go_video.default
 targetEntityType: paragraph
@@ -28,6 +29,13 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
+  field_url:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
 hidden:
-  field_url: true
   search_api_excerpt: true

--- a/config/sync/graphql_compose.settings.yml
+++ b/config/sync/graphql_compose.settings.yml
@@ -289,6 +289,9 @@ field_config:
     go_video:
       field_go_video_title:
         enabled: true
+        name_sdl: title
+      field_url:
+        enabled: true
     go_video_bundle_automatic:
       field_cql_search:
         enabled: true


### PR DESCRIPTION
Made sure the URL field on "GO Video" Paragraph is not hidden in the form.

Enabled URL field in GraphQL Compose and changed the title field graphql schema name to match what is expected in the codegen.