### PR TITLE
Mapper renaming

### DIFF
--- a/web/modules/custom/bnf/src/Plugin/bnf_mapper/NodeArticleMapper.php
+++ b/web/modules/custom/bnf/src/Plugin/bnf_mapper/NodeArticleMapper.php
@@ -6,7 +6,7 @@ namespace Drupal\bnf\Plugin\bnf_mapper;
 
 use Drupal\bnf\Attribute\BnfMapper;
 use Drupal\bnf\BnfMapperManager;
-use Drupal\bnf\GraphQL\Operations\GetNode\Node\NodeArticle as GraphQLNodeArticle;
+use Drupal\bnf\GraphQL\Operations\GetNode\Node\NodeArticle;
 use Drupal\bnf\Plugin\BnfMapperPluginBase;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -16,9 +16,9 @@ use Spawnia\Sailor\ObjectLike;
  * Maps article nodes.
  */
 #[BnfMapper(
-  id: GraphQLNodeArticle::class,
+  id: NodeArticle::class,
 )]
-class NodeArticle extends BnfMapperPluginBase {
+class NodeArticleMapper extends BnfMapperPluginBase {
 
   /**
    * Entity storage to create node in.
@@ -44,7 +44,7 @@ class NodeArticle extends BnfMapperPluginBase {
    * {@inheritdoc}
    */
   public function map(ObjectLike $object): mixed {
-    if (!$object instanceof GraphQLNodeArticle) {
+    if (!$object instanceof NodeArticle) {
       throw new \RuntimeException('Wrong class handed to mapper');
     }
 

--- a/web/modules/custom/bnf/src/Plugin/bnf_mapper/ParagraphAccordionMapper.php
+++ b/web/modules/custom/bnf/src/Plugin/bnf_mapper/ParagraphAccordionMapper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\bnf\Plugin\bnf_mapper;
 
 use Drupal\bnf\Attribute\BnfMapper;
-use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\ParagraphAccordion as GraphQLParagraphAccordion;
+use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\ParagraphAccordion;
 use Drupal\bnf\Plugin\BnfMapperPluginBase;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -15,9 +15,9 @@ use Spawnia\Sailor\ObjectLike;
  * Maps accordion paragraphs.
  */
 #[BnfMapper(
-  id: GraphQLParagraphAccordion::class,
+  id: ParagraphAccordion::class,
   )]
-class ParagraphAccordion extends BnfMapperPluginBase {
+class ParagraphAccordionMapper extends BnfMapperPluginBase {
 
   /**
    * Entity storage to create paragroph in.
@@ -42,7 +42,7 @@ class ParagraphAccordion extends BnfMapperPluginBase {
    * {@inheritdoc}
    */
   public function map(ObjectLike $object): mixed {
-    if (!$object instanceof GraphQLParagraphAccordion) {
+    if (!$object instanceof ParagraphAccordion) {
       throw new \RuntimeException('Wrong class handed to mapper');
     }
 

--- a/web/modules/custom/bnf/src/Plugin/bnf_mapper/ParagraphTextBodyMapper.php
+++ b/web/modules/custom/bnf/src/Plugin/bnf_mapper/ParagraphTextBodyMapper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\bnf\Plugin\bnf_mapper;
 
 use Drupal\bnf\Attribute\BnfMapper;
-use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\ParagraphTextBody as GraphQLParagraphTextBody;
+use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\ParagraphTextBody;
 use Drupal\bnf\Plugin\BnfMapperPluginBase;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -15,9 +15,9 @@ use Spawnia\Sailor\ObjectLike;
  * Maps text paragraphs.
  */
 #[BnfMapper(
-  id: GraphQLParagraphTextBody::class,
-)]
-class ParagraphTextBody extends BnfMapperPluginBase {
+  id: ParagraphTextBody::class,
+  )]
+class ParagraphTextBodyMapper extends BnfMapperPluginBase {
 
   /**
    * Entity storage to create paragroph in.
@@ -42,7 +42,7 @@ class ParagraphTextBody extends BnfMapperPluginBase {
    * {@inheritdoc}
    */
   public function map(ObjectLike $object): mixed {
-    if (!$object instanceof GraphQLParagraphTextBody) {
+    if (!$object instanceof ParagraphTextBody) {
       throw new \RuntimeException('Wrong class handed to mapper');
     }
 

--- a/web/modules/custom/bnf/tests/src/Unit/Mapper/EntityMapperTestBase.php
+++ b/web/modules/custom/bnf/tests/src/Unit/Mapper/EntityMapperTestBase.php
@@ -12,10 +12,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 /**
  * Base class for testing mappers that produce entities.
  */
-class EntityMapperTestBase extends UnitTestCase {
-
-  const ENTITY_NAME = '';
-  const ENTITY_CLASS = '';
+abstract class EntityMapperTestBase extends UnitTestCase {
 
   /**
    * EntityManager prophecy.
@@ -44,14 +41,20 @@ class EntityMapperTestBase extends UnitTestCase {
   public function setUp(): void {
     parent::setUp();
 
-    if (empty(static::ENTITY_NAME) || empty(static::ENTITY_CLASS)) {
-      throw new \LogicException('Test classes should define ENTITY_CLASS and ENTITY_NAME constants');
-    }
-
     $this->entityManagerProphecy = $this->prophesize(EntityTypeManagerInterface::class);
     $this->storageProphecy = $this->prophesize(EntityStorageInterface::class);
-    $this->entityManagerProphecy->getStorage(static::ENTITY_NAME)->willReturn($this->storageProphecy);
-    $this->entityProphecy = $this->prophesize(static::ENTITY_CLASS);
+    $this->entityManagerProphecy->getStorage($this->getEntityName())->willReturn($this->storageProphecy);
+    $this->entityProphecy = $this->prophesize($this->getEntityClass());
   }
+
+  /**
+   * Return the name of the entity type to work with.
+   */
+  abstract protected function getEntityName(): string;
+
+  /**
+   * Return the class name of the entity to work with.
+   */
+  abstract protected function getEntityClass(): string;
 
 }

--- a/web/modules/custom/bnf/tests/src/Unit/Mapper/NodeArticleMapperTest.php
+++ b/web/modules/custom/bnf/tests/src/Unit/Mapper/NodeArticleMapperTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\bnf\Unit\Mapper;
 
 use Drupal\bnf\BnfMapperManager;
-use Drupal\bnf\GraphQL\Operations\GetNode\Node\NodeArticle as GraphQLArticle;
-use Drupal\bnf\Plugin\bnf_mapper\NodeArticle;
+use Drupal\bnf\GraphQL\Operations\GetNode\Node\NodeArticle;
+use Drupal\bnf\Plugin\bnf_mapper\NodeArticleMapper;
 use Drupal\node\Entity\Node;
 
 /**
  * Test the article node mapper.
  */
-class NodeArticleTest extends EntityMapperTestBase {
+class NodeArticleTestMapper extends EntityMapperTestBase {
 
   const ENTITY_NAME = 'node';
   const ENTITY_CLASS = Node::class;
@@ -27,7 +27,7 @@ class NodeArticleTest extends EntityMapperTestBase {
     ])->willReturn($this->entityProphecy);
 
     $manager = $this->prophesize(BnfMapperManager::class);
-    $mapper = new NodeArticle(
+    $mapper = new NodeArticleMapper(
       [],
       '',
       [],
@@ -35,7 +35,7 @@ class NodeArticleTest extends EntityMapperTestBase {
       $this->entityManagerProphecy->reveal(),
     );
 
-    $graphqlArticle = GraphQLArticle::make('123', 'this is the title');
+    $graphqlArticle = NodeArticle::make('123', 'this is the title');
 
     $node = $mapper->map($graphqlArticle);
 

--- a/web/modules/custom/bnf/tests/src/Unit/Mapper/NodeArticleMapperTest.php
+++ b/web/modules/custom/bnf/tests/src/Unit/Mapper/NodeArticleMapperTest.php
@@ -12,10 +12,21 @@ use Drupal\node\Entity\Node;
 /**
  * Test the article node mapper.
  */
-class NodeArticleTestMapper extends EntityMapperTestBase {
+class NodeArticleMapperTest extends EntityMapperTestBase {
 
-  const ENTITY_NAME = 'node';
-  const ENTITY_CLASS = Node::class;
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityName(): string {
+    return 'node';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityClass(): string {
+    return Node::class;
+  }
 
   /**
    * Test article node mapping.

--- a/web/modules/custom/bnf/tests/src/Unit/Mapper/ParagraphAccordionMapperTest.php
+++ b/web/modules/custom/bnf/tests/src/Unit/Mapper/ParagraphAccordionMapperTest.php
@@ -15,8 +15,19 @@ use Drupal\paragraphs\Entity\Paragraph;
  */
 class ParagraphAccordionMapperTest extends EntityMapperTestBase {
 
-  const ENTITY_NAME = 'paragraph';
-  const ENTITY_CLASS = Paragraph::class;
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityName(): string {
+    return 'paragraph';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityClass(): string {
+    return Paragraph::class;
+  }
 
   /**
    * Test text paragraph mapping.

--- a/web/modules/custom/bnf/tests/src/Unit/Mapper/ParagraphAccordionMapperTest.php
+++ b/web/modules/custom/bnf/tests/src/Unit/Mapper/ParagraphAccordionMapperTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\bnf\Unit\Mapper;
 
-use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\AccordionDescription\Text as GraphqlDescriptionText;
-use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\AccordionTitle\Text as GraphqlTitleText;
-use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\ParagraphAccordion as GraphqlParagraphAccordion;
-use Drupal\bnf\Plugin\bnf_mapper\ParagraphAccordion;
+use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\AccordionDescription\Text as DescriptionText;
+use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\AccordionTitle\Text as TitleText;
+use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\ParagraphAccordion;
+use Drupal\bnf\Plugin\bnf_mapper\ParagraphAccordionMapper;
 use Drupal\paragraphs\Entity\Paragraph;
 
 /**
  * Tests the text_body paragraph mapper.
  */
-class ParagraphAccordionTest extends EntityMapperTestBase {
+class ParagraphAccordionMapperTest extends EntityMapperTestBase {
 
   const ENTITY_NAME = 'paragraph';
   const ENTITY_CLASS = Paragraph::class;
@@ -26,11 +26,11 @@ class ParagraphAccordionTest extends EntityMapperTestBase {
       'type' => 'accordion',
     ])->willReturn($this->entityProphecy);
 
-    $mapper = new ParagraphAccordion([], '', [], $this->entityManagerProphecy->reveal());
+    $mapper = new ParagraphAccordionMapper([], '', [], $this->entityManagerProphecy->reveal());
 
-    $graphqlArticle = GraphqlParagraphAccordion::make(
-      GraphqlTitleText::make('This is the title', 'format1'),
-      GraphqlDescriptionText::make('This is the description', 'format2'),
+    $graphqlArticle = ParagraphAccordion::make(
+      TitleText::make('This is the title', 'format1'),
+      DescriptionText::make('This is the description', 'format2'),
     );
 
     $paragraph = $mapper->map($graphqlArticle);

--- a/web/modules/custom/bnf/tests/src/Unit/Mapper/ParagraphTextBodyMapperTest.php
+++ b/web/modules/custom/bnf/tests/src/Unit/Mapper/ParagraphTextBodyMapperTest.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\bnf\Unit\Mapper;
 
-use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\Body\Text as GraphqlText;
-use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\ParagraphTextBody as GraphqlParagraphTextBody;
-use Drupal\bnf\Plugin\bnf_mapper\ParagraphTextBody;
+use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\Body\Text;
+use Drupal\bnf\GraphQL\Operations\GetNode\Node\Paragraphs\ParagraphTextBody;
+use Drupal\bnf\Plugin\bnf_mapper\ParagraphTextBodyMapper;
 use Drupal\paragraphs\Entity\Paragraph;
 
 /**
  * Tests the text_body paragraph mapper.
  */
-class ParagraphTextBodyTest extends EntityMapperTestBase {
+class ParagraphTextBodyMapperTest extends EntityMapperTestBase {
 
   const ENTITY_NAME = 'paragraph';
   const ENTITY_CLASS = Paragraph::class;
@@ -25,10 +25,10 @@ class ParagraphTextBodyTest extends EntityMapperTestBase {
       'type' => 'text_body',
     ])->willReturn($this->entityProphecy);
 
-    $mapper = new ParagraphTextBody([], '', [], $this->entityManagerProphecy->reveal());
+    $mapper = new ParagraphTextBodyMapper([], '', [], $this->entityManagerProphecy->reveal());
 
-    $graphqlArticle = GraphqlParagraphTextBody::make(
-      GraphqlText::make('This is the text', 'with_format')
+    $graphqlArticle = ParagraphTextBody::make(
+      Text::make('This is the text', 'with_format')
     );
 
     $paragraph = $mapper->map($graphqlArticle);

--- a/web/modules/custom/bnf/tests/src/Unit/Mapper/ParagraphTextBodyMapperTest.php
+++ b/web/modules/custom/bnf/tests/src/Unit/Mapper/ParagraphTextBodyMapperTest.php
@@ -14,8 +14,19 @@ use Drupal\paragraphs\Entity\Paragraph;
  */
 class ParagraphTextBodyMapperTest extends EntityMapperTestBase {
 
-  const ENTITY_NAME = 'paragraph';
-  const ENTITY_CLASS = Paragraph::class;
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityName(): string {
+    return 'paragraph';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityClass(): string {
+    return Paragraph::class;
+  }
 
   /**
    * Test text paragraph mapping.


### PR DESCRIPTION
Rename mappers to `*Mapper`. Means we don't have to do as much `as`ing, and that it's more obvious at a glance what the classes does.

Also use abstract getters for entity type/class in `EntityMapperTestBase` and make it abstract, so we don't have to check and thrown an exception ourselves.