### PR TITLE
DDFBRA-258 -  Re-add videotool media source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,7 @@
     ],
     "require": {
         "php": "8.1.*",
+        "ext-dom": "*",
         "amazeeio/drupal_integrations": "^0.5",
         "bower-asset/jsnlog": "^2.30",
         "brick/math": "^0.12.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75222dbc7856c35e42ec44443d1e78dd",
+    "content-hash": "24510f35008d32d0e67734c80590311b",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -20313,8 +20313,9 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "8.1.*"
+        "php": "8.1.*",
+        "ext-dom": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/config/sync/core.entity_form_display.media.videotool.default.yml
+++ b/config/sync/core.entity_form_display.media.videotool.default.yml
@@ -1,0 +1,64 @@
+uuid: ac52f811-4929-45d0-9752-1bb4e707efb7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.videotool.field_media_videotool
+    - media.type.videotool
+  module:
+    - media_videotool
+    - path
+    - select2
+id: media.videotool.default
+targetEntityType: media
+bundle: videotool
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_videotool:
+    type: videotool_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  uid:
+    type: select2_entity_reference
+    weight: 2
+    region: content
+    settings:
+      width: 100%
+      autocomplete: true
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
+hidden:
+  name: true
+  publish_on: true
+  unpublish_on: true

--- a/config/sync/core.entity_form_display.media.videotool.media_library.yml
+++ b/config/sync/core.entity_form_display.media.videotool.media_library.yml
@@ -1,0 +1,37 @@
+uuid: 0df3f36d-b107-4e99-a810-eb2b0c773b10
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.videotool.field_media_videotool
+    - media.type.videotool
+  module:
+    - path
+id: media.videotool.media_library
+targetEntityType: media
+bundle: videotool
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_media_videotool: true
+  langcode: true
+  publish_on: true
+  status: true
+  uid: true
+  unpublish_on: true

--- a/config/sync/core.entity_form_display.paragraph.go_video_bundle_automatic.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.go_video_bundle_automatic.default.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.go_video_bundle_automatic.field_cql_search
+    - field.field.paragraph.go_video_bundle_automatic.field_embed_video
     - field.field.paragraph.go_video_bundle_automatic.field_go_video_title
     - field.field.paragraph.go_video_bundle_automatic.field_url
     - field.field.paragraph.go_video_bundle_automatic.field_video_amount_of_materials
     - paragraphs.paragraphs_type.go_video_bundle_automatic
   module:
     - dpl_fbi
+    - media_library
 id: paragraph.go_video_bundle_automatic.default
 targetEntityType: paragraph
 bundle: go_video_bundle_automatic
@@ -17,9 +19,16 @@ mode: default
 content:
   field_cql_search:
     type: cql_search_widget
-    weight: 3
+    weight: 2
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_embed_video:
+    type: media_library_widget
+    weight: 1
+    region: content
+    settings:
+      media_types: {  }
     third_party_settings: {  }
   field_go_video_title:
     type: string_textfield
@@ -39,7 +48,7 @@ content:
     third_party_settings: {  }
   field_video_amount_of_materials:
     type: number
-    weight: 0
+    weight: 3
     region: content
     settings:
       placeholder: ''

--- a/config/sync/core.entity_form_display.paragraph.go_video_bundle_manual.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.go_video_bundle_manual.default.yml
@@ -3,17 +3,26 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.go_video_bundle_manual.field_embed_video
     - field.field.paragraph.go_video_bundle_manual.field_go_video_title
     - field.field.paragraph.go_video_bundle_manual.field_url
     - field.field.paragraph.go_video_bundle_manual.field_video_bundle_work_ids
     - paragraphs.paragraphs_type.go_video_bundle_manual
   module:
     - dpl_fbi
+    - media_library
 id: paragraph.go_video_bundle_manual.default
 targetEntityType: paragraph
 bundle: go_video_bundle_manual
 mode: default
 content:
+  field_embed_video:
+    type: media_library_widget
+    weight: 1
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
   field_go_video_title:
     type: string_textfield
     weight: 0
@@ -24,7 +33,7 @@ content:
     third_party_settings: {  }
   field_url:
     type: string_textfield
-    weight: 1
+    weight: 3
     region: content
     settings:
       size: 60

--- a/config/sync/core.entity_view_display.media.videotool.default.yml
+++ b/config/sync/core.entity_view_display.media.videotool.default.yml
@@ -1,0 +1,28 @@
+uuid: 8ff2c8f8-73b2-45a2-9968-9eea44a64301
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.videotool.field_media_videotool
+    - media.type.videotool
+  module:
+    - media_videotool
+id: media.videotool.default
+targetEntityType: media
+bundle: videotool
+mode: default
+content:
+  field_media_videotool:
+    type: media_videotool_embed
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.media.videotool.media_library.yml
+++ b/config/sync/core.entity_view_display.media.videotool.media_library.yml
@@ -1,0 +1,34 @@
+uuid: 8c6af3d7-a26f-4538-83f9-5f4f018e4501
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.videotool.field_media_videotool
+    - image.style.media_library
+    - media.type.videotool
+  module:
+    - image
+id: media.videotool.media_library
+targetEntityType: media
+bundle: videotool
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: media_library
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_media_videotool: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  uid: true

--- a/config/sync/core.entity_view_display.paragraph.go_video.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.go_video.preview.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.go_video.field_embed_video
     - field.field.paragraph.go_video.field_go_video_title
+    - field.field.paragraph.go_video.field_url
     - paragraphs.paragraphs_type.go_video
 id: paragraph.go_video.preview
 targetEntityType: paragraph

--- a/config/sync/core.entity_view_display.paragraph.go_video_bundle_automatic.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.go_video_bundle_automatic.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.go_video_bundle_automatic.field_cql_search
+    - field.field.paragraph.go_video_bundle_automatic.field_embed_video
     - field.field.paragraph.go_video_bundle_automatic.field_go_video_title
     - field.field.paragraph.go_video_bundle_automatic.field_url
     - field.field.paragraph.go_video_bundle_automatic.field_video_amount_of_materials
@@ -21,6 +22,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_embed_video:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 0
     region: content
   field_go_video_title:
     type: string

--- a/config/sync/core.entity_view_display.paragraph.go_video_bundle_automatic.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.go_video_bundle_automatic.preview.yml
@@ -1,0 +1,31 @@
+uuid: 1e881918-39c8-49ed-9a0f-8fecb667dd1c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.go_video_bundle_automatic.field_cql_search
+    - field.field.paragraph.go_video_bundle_automatic.field_embed_video
+    - field.field.paragraph.go_video_bundle_automatic.field_go_video_title
+    - field.field.paragraph.go_video_bundle_automatic.field_url
+    - field.field.paragraph.go_video_bundle_automatic.field_video_amount_of_materials
+    - paragraphs.paragraphs_type.go_video_bundle_automatic
+id: paragraph.go_video_bundle_automatic.preview
+targetEntityType: paragraph
+bundle: go_video_bundle_automatic
+mode: preview
+content:
+  field_embed_video:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_cql_search: true
+  field_go_video_title: true
+  field_url: true
+  field_video_amount_of_materials: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.go_video_bundle_manual.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.go_video_bundle_manual.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.go_video_bundle_manual.field_embed_video
     - field.field.paragraph.go_video_bundle_manual.field_go_video_title
     - field.field.paragraph.go_video_bundle_manual.field_url
     - field.field.paragraph.go_video_bundle_manual.field_video_bundle_work_ids
@@ -12,6 +13,15 @@ targetEntityType: paragraph
 bundle: go_video_bundle_manual
 mode: default
 content:
+  field_embed_video:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_go_video_title:
     type: string
     label: hidden

--- a/config/sync/core.entity_view_display.paragraph.go_video_bundle_manual.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.go_video_bundle_manual.preview.yml
@@ -1,0 +1,29 @@
+uuid: 6e027736-a184-4930-86e0-3bb14a3f2748
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.go_video_bundle_manual.field_embed_video
+    - field.field.paragraph.go_video_bundle_manual.field_go_video_title
+    - field.field.paragraph.go_video_bundle_manual.field_url
+    - field.field.paragraph.go_video_bundle_manual.field_video_bundle_work_ids
+    - paragraphs.paragraphs_type.go_video_bundle_manual
+id: paragraph.go_video_bundle_manual.preview
+targetEntityType: paragraph
+bundle: go_video_bundle_manual
+mode: preview
+content:
+  field_embed_video:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_go_video_title: true
+  field_url: true
+  field_video_bundle_work_ids: true
+  search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -127,6 +127,7 @@ module:
   media_library: 0
   media_library_edit: 0
   media_twentythree: 0
+  media_videotool: 0
   menu_link_content: 0
   menu_ui: 0
   metatag: 0

--- a/config/sync/field.field.media.videotool.field_media_videotool.yml
+++ b/config/sync/field.field.media.videotool.field_media_videotool.yml
@@ -1,0 +1,19 @@
+uuid: 3714c595-c665-4795-8111-b952556bd318
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_videotool
+    - media.type.videotool
+id: media.videotool.field_media_videotool
+field_name: field_media_videotool
+entity_type: media
+bundle: videotool
+label: 'VideoTool URL'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.go_page.field_paragraphs.yml
+++ b/config/sync/field.field.node.go_page.field_paragraphs.yml
@@ -30,8 +30,8 @@ settings:
       go_video: go_video
       go_linkbox: go_linkbox
       go_material_slider_automatic: go_material_slider_automatic
-      go_material_slider_manual: go_material_slider_manual
       go_video_bundle_automatic: go_video_bundle_automatic
+      go_material_slider_manual: go_material_slider_manual
       go_video_bundle_manual: go_video_bundle_manual
     negate: 0
     target_bundles_drag_drop:

--- a/config/sync/field.field.paragraph.go_video.field_embed_video.yml
+++ b/config/sync/field.field.paragraph.go_video.field_embed_video.yml
@@ -4,7 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_embed_video
-    - media.type.video
+    - media.type.videotool
     - paragraphs.paragraphs_type.go_video
 id: paragraph.go_video.field_embed_video
 field_name: field_embed_video
@@ -12,7 +12,7 @@ entity_type: paragraph
 bundle: go_video
 label: 'Embed video'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -20,10 +20,10 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
-      video: video
+      videotool: videotool
     sort:
       field: name
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: video
 field_type: entity_reference

--- a/config/sync/field.field.paragraph.go_video.field_go_video_title.yml
+++ b/config/sync/field.field.paragraph.go_video.field_go_video_title.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: go_video
 label: Title
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.paragraph.go_video.field_url.yml
+++ b/config/sync/field.field.paragraph.go_video.field_url.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: go_video
 label: URL
 description: 'VideoTool URL. Example: https://media.videotool.dk/?vn=557_2023103014511477700668916683'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.paragraph.go_video_bundle_automatic.field_embed_video.yml
+++ b/config/sync/field.field.paragraph.go_video_bundle_automatic.field_embed_video.yml
@@ -1,19 +1,18 @@
-uuid: a4b6b9dd-ed61-4134-89a8-29de11861556
+uuid: 57e2355f-a212-4847-a729-efe3c48f041d
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.paragraph.field_embed_video
-    - media.type.video
     - media.type.videotool
-    - paragraphs.paragraphs_type.video
-id: paragraph.video.field_embed_video
+    - paragraphs.paragraphs_type.go_video_bundle_automatic
+id: paragraph.go_video_bundle_automatic.field_embed_video
 field_name: field_embed_video
 entity_type: paragraph
-bundle: video
+bundle: go_video_bundle_automatic
 label: 'Embed video'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -21,7 +20,6 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
-      video: video
       videotool: videotool
     sort:
       field: name

--- a/config/sync/field.field.paragraph.go_video_bundle_automatic.field_url.yml
+++ b/config/sync/field.field.paragraph.go_video_bundle_automatic.field_url.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: go_video_bundle_automatic
 label: URL
 description: 'VideoTool URL. Example: https://media.videotool.dk/?vn=557_2023103014511477700668916683'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.paragraph.go_video_bundle_manual.field_embed_video.yml
+++ b/config/sync/field.field.paragraph.go_video_bundle_manual.field_embed_video.yml
@@ -1,19 +1,18 @@
-uuid: a4b6b9dd-ed61-4134-89a8-29de11861556
+uuid: 2c094a47-ed72-4d31-a0a5-98927ea6d2c8
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.paragraph.field_embed_video
-    - media.type.video
     - media.type.videotool
-    - paragraphs.paragraphs_type.video
-id: paragraph.video.field_embed_video
+    - paragraphs.paragraphs_type.go_video_bundle_manual
+id: paragraph.go_video_bundle_manual.field_embed_video
 field_name: field_embed_video
 entity_type: paragraph
-bundle: video
+bundle: go_video_bundle_manual
 label: 'Embed video'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -21,7 +20,6 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
-      video: video
       videotool: videotool
     sort:
       field: name

--- a/config/sync/field.field.paragraph.go_video_bundle_manual.field_url.yml
+++ b/config/sync/field.field.paragraph.go_video_bundle_manual.field_url.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: go_video_bundle_manual
 label: URL
 description: 'VideoTool URL. Example: https://media.videotool.dk/?vn=557_2023103014511477700668916683'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.storage.media.field_media_videotool.yml
+++ b/config/sync/field.storage.media.field_media_videotool.yml
@@ -1,0 +1,21 @@
+uuid: 26202e94-4de3-4d31-82ca-30d48e7bbfb2
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_media_videotool
+field_name: field_media_videotool
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/graphql_compose.settings.yml
+++ b/config/sync/graphql_compose.settings.yml
@@ -10,6 +10,8 @@ entity_config:
       enabled: true
     video:
       enabled: true
+    videotool:
+      enabled: true
   node:
     article:
       enabled: true
@@ -131,6 +133,9 @@ field_config:
         enabled: true
     video:
       field_media_oembed_video:
+        enabled: true
+    videotool:
+      field_media_videotool:
         enabled: true
   node:
     article:
@@ -287,6 +292,8 @@ field_config:
       field_title:
         enabled: true
     go_video:
+      field_embed_video:
+        enabled: true
       field_go_video_title:
         enabled: true
         name_sdl: title
@@ -295,6 +302,8 @@ field_config:
     go_video_bundle_automatic:
       field_cql_search:
         enabled: true
+      field_embed_video:
+        enabled: true
       field_go_video_title:
         enabled: true
       field_url:
@@ -302,6 +311,8 @@ field_config:
       field_video_amount_of_materials:
         enabled: true
     go_video_bundle_manual:
+      field_embed_video:
+        enabled: true
       field_go_video_title:
         enabled: true
       field_url:

--- a/config/sync/language.content_settings.media.videotool.yml
+++ b/config/sync/language.content_settings.media.videotool.yml
@@ -1,0 +1,11 @@
+uuid: 12270206-6f4a-4535-9be1-0aae4eeda411
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.videotool
+id: media.videotool
+target_entity_type_id: media
+target_bundle: videotool
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/media.type.videotool.yml
+++ b/config/sync/media.type.videotool.yml
@@ -1,0 +1,30 @@
+uuid: a5908289-52b1-4780-b324-d780ef2c23ad
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_videotool
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+id: videotool
+label: VideoTool
+description: ''
+source: videotool
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_videotool
+field_map: {  }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,7 +14,7 @@ parameters:
     - '#Call to deprecated method legacyConfig\(\) of class Drupal\\dpl_react\\DplReactConfigBase.#'
     # Drupal Form API makes extensive use for arrays which we cannot provide
     # more detailed typing of.
-    - '#.*\:\:(buildForm|getEditableConfigNames|submitForm|validateForm)\(\) .* no value type specified in iterable type array\.#'
+    - '#.*\:\:(addButtonSubmit|buildConfigurationForm|buildForm|buildInputElement|defaultConfiguration|getEditableConfigNames|getMetadataAttributes|submitForm|validateElement|validateForm)\(\) .* no value type specified in iterable type array\.#'
     - '#_alter\(\) has parameter \$form with no value type specified in iterable type array\.#'
     - '#_form_submit\(\) has parameter \$form with no value type specified in iterable type array\.#'
     # Drupal *_theme() implementation returns array which we cannot provide more detailed typing of.

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -115,6 +115,7 @@ function dpl_update_install(): string {
   $messages[] = dpl_update_update_10031();
   $messages[] = dpl_update_update_10034();
   $messages[] = dpl_update_update_10035();
+  $messages[] = dpl_update_update_10037();
 
   return implode('\r\n', $messages);
 }
@@ -398,4 +399,11 @@ function dpl_update_update_10035(): string {
  */
 function dpl_update_update_10036(): string {
   return _dpl_update_install_modules(['state_log']);
+}
+
+/**
+ * Installing Media VideoTool.
+ */
+function dpl_update_update_10037(): string {
+  return _dpl_update_install_modules(['media_videotool']);
 }

--- a/web/modules/custom/media_videotool/media_videotool.info.yml
+++ b/web/modules/custom/media_videotool/media_videotool.info.yml
@@ -1,0 +1,8 @@
+name: 'VideoTool'
+type: module
+description: 'Integrate the VideoTool video platform into the Media module'
+package: Media
+core_version_requirement: ^10
+
+dependencies:
+  - drupal:media

--- a/web/modules/custom/media_videotool/src/Form/VideoToolMediaLibraryAddForm.php
+++ b/web/modules/custom/media_videotool/src/Form/VideoToolMediaLibraryAddForm.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\media_videotool\Form;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\media\MediaTypeInterface;
+use Drupal\media_library\Form\AddFormBase;
+use Drupal\media_videotool\Traits\HasVideoToolFeaturesTrait;
+
+/**
+ * Creates a form to create VideoTool media entities from within Media Library.
+ */
+class VideoToolMediaLibraryAddForm extends AddFormBase {
+
+  use HasVideoToolFeaturesTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'media_videotool_media_library_add';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function buildInputElement(array $form, FormStateInterface $form_state): array {
+    $media_type = $this->getMediaType($form_state);
+
+    $form['container'] = [
+      '#type' => 'container',
+      '#title' => $this->t('Add @type', [
+        '@type' => $media_type->label(),
+      ]),
+    ];
+
+    $form['container']['url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Add @type video via URL', [
+        '@type' => $media_type->label(),
+      ]),
+      '#description' => $this->t('VideoTool URL example: https://media.videotool.dk/?vn=557_2023103014511477700668916683'),
+      '#required' => TRUE,
+      '#attributes' => [
+        'placeholder' => 'https://',
+      ],
+    ];
+
+    $form['container']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add'),
+      '#button_type' => 'primary',
+      '#submit' => ['::addButtonSubmit'],
+      '#ajax' => [
+        'callback' => '::updateFormCallback',
+        'wrapper' => 'media-library-wrapper',
+        'url' => Url::fromRoute('media_library.ui'),
+        'options' => [
+          'query' => $this->getMediaLibraryState($form_state)->all() + [
+            FormBuilderInterface::AJAX_FORM_REQUEST => TRUE,
+          ],
+        ],
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    if ($form_state->getValue('url') !== NULL) {
+      if (!self::isValidVideoToolUrl($form_state->getValue('url'))) {
+        $form_state->setError($form, $this->t("The given URL does not match the VideoTool URL pattern."));
+      }
+    }
+  }
+
+  /**
+   * Submit handler for the add button.
+   *
+   * @param array $form
+   *   The form render array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function addButtonSubmit(array $form, FormStateInterface $form_state): void {
+    $this->processInputValues([$form_state->getValue('url')], $form, $form_state);
+  }
+
+  /**
+   * Returns the definition of the source field for a media type.
+   *
+   * @param \Drupal\media\MediaTypeInterface $media_type
+   *   The media type to get the source definition for.
+   *
+   * @return \Drupal\Core\Field\FieldDefinitionInterface|null
+   *   The field definition.
+   */
+  protected function getSourceFieldDefinition(MediaTypeInterface $media_type): ?FieldDefinitionInterface {
+    return $media_type->getSource()->getSourceFieldDefinition($media_type);
+  }
+
+}

--- a/web/modules/custom/media_videotool/src/Plugin/Field/FieldFormatter/VideoToolFormatter.php
+++ b/web/modules/custom/media_videotool/src/Plugin/Field/FieldFormatter/VideoToolFormatter.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\media_videotool\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\media_videotool\Plugin\media\Source\VideoTool;
+use Drupal\media_videotool\Traits\HasVideoToolFeaturesTrait;
+
+/**
+ * Plugin implementation of the 'VideoTool embed' formatter.
+ */
+#[FieldFormatter(
+  id: 'media_videotool_embed',
+  label: new TranslatableMarkup('VideoTool embed'),
+  field_types: [
+    'string',
+  ],
+)]
+class VideoToolFormatter extends FormatterBase {
+
+  use HasVideoToolFeaturesTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $element = [];
+
+    /** @var \Drupal\media\MediaInterface $media */
+    $media = $items->getEntity();
+
+    /** @var \Drupal\media_videotool\Plugin\media\Source\VideoTool $videotool */
+    $videotool = $media->getSource();
+
+    foreach ($items as $delta => $item) {
+      $url = $videotool->getMetadata($media, VideoTool::METADATA_ATTRIBUTE_URL);
+      if ($url) {
+        $element[$delta] = [
+          '#type' => 'html_tag',
+          '#tag' => 'iframe',
+          '#attributes' => [
+            'src' => '',
+            'data-consent-src' => $url,
+            'frameborder' => 0,
+            'allowtransparency' => TRUE,
+            'height' => '100%',
+            'width' => '100%',
+            'data-category-consent' => 'cookie_cat_marketing',
+            'data-once' => 'cookieinformation-iframe',
+          ],
+        ];
+      }
+      else {
+        $element[$delta] = [
+          '#markup' => $item->value,
+        ];
+      }
+    }
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function isApplicable(FieldDefinitionInterface $field_definition): bool {
+    return self::targetEntityIsVideoTool($field_definition, parent::isApplicable(...));
+  }
+
+}

--- a/web/modules/custom/media_videotool/src/Plugin/Field/FieldWidget/VideoToolWidget.php
+++ b/web/modules/custom/media_videotool/src/Plugin/Field/FieldWidget/VideoToolWidget.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\media_videotool\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldWidget\StringTextfieldWidget;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\media_videotool\Traits\HasVideoToolFeaturesTrait;
+
+/**
+ * Plugin implementation of the 'videotool_textfield' widget.
+ */
+#[FieldWidget(
+  id: 'videotool_textfield',
+  label: new TranslatableMarkup('VideoTool URL'),
+  field_types: ['string'],
+)]
+class VideoToolWidget extends StringTextfieldWidget {
+
+  use HasVideoToolFeaturesTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+
+    $message = $this->t('VideoTool URL example: https://media.videotool.dk/?vn=557_2023103014511477700668916683');
+
+    if (!empty($element['value']['#description'])) {
+      $element['value']['#description'] = [
+        '#theme' => 'item_list',
+        '#items' => [$element['value']['#description'], $message],
+      ];
+    }
+    else {
+      $element['value']['#description'] = $message;
+    }
+
+    $element['#element_validate'][] = [static::class, 'validateElement'];
+
+    return $element;
+  }
+
+  /**
+   * Validate the VideoTool URL.
+   *
+   * @param array $element
+   *   The form element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @throws \Safe\Exceptions\PcreException
+   */
+  public static function validateElement(array $element, FormStateInterface $form_state): void {
+    if (!self::isValidVideoToolUrl($element['value']['#value'])) {
+      $form_state->setError($element, t("The given URL does not match the VideoTool URL pattern."));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function isApplicable(FieldDefinitionInterface $field_definition): bool {
+    return self::targetEntityIsVideoTool($field_definition, parent::isApplicable(...));
+  }
+
+}

--- a/web/modules/custom/media_videotool/src/Plugin/media/Source/VideoTool.php
+++ b/web/modules/custom/media_videotool/src/Plugin/media/Source/VideoTool.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Drupal\media_videotool\Plugin\media\Source;
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\File\Exception\FileException;
+use Drupal\Core\File\FileExists;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaSourceBase;
+use Drupal\media\MediaTypeInterface;
+use Drupal\media_videotool\Traits\HasVideoToolFeaturesTrait;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use function Safe\file_get_contents;
+use function Safe\preg_match;
+
+/**
+ * Provides a media source plugin for VideoTool resources.
+ *
+ * @MediaSource(
+ *   id = "videotool",
+ *   label = @Translation("VideoTool"),
+ *   description = @Translation("Embed VideoTool content."),
+ *   allowed_field_types = {"string"},
+ *   default_thumbnail_filename = "no-thumbnail.png",
+ *   forms = {
+ *     "media_library_add" = "\Drupal\media_videotool\Form\VideoToolMediaLibraryAddForm",
+ *   }
+ * )
+ */
+class VideoTool extends MediaSourceBase {
+
+  use HasVideoToolFeaturesTrait;
+
+  /**
+   * Key for "Name" metadata attribute.
+   *
+   * @var string
+   */
+  private const METADATA_ATTRIBUTE_NAME = 'og:title';
+
+  /**
+   * Key for "Description" metadata attribute.
+   *
+   * @var string
+   */
+  private const METADATA_ATTRIBUTE_DESCRIPTION = 'og:description';
+
+  /**
+   * Key for "URL" metadata attribute.
+   *
+   * @var string
+   */
+  public const METADATA_ATTRIBUTE_URL = 'og:url';
+
+  /**
+   * Key for "Image" metadata attribute.
+   *
+   * @var string
+   */
+  private const METADATA_ATTRIBUTE_IMAGE = 'og:image';
+
+  /**
+   * Key for "type" metadata attribute.
+   *
+   * @var string
+   */
+  private const METADATA_ATTRIBUTE_TYPE = 'og:type';
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityFieldManagerInterface $entity_field_manager,
+    $field_type_manager,
+    $config_factory,
+    protected ClientInterface $httpClient,
+    protected FileSystemInterface $fileSystem,
+    protected LoggerInterface $logger,
+  ) {
+    parent::__construct(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $entity_type_manager,
+      $entity_field_manager,
+      $field_type_manager,
+      $config_factory
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+  ) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('entity_field.manager'),
+      $container->get('plugin.manager.field.field_type'),
+      $container->get('config.factory'),
+      $container->get('http_client'),
+      $container->get('file_system'),
+      $container->get('logger.factory')->get('media'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMetadataAttributes(): array {
+    return [
+      self::METADATA_ATTRIBUTE_NAME => $this->t('Name'),
+      self::METADATA_ATTRIBUTE_DESCRIPTION => $this->t('Description'),
+      self::METADATA_ATTRIBUTE_URL => $this->t('Url'),
+      self::METADATA_ATTRIBUTE_IMAGE => $this->t('Image'),
+      self::METADATA_ATTRIBUTE_TYPE => $this->t('Media type'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMetadata(MediaInterface $media, $attribute_name) {
+
+    $media_url = $this->getSourceFieldValue($media);
+    // The URL may be NULL if the source field is empty, in which case just
+    // return NULL.
+    if (empty($media_url)) {
+      return NULL;
+    }
+
+    if (!self::isValidVideoToolUrl($media_url)) {
+      return NULL;
+    }
+
+    $doc = new \DOMDocument();
+    @$doc->loadHTML(file_get_contents($media_url));
+    $metaTags = $doc->getElementsByTagName('meta');
+
+    $metaData = [];
+    foreach ($metaTags as $metaTag) {
+      if ($metaTag->hasAttribute('property') && $metaTag->hasAttribute('content')) {
+        $metaData[$metaTag->getAttribute('property')] = $metaTag->getAttribute('content');
+      }
+    }
+
+    if (!$metaData) {
+      return NULL;
+    }
+
+    return match ($attribute_name) {
+      self::METADATA_ATTRIBUTE_NAME, 'default_name' => $metaData['og:title'],
+      self::METADATA_ATTRIBUTE_DESCRIPTION => $metaData['og:description'],
+      self::METADATA_ATTRIBUTE_URL => $metaData['og:url'],
+      self::METADATA_ATTRIBUTE_IMAGE, 'thumbnail_uri' => $this->getLocalThumbnailUri($media_url, $metaData['og:image']),
+      self::METADATA_ATTRIBUTE_TYPE => $metaData['og:type'],
+      default => parent::getMetadata($media, $attribute_name),
+    };
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    $form['generate_thumbnails'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Generate thumbnails'),
+      '#default_value' => $this->configuration['generate_thumbnails'],
+      '#description' => $this->t('If checked, Drupal will automatically generate thumbnails from VideoTool provided images.'),
+    ];
+    return $form;
+  }
+
+  /**
+   * Retrieve a thumbnail for a VideoTool resource.
+   *
+   * @param string $media_url
+   *   VideoTool media URL.
+   * @param string $remote_thumbnail_url
+   *   Thumbnail url returned from VideoTool og:image meta tag.
+   *
+   * @return string|null
+   *   Either the URL of a local thumbnail, or NULL.
+   */
+  protected function getLocalThumbnailUri(string $media_url, string $remote_thumbnail_url): ?string {
+
+    // Compute the local thumbnail URI, regardless of whether it exists.
+    $directory = $this->configuration['thumbnails_directory'];
+    preg_match('/\?vn=(.*)/', $media_url, $matches);
+    $local_thumbnail_uri = "$directory/" . $matches[1] . '.jpg';
+
+    // If the local thumbnail already exists, return its URI.
+    if (file_exists($local_thumbnail_uri)) {
+      return $local_thumbnail_uri;
+    }
+
+    // The local thumbnail doesn't exist yet, so try to download it. First,
+    // ensure that the destination directory is writable, and if it's not,
+    // log an error and bail out.
+    if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
+      $this->logger->warning('Could not prepare thumbnail destination directory @dir for VideoTool media.', [
+        '@dir' => $directory,
+      ]);
+      return NULL;
+    }
+
+    try {
+      $response = $this->httpClient->request('GET', $remote_thumbnail_url);
+      if ($response->getStatusCode() === 200) {
+        $this->fileSystem->saveData((string) $response->getBody(), $local_thumbnail_uri, FileExists::Replace);
+
+        return $local_thumbnail_uri;
+      }
+    }
+    catch (RequestException $e) {
+      $this->logger->warning($e->getMessage());
+    }
+    catch (FileException $e) {
+      $this->logger->warning('Could not download remote thumbnail from {url}.', [
+        'url' => $remote_thumbnail_url,
+      ]);
+    }
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'thumbnails_directory' => 'public://videotool_thumbnails',
+      'height' => '',
+      'width' => '',
+      'generate_thumbnails' => TRUE,
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareViewDisplay(MediaTypeInterface $type, EntityViewDisplayInterface $display): void {
+    $sourceField = $this->getSourceFieldDefinition($type);
+
+    if ($sourceField instanceof FieldDefinitionInterface) {
+      $sourceField->getDescription();
+      $display->setComponent($sourceField->getName(), [
+        'type' => 'media_videotool_embed',
+        'label' => 'visually_hidden',
+      ]);
+    }
+  }
+
+}

--- a/web/modules/custom/media_videotool/src/Traits/HasVideoToolFeaturesTrait.php
+++ b/web/modules/custom/media_videotool/src/Traits/HasVideoToolFeaturesTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\media_videotool\Traits;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\media\Entity\MediaType;
+use Drupal\media_videotool\Plugin\media\Source\VideoTool;
+
+use function Safe\preg_match;
+
+/**
+ * Trait used for common VideoTool methods.
+ */
+trait HasVideoToolFeaturesTrait {
+
+  /**
+   * Function for checking if a URL match the VideoTool URL format.
+   */
+  protected static function isValidVideoToolUrl(string $url): bool {
+    return (bool) preg_match('/^https:\/\/media\.videotool\.dk\/\?vn=\d+_\d+$/', $url);
+  }
+
+  /**
+   * Function for checking if a specific entity is of the VideoTool type..
+   */
+  protected static function targetEntityIsVideoTool(FieldDefinitionInterface $fieldDefinition, callable $isApplicable): bool {
+    if ($fieldDefinition->getTargetEntityTypeId() !== 'media') {
+      return FALSE;
+    }
+
+    if ($isApplicable($fieldDefinition)) {
+      $media_type = $fieldDefinition->getTargetBundle();
+
+      if ($media_type) {
+        $media_type = MediaType::load($media_type);
+        return $media_type && $media_type->getSource() instanceof VideoTool;
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/web/themes/custom/novel/templates/fields/field--media--videotool.html.twig
+++ b/web/themes/custom/novel/templates/fields/field--media--videotool.html.twig
@@ -1,0 +1,21 @@
+<div class="consent-placeholder cookie-placeholder cookie-placeholder__hide" data-category="cookie_cat_marketing">
+  <div class="pagefold-triangle--medium pagefold-inherit-parent"></div>
+  <div class="cookie-placeholder__wrapper">
+    <div class="cookie-placeholder__description">
+      <div id="dpl-react-apps-cookie-placeholder">
+        {{ "To view this content, we need your consent to use marketing cookies."|t({}, {"context": "Cookie Placeholder"}) }}
+      </div>
+    </div>
+    <button
+      type="button"
+      class="cookie-placeholder__manage-consent-button btn-primary btn-outline btn-xlarge arrow__hover--right-small"
+      aria-label="{{ 'Manage consent'|t({}, {'context': 'Cookie Placeholder'}) }}"
+      onClick="javascript:CookieConsent.renew();"
+    >
+      {{ "Manage consent"|t({}, {"context": "Cookie Placeholder"}) }}
+    </button>
+  </div>
+</div>
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/web/themes/custom/novel/templates/media/media--videotool--full.html.twig
+++ b/web/themes/custom/novel/templates/media/media--videotool--full.html.twig
@@ -1,0 +1,9 @@
+{% set classes = [
+  'video-embed'
+] %}
+
+<section{{ attributes.addClass(classes) }}>
+  <div class="video-embed__wrapper">
+    {{ content }}
+  </div>
+</section>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-258

#### Description

This PR is a copy of a previously added [PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2007).
The previous PR got merged to develop and then reverted. This PR seeks to re-add the same code again.

This PR introduces a new Media Type called "VideoTool" which are used on video paragraphs.
The PR adds:

1. New module called "media_videotool" which adds a new media source called "VideoTool". The module adds the following files:
  - `VideoTool.php` - Contains logic for adding the new mediasource, which is created by fetching meta data from the submittet VideoTool URL. The thumbnail is generated by fetching an image from the "og:image" metatag value which contains a URL for downloading the image.
  - `VideoToolWidget.php` - A new VideoTool widget which contains the logic for how to add new VideoTool resources in through the Video Embed field. Also takes care of the validation of the submitted VideoTool URL.
  - `VideoToolMediaLibraryAddForm.php` - Similar as above, but this form is used directly from inside Drupals Media Library UI when adding new VideoTool resources.
  - `VideoToolFormatter.php` - Contains the logic for how the media field should handle VideoTool video fields in twig. This also include setting up cookieinformation logic. This is basically tells how the iFrame should be constructed.
  
2. Adds 2 new twig templates for displaying the VideoTool media type field in FB-CMS.

3. Adds configuration for adding the VideoTool media type to all existing Video paragraphs. Added to the following paragraphs:
  - Video
  - GO Video
  - GO Video Bundle - Automatic
  - GO Video Bundle - Manual

4. Enables the new field on all GO Paragraphs in GraphQL Compose.
  
#### Screenshot of the result

Screenshot showing the Media Library "Add or select media" UI after choosing VideoTool
![Screenshot 2025-01-25 at 00 58 11](https://github.com/user-attachments/assets/2e3d3988-71fe-4605-b717-503cb994dc11)

Screenshot showing how the video looks in FB-CMS after accepting cookies:
![Screenshot 2025-01-25 at 00 43 05](https://github.com/user-attachments/assets/9e1353b1-a813-4705-b1d4-f54552391f95)

#### Additional comments or questions

The existing URL textfield added to the Video GO paragraphs is now deprecated. However it is not removed in this PR, as we do not want to break things in the GO FE. A separate [task](https://reload.atlassian.net/browse/DDFBRA-408) has been added in JIRA for removing the deprecated URL field once the new VideoTool Embed field has been implemented in the GO FE.


GraphQL query example fetching a GO Video Paragraph on a GO Page:
```
query MyQuery {
  route(path: "go-video-page-title-example") {
    ... on RouteInternal {
      __typename
      entity {
        ... on NodeGoPage {
          id
          paragraphs {
            ... on ParagraphGoVideo {
              id
              embedVideo {
                ... on MediaVideotool {
                  id
                  name
                  mediaVideotool
                  path
                }
              }
              goVideoTitle
            }
          }
          title
        }
      }
    }
  }
}
```

Result:
```
{
  "data": {
    "route": {
      "__typename": "RouteInternal",
      "entity": {
        "id": "2b371a09-f953-4c42-8658-191a0dd45c5e",
        "paragraphs": [
          {
            "id": "d68540e1-e183-4c2c-9a6e-c2a1f5140c3e",
            "embedVideo": {
              "id": "9a3e328e-bc7f-4e88-bb63-6aaa8afdfcec",
              "name": "Emilie bliver KIDNAPPET! | Suget Ind |",
              "mediaVideotool": "https://media.videotool.dk/?vn=557_2023103014511477700668916683",
              "path": "/media/17/edit"
            },
            "goVideoTitle": "GO Video Paragraph Title Example"
          }
        ],
        "title": "GO Video Page Title Example"
      }
    }
  }
}
```