### PR TITLE
DDFBRA-374 - Preserve scroll position after clicking “Show More” on `Articles

### DIFF
--- a/config/sync/views.view.articles.yml
+++ b/config/sync/views.view.articles.yml
@@ -345,6 +345,7 @@ display:
           preserve_facet_query_args: false
           query_tags: {  }
       relationships: {  }
+      use_ajax: true
       header: {  }
       footer: {  }
       display_extenders: {  }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-374

#### Description
This pull request restores functionality that was previously enabled in [PR #1678](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1678) but later removed for unknown reasons.

Reintroducing use_ajax ensures that the scroll position is preserved when clicking the “Show More” button on the article page.