### PR TITLE
Apply patch to prevent non-existent permission error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -309,7 +309,8 @@
                 "3293926: Error decorating non-existent service when inner service's module not installed": "https://git.drupalcode.org/project/drupal/-/commit/a64662a3cea209c106b888ce9ef03cc1808f9ffe.patch",
                 "Always assume chmod succeeds": "patches/core-chmod-true.patch",
                 "Debug Form triggering element detection": "patches/form-triggering-element-detection-paragraphs-ee.patch",
-                "Don't check for file owner in update": "patches/dont-check-fileowner.patch"
+                "Don't check for file owner in update": "patches/dont-check-fileowner.patch",
+                "Do not throw error when non-existent permission exist": "https://www.drupal.org/files/issues/2024-06-03/3358586-36.patch"
             },
             "drupal/date_range_formatter": {
                 "3309324: Fails when start and end date are identical": "https://www.drupal.org/files/issues/2023-12-22/date_range_formatter_3309324_1.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8311c4fd5c9f6f33c8c348e3edb6ca0c",
+    "content-hash": "42fbb5439aa5e8caa9694129d7682182",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
We deployed to staging and customizable-canary and got the error:

Adding non-existent permissions to a role is not allowed. The incorrect permissions are "Administer maintenance mode".

We found a Drupal issue about the problem with patches that are about to be released in 10.4.x but are not available yet:

https://www.drupal.org/project/drupal/issues/3358586#comment-15931282

So we choose to apply the patch which can be removed when Drupal gets updated.
