### PR TITLE
Stop things breaking, when dealing with orphaned eventinstances. DDFHER-204

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -375,7 +375,8 @@
                 "3468521: (3/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad8a4294b1ffb754a338bb2cfa0146f203aa6fc1.patch",
                 "3468521: (4/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad99ae79f5c55fc2db17427e9936ab141314609d.patch",
                 "3468300: Update EventSeriesSettings to use datetime form element.": "https://git.drupalcode.org/project/recurring_events/-/commit/5d9bc3b1cf7c00972f053f3d14873012b1ad7140.patch",
-                "3487412: Fix WSOD when EventInstance has invalid translation.": "https://git.drupalcode.org/project/recurring_events/-/commit/996052eeb7518ce591df968a0bb12c4819fb4edf.patch"
+                "3487412: Fix WSOD when EventInstance has invalid translation.": "https://git.drupalcode.org/project/recurring_events/-/commit/996052eeb7518ce591df968a0bb12c4819fb4edf.patch",
+                "3504806: Clean up orphaned eventinstances automatically": "https://www.drupal.org/files/issues/2025-02-06/reccuring_events_auto_delete_orphaned.patch"
             },
             "drupal/state_log": {
                 "3501178: Call to undefined method Drupal\\state_log\\StateLog::destruct()": "https://git.drupalcode.org/project/state_log/-/commit/8d63dd4827a930f5294004a1d13f051487ec4269.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be9bb52e1a5b636f3e760c3b7ab280f3",
+    "content-hash": "916e71daa47e3de77d0d583c9490ec62",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/config/sync/recurring_events.eventinstance.config.yml
+++ b/config/sync/recurring_events.eventinstance.config.yml
@@ -2,3 +2,4 @@ _core:
   default_config_hash: 4hMKdEF-IZHfBewW8ok-H2e30isynIPysiFD7hucbk4
 date_format: 'd/m/y - H:i'
 limit: 10
+auto_delete_orphaned: 1

--- a/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
+++ b/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
@@ -12,6 +12,7 @@ use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\node\NodeInterface;
 use Drupal\pathauto\AliasCleanerInterface;
 use Drupal\recurring_events\Entity\EventInstance;
+use Drupal\recurring_events\Entity\EventSeries;
 use Drupal\taxonomy\TermInterface;
 use Psr\Log\LoggerInterface;
 use Safe\DateTime;
@@ -258,8 +259,20 @@ class BreadcrumbHelper {
    */
   public function getEventInstanceBreadcrumbSuffix(EventInstance $instance, Breadcrumb $breadcrumb): Breadcrumb {
     $series = $instance->getEventSeries();
+
+    // If the eventinstance is orphaned, it means that we cannot get the series
+    // ID - this should hopefully never happen.
+    if (!($series instanceof EventSeries)) {
+      return $breadcrumb;
+    }
+
     $instance_count =
-      $this->entityTypeManager->getStorage('eventinstance')->getQuery()->condition('eventseries_id', $series->id())->accessCheck()->count()->execute();
+      $this->entityTypeManager->getStorage('eventinstance')
+        ->getQuery()
+        ->condition('eventseries_id', $series->id())
+        ->accessCheck()
+        ->count()
+        ->execute();
 
     // Technically an instance date may be a range over several days or months,
     // but this quickly becomes very complicated, both to display for the user,

--- a/web/modules/custom/dpl_event/src/Entity/EventInstance.php
+++ b/web/modules/custom/dpl_event/src/Entity/EventInstance.php
@@ -8,6 +8,7 @@ use Drupal\dpl_event\EventState;
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\recurring_events\Entity\EventInstance as RecurringEventInstance;
+use Drupal\recurring_events\Entity\EventSeries;
 use Psr\Log\LoggerInterface;
 use Safe\DateTime;
 use Safe\DateTimeImmutable;
@@ -213,7 +214,7 @@ class EventInstance extends RecurringEventInstance {
     $series = $this->getEventSeries();
 
     $changed_instance = $this->getChangedTime();
-    $changed_series = $series->getChangedTime();
+    $changed_series = ($series instanceof EventSeries) ? $series->getChangedTime() : 0;
 
     // Setting the timestamp to whichever is the larger.
     $timestamp = ($changed_instance > $changed_series) ?


### PR DESCRIPTION
# Patching recurring_events to automatically clean up orphaned events. DDFHER-204

If for whatever reason an eventinstance ends up orphaned after a series
has been deleted, the event API and the breadcrumb builder will fail
hard.

I've created an upstream patch at
https://www.drupal.org/project/recurring_events/issues/3504806 that
deals with this - it cleans up orphaned eventinstances as part of cron.

# Make custom event code not fail with orphaned events. DDFHER-204

recurring_events has a ->getEventSeries() function that always should
return a series, but sometimes it doesnt.
As part of the previous commit, we make sure that orphaned eventinstances
get removed, but until they are removed, the breadcrumb builder and
event API will fail.
This commit makes our code more robust when it stumbles upon an orphaned
instance.