### PR TITLE
Refactor `go_linkbox` paragraph to support a single link

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.go_link.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.go_link.default.yml
@@ -1,10 +1,10 @@
-uuid: aea77006-ef8e-4082-be55-079008cf2399
+uuid: 856b0a56-5938-485d-b19d-281982a026bc
 langcode: en
 status: true
 dependencies:
   config:
     - field.field.paragraph.go_link.field_aria_label
-    - field.field.paragraph.go_link.field_link
+    - field.field.paragraph.go_link.field_go_link
     - field.field.paragraph.go_link.field_target_blank
     - paragraphs.paragraphs_type.go_link
   module:
@@ -22,7 +22,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_link:
+  field_go_link:
     type: linkit
     weight: 0
     region: content

--- a/config/sync/core.entity_form_display.paragraph.go_linkbox.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.go_linkbox.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.paragraph.go_linkbox.field_go_color
     - field.field.paragraph.go_linkbox.field_go_description
     - field.field.paragraph.go_linkbox.field_go_image
-    - field.field.paragraph.go_linkbox.field_go_link
+    - field.field.paragraph.go_linkbox.field_go_link_paragraph
     - field.field.paragraph.go_linkbox.field_title
     - paragraphs.paragraphs_type.go_linkbox
   module:
@@ -40,7 +40,7 @@ content:
     settings:
       media_types: {  }
     third_party_settings: {  }
-  field_go_link:
+  field_go_link_paragraph:
     type: paragraphs
     weight: 3
     region: content

--- a/config/sync/core.entity_view_display.paragraph.go_link.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.go_link.default.yml
@@ -1,10 +1,10 @@
-uuid: 149c4c93-19c3-422b-af2f-8d70e8c249b9
+uuid: 987ca6b6-5a43-4189-98f4-919808d4216a
 langcode: en
 status: true
 dependencies:
   config:
     - field.field.paragraph.go_link.field_aria_label
-    - field.field.paragraph.go_link.field_link
+    - field.field.paragraph.go_link.field_go_link
     - field.field.paragraph.go_link.field_target_blank
     - paragraphs.paragraphs_type.go_link
   module:
@@ -20,17 +20,17 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
-  field_link:
+  field_go_link:
     type: link
-    label: hidden
+    label: above
     settings:
-      trim_length: null
+      trim_length: 80
       url_only: false
       url_plain: false
-      rel: '0'
-      target: '0'
+      rel: ''
+      target: ''
     third_party_settings: {  }
     weight: 0
     region: content
@@ -42,7 +42,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
 hidden:
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.go_linkbox.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.go_linkbox.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.paragraph.go_linkbox.field_go_color
     - field.field.paragraph.go_linkbox.field_go_description
     - field.field.paragraph.go_linkbox.field_go_image
-    - field.field.paragraph.go_linkbox.field_go_link
+    - field.field.paragraph.go_linkbox.field_go_link_paragraph
     - field.field.paragraph.go_linkbox.field_title
     - paragraphs.paragraphs_type.go_linkbox
   module:
@@ -40,7 +40,7 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
-  field_go_link:
+  field_go_link_paragraph:
     type: entity_reference_revisions_entity_view
     label: above
     settings:

--- a/config/sync/core.entity_view_display.paragraph.go_linkbox.preview.yml
+++ b/config/sync/core.entity_view_display.paragraph.go_linkbox.preview.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.paragraph.go_linkbox.field_go_color
     - field.field.paragraph.go_linkbox.field_go_description
     - field.field.paragraph.go_linkbox.field_go_image
-    - field.field.paragraph.go_linkbox.field_go_link
+    - field.field.paragraph.go_linkbox.field_go_link_paragraph
     - field.field.paragraph.go_linkbox.field_title
     - paragraphs.paragraphs_type.go_linkbox
 id: paragraph.go_linkbox.preview
@@ -27,5 +27,5 @@ hidden:
   field_go_color: true
   field_go_description: true
   field_go_image: true
-  field_go_link: true
+  field_go_link_paragraph: true
   search_api_excerpt: true

--- a/config/sync/field.field.paragraph.go_link.field_aria_label.yml
+++ b/config/sync/field.field.paragraph.go_link.field_aria_label.yml
@@ -1,4 +1,4 @@
-uuid: e049297d-570d-481a-abee-9437d848be45
+uuid: d14cd802-105a-4781-bd60-1fb52aba4071
 langcode: en
 status: true
 dependencies:

--- a/config/sync/field.field.paragraph.go_link.field_go_link.yml
+++ b/config/sync/field.field.paragraph.go_link.field_go_link.yml
@@ -1,14 +1,14 @@
-uuid: 87a4e6be-a19b-422e-81ac-7355c25825ba
+uuid: fc4613d5-10dd-468b-b47f-9721055f73ef
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.paragraph.field_link
+    - field.storage.paragraph.field_go_link
     - paragraphs.paragraphs_type.go_link
   module:
     - link
-id: paragraph.go_link.field_link
-field_name: field_link
+id: paragraph.go_link.field_go_link
+field_name: field_go_link
 entity_type: paragraph
 bundle: go_link
 label: Link

--- a/config/sync/field.field.paragraph.go_link.field_target_blank.yml
+++ b/config/sync/field.field.paragraph.go_link.field_target_blank.yml
@@ -1,4 +1,4 @@
-uuid: c68b4c84-fd62-40e9-9d62-155b50a0e8b7
+uuid: 2d27877f-5ba2-4059-954d-4ead3d65267f
 langcode: en
 status: true
 dependencies:

