### PR TITLE
DDFBRA-441 - Added patch for fixing StateLog logging.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -378,7 +378,8 @@
                 "3487412: Fix WSOD when EventInstance has invalid translation.": "https://git.drupalcode.org/project/recurring_events/-/commit/996052eeb7518ce591df968a0bb12c4819fb4edf.patch"
             },
             "drupal/state_log": {
-                "3501178: Call to undefined method Drupal\\state_log\\StateLog::destruct()": "https://git.drupalcode.org/project/state_log/-/commit/8d63dd4827a930f5294004a1d13f051487ec4269.patch"
+                "3501178: Call to undefined method Drupal\\state_log\\StateLog::destruct()": "https://git.drupalcode.org/project/state_log/-/commit/8d63dd4827a930f5294004a1d13f051487ec4269.patch",
+                "3505648: var_export does not handle circular references": "https://git.drupalcode.org/project/state_log/-/commit/10afc5f782869420d345bb38979250e69b55872d.patch"
             },
             "drupal/theme_permission": {
                 "3105637: Edit, install and uninstall permission": "https://www.drupal.org/files/issues/2024-02-01/theme-permission-edit-install-uninstall-3105637-7.patch"


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-441

#### Description

This PR adds a patch the "stage_log" that fixes the saving of footer configuration. 
The reason it was failing hard when saving footer configuration, was because of the StateLog modules use of "var_export". The "var_export" is being unable to handle circular references, which can occur when passing class's. In this case we are passing the "TranslatableMarkup" class.

The patch introduces the use of Symfonys "VarDumper" instead of using "var_export".

Link to Drupal module issue: https://www.drupal.org/project/state_log/issues/3505648