### PR TITLE
Make bnf state field an enum_field

### DIFF
--- a/web/modules/custom/bnf/bnf.module
+++ b/web/modules/custom/bnf/bnf.module
@@ -18,29 +18,15 @@ function bnf_entity_base_field_info(EntityTypeInterface $entity_type): array {
 
   // Create new fields for node bundle.
   if ($entity_type->id() === 'node') {
-    $fields[BnfStateEnum::FIELD_NAME] = BaseFieldDefinition::create('list_integer')
+    $fields[BnfStateEnum::FIELD_NAME] = BaseFieldDefinition::create('enum_integer')
       ->setName(BnfStateEnum::FIELD_NAME)
       ->setLabel(t('BNF State'))
       ->setDescription(t('The BNF state of the entity, defining if it was imported, exported, or neither.'))
-      ->setSetting('allowed_values_function', 'bnf_get_bnf_state_allowed_values')
-      ->setDefaultValue(BnfStateEnum::None->value);
+      ->setSetting('enum_class', BnfStateEnum::class)
+      ->setDefaultValue(BnfStateEnum::None);
   }
 
   return $fields;
-}
-
-/**
- * Provides allowed values for the BNF State field.
- *
- * @return string[]
- *   The enum values of BnfStateEnum.
- */
-function bnf_get_bnf_state_allowed_values(): array {
-  $values = [];
-  foreach (BnfStateEnum::cases() as $case) {
-    $values[$case->value] = $case->name;
-  }
-  return $values;
 }
 
 /**

--- a/web/modules/custom/bnf/bnf_client/src/Services/BnfExporter.php
+++ b/web/modules/custom/bnf/bnf_client/src/Services/BnfExporter.php
@@ -90,7 +90,7 @@ class BnfExporter {
       throw new \Exception($message);
     }
 
-    $node->set(BnfStateEnum::FIELD_NAME, BnfStateEnum::Exported->value);
+    $node->set(BnfStateEnum::FIELD_NAME, BnfStateEnum::Exported);
     $node->save();
 
   }

--- a/web/modules/custom/bnf/src/Services/BnfImporter.php
+++ b/web/modules/custom/bnf/src/Services/BnfImporter.php
@@ -80,7 +80,7 @@ class BnfImporter {
 
       $node = $this->mapperManager->map($nodeData);
 
-      $node->set(BnfStateEnum::FIELD_NAME, BnfStateEnum::Imported->value);
+      $node->set(BnfStateEnum::FIELD_NAME, BnfStateEnum::Imported);
 
       $node->set('status', NodeInterface::NOT_PUBLISHED);
 


### PR DESCRIPTION
We can just change the `BaseFieldDefinition` and call it a day, as the `enum_integer` field inherits from `list_integer` so they use the same storage.