--- a/config/sync/field.field.paragraph.go_linkbox.field_go_link_paragraph.yml
+++ b/config/sync/field.field.paragraph.go_linkbox.field_go_link_paragraph.yml
@@ -1,15 +1,15 @@
-uuid: 11d0e9cf-02a4-4073-8d16-98c6d0796551
+uuid: 777de8e5-6114-4e88-b8e4-c8e53a7367d4
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.paragraph.field_go_link
+    - field.storage.paragraph.field_go_link_paragraph
     - paragraphs.paragraphs_type.go_link
     - paragraphs.paragraphs_type.go_linkbox
   module:
     - entity_reference_revisions
-id: paragraph.go_linkbox.field_go_link
-field_name: field_go_link
+id: paragraph.go_linkbox.field_go_link_paragraph
+field_name: field_go_link_paragraph
 entity_type: paragraph
 bundle: go_linkbox
 label: Link

--- a/config/sync/field.storage.paragraph.field_aria_label.yml
+++ b/config/sync/field.storage.paragraph.field_aria_label.yml
@@ -1,4 +1,4 @@
-uuid: 4d442613-4a21-4ad0-b43b-1300246169c3
+uuid: 6c025938-c63c-4102-a3ff-6782d9b97b1a
 langcode: en
 status: true
 dependencies:

--- a/config/sync/field.storage.paragraph.field_go_link.yml
+++ b/config/sync/field.storage.paragraph.field_go_link.yml
@@ -1,17 +1,16 @@
-uuid: 21293302-f1f1-4d53-8ffe-4e5f06701647
+uuid: 8731de3f-3283-4da4-aa60-5bde1d9eb8e3
 langcode: en
 status: true
 dependencies:
   module:
-    - entity_reference_revisions
+    - link
     - paragraphs
 id: paragraph.field_go_link
 field_name: field_go_link
 entity_type: paragraph
-type: entity_reference_revisions
-settings:
-  target_type: paragraph
-module: entity_reference_revisions
+type: link
+settings: {  }
+module: link
 locked: false
 cardinality: 1
 translatable: true

--- a/config/sync/field.storage.paragraph.field_go_link_paragraph.yml
+++ b/config/sync/field.storage.paragraph.field_go_link_paragraph.yml
@@ -1,0 +1,20 @@
+uuid: 9c9f609b-fe0f-4ded-8c19-26a1b58da25f
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_go_link_paragraph
+field_name: field_go_link_paragraph
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_target_blank.yml
+++ b/config/sync/field.storage.paragraph.field_target_blank.yml
@@ -1,4 +1,4 @@
-uuid: 2b390fd3-d69d-428a-b0c1-89e0a809f677
+uuid: ba03a13a-3c00-4dfc-a658-4aaedaef5d2a
 langcode: en
 status: true
 dependencies:

--- a/config/sync/graphql_compose.settings.yml
+++ b/config/sync/graphql_compose.settings.yml
@@ -273,7 +273,7 @@ field_config:
     go_link:
       field_aria_label:
         enabled: true
-      field_link:
+      field_go_link:
         enabled: true
       field_target_blank:
         enabled: true
@@ -284,7 +284,7 @@ field_config:
         enabled: true
       field_go_image:
         enabled: true
-      field_go_link:
+      field_go_link_paragraph:
         enabled: true
       field_title:
         enabled: true

--- a/config/sync/paragraphs.paragraphs_type.go_link.yml
+++ b/config/sync/paragraphs.paragraphs_type.go_link.yml
@@ -1,4 +1,4 @@
-uuid: 1a589c1b-3439-4296-8167-f0fe72444234
+uuid: caa6de01-e7fb-4619-b7a8-f09532ea5a8c
 langcode: en
 status: true
 dependencies:


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-456

#### Description

I encountered issues when trying to remove the `field_link` from the `go_link` paragraph. As a result, I deleted it and recreated it all. The main issue stemmed from a previous reuse of the `field_link`, which allowed multiple links. To resolve this, I have introduced a `field_go_link` that supports only one link.


<img width="828" alt="image" src="https://github.com/user-attachments/assets/a0e21e63-f279-4648-bb0f-b79d8cde6ab7" />


```
query MyQuery {
  route(path: "test-linkbox") {
    ... on RouteInternal {
      __typename
      url
      entity {
        ... on NodeGoPage {
          id
          title
          paragraphs {
            ... on ParagraphGoLinkbox {
              goColor
              title
              goDescription
              goLinkParagraph {
                ... on ParagraphGoLink {
                  goLink {
                    title
                    url
                  }
                  targetBlank
                  ariaLabel
                }
              }
            }
          }
        }
      }
    }
  }
}
```

```

{
  "data": {
    "route": {
      "__typename": "RouteInternal",
      "url": "/test-linkbox",
      "entity": {
        "id": "b844cfb6-c9f7-460e-bba5-91051df62495",
        "title": "Test linkbox",
        "paragraphs": [
          {
            "goColor": "content_color_2",
            "title": "linkbox Title",
            "goDescription": "linkbox Description",
            "goLinkParagraph": {
              "goLink": {
                "title": "Besøg google",
                "url": "https://www.google.com/"
              },
              "targetBlank": true,
              "ariaLabel": "Besøg google (Aria Label)"
            }
          }
        ]
      }
    }
  }
}
```

