### PR TITLE
bnf: Search for editors, on BNF server

### DIFF
--- a/.github/workflows/lagoon.yml
+++ b/.github/workflows/lagoon.yml
@@ -48,7 +48,7 @@ jobs:
   CreateDeploymentBNF:
     name: Create BNF deployment
     runs-on: ubuntu-latest
-    if: ${{ startsWith('bnf:', github.event.pull_request.title) && github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' }}
+    if: ${{ (startsWith(github.event.pull_request.title, 'bnf:')) && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize') }}
     needs: [BranchNameLength]
     steps:
       - run: |

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -53,6 +53,11 @@ tasks:
             if [[ "$LAGOON_PROJECT" == "dpl-bnf" ]]; then
               # Enable the server module on environments in the BNF project.
               drush pm:enable -y bnf_server
+              drush config:set --yes system.site name "BNF test"
+              drush config:set --yes novel.settings logo_title "BNF"
+              drush config:set --yes novel.settings logo_place "test"
+              drush config:set --yes novel.settings logo_img_enable "0"
+
             elif [[ ${LAGOON_PR_TITLE,,} =~ ^bnf: ]]; then
               # Or configure the client if there's a BNF environment.
               drush --yes pm:enable bnf_client

--- a/config/sync/config_ignore_auto.settings.yml
+++ b/config/sync/config_ignore_auto.settings.yml
@@ -10,6 +10,7 @@ whitelist_config_entities:
   - user.role.external_system
   - user.role.mediator
   - user.role.patron
+  - bnf_client.settings.yml
 direction_operations:
   - import_create
   - import_update

--- a/config/sync/novel.settings.yml
+++ b/config/sync/novel.settings.yml
@@ -4,7 +4,10 @@ features:
   comment_user_verification: true
   favicon: 1
 logo:
-  use_default: 1
+  use_default: 0
+  logo: "public://2024-07/logoeksempelbib.png"
+logo_title: "Eksempel Biblioteket"
+logo_place: "Eksempelvej Bib"
 favicon:
   use_default: 1
   mimetype: image/vnd.microsoft.icon

--- a/config/sync/novel.settings.yml
+++ b/config/sync/novel.settings.yml
@@ -5,9 +5,9 @@ features:
   favicon: 1
 logo:
   use_default: 0
-  logo: "public://2024-07/logoeksempelbib.png"
-logo_title: "Eksempel Biblioteket"
-logo_place: "Eksempelvej Bib"
+  logo: 'public://2024-07/logoeksempelbib.png'
+logo_title: 'Eksempel Biblioteket'
+logo_place: 'Eksempelvej Bib'
 favicon:
   use_default: 1
   mimetype: image/vnd.microsoft.icon

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -31,3 +31,4 @@ permissions:
   - 'view eventinstance entity'
   - 'view eventseries entity'
   - 'view media'
+  - 'view the administration theme'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -30,3 +30,4 @@ permissions:
   - 'view eventinstance entity'
   - 'view eventseries entity'
   - 'view media'
+  - 'view the administration theme'

--- a/config/sync/views.view.importable_content.yml
+++ b/config/sync/views.view.importable_content.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_canonical_url
+    - field.storage.node.field_categories
     - field.storage.node.field_subtitle
     - field.storage.node.field_teaser_image
     - image.style.small_preview
     - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.tags
   module:
+    - better_exposed_filters
     - dpl_admin
     - link
     - media
@@ -269,7 +271,7 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: 'Bibliotekernes Nationale Redaktion'
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -346,6 +348,69 @@ display:
           type: entity_reference_label
           settings:
             link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_categories:
+          id: field_categories
+          table: node__field_categories
+          field: field_categories
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Edited by BNR'
+          exclude: false
+          alter:
+            alter_text: true
+            text: 'Edited by BNR'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: Unedited
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -647,15 +712,96 @@ display:
             offset_label: Offset
           quantity: 9
       exposed_form:
-        type: basic
+        type: bef
         options:
           submit_button: Apply
-          reset_button: false
+          reset_button: true
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: basic
+          bef:
+            general:
+              autosubmit: false
+              autosubmit_exclude_textfield: false
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: false
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+              reset_button_always_show: false
+            filter:
+              combine:
+                plugin_id: default
+                advanced:
+                  placeholder_text: ''
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: false
+              type_1:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: 0
+              field_categories_target_id:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: 0
+              field_categories_target_id_1:
+                plugin_id: default
+                advanced:
+                  placeholder_text: test
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: 0
+              field_tags_target_id:
+                plugin_id: default
+                advanced:
+                  placeholder_text: ''
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: 0
       access:
         type: bnf_server_access
         options: {  }
@@ -877,6 +1023,69 @@ display:
           hierarchy: true
           limit: true
           error_message: true
+        field_categories_target_id_1:
+          id: field_categories_target_id_1
+          table: node__field_categories
+          field: field_categories_target_id
+          relationship: none
+          group_type: group
+          admin_label: 'Approved by BNR'
+          plugin_id: taxonomy_index_tid
+          operator: 'not empty'
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_categories_target_id_1_op
+            label: 'Approved by BNR'
+            description: 'Shows content that has been tagged with a category, by BNR'
+            use_operator: false
+            operator: field_categories_target_id_1_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: approved
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+              bnf_graphql_client: '0'
+              go_graphql_client: '0'
+              go_editor: '0'
+            reduce: false
+          is_grouped: true
+          group_info:
+            label: 'Edited by BNR'
+            description: ''
+            identifier: approved
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: '1'
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Categorized
+                operator: 'not empty'
+                value: null
+              2:
+                title: Uncategorized
+                operator: empty
+                value: null
+          reduce_duplicates: false
+          vid: categories
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
         field_tags_target_id:
           id: field_tags_target_id
           table: node__field_tags
@@ -956,6 +1165,7 @@ display:
             field_teaser_image: field_teaser_image
             field_subtitle: field_subtitle
             title: title
+            field_canonical_url: field_canonical_url
             type: type
             changed: changed
             changed_1: changed_1
@@ -984,6 +1194,11 @@ display:
               separator: ''
               empty_column: true
               responsive: ''
+            field_canonical_url:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
             type:
               sortable: true
               default_sort_order: asc
@@ -993,14 +1208,14 @@ display:
               responsive: ''
             changed:
               sortable: true
-              default_sort_order: asc
+              default_sort_order: desc
               align: ''
               separator: ''
               empty_column: true
               responsive: ''
             changed_1:
               sortable: true
-              default_sort_order: asc
+              default_sort_order: desc
               align: ''
               separator: ''
               empty_column: true
@@ -1045,6 +1260,7 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_canonical_url'
+        - 'config:field.storage.node.field_categories'
         - 'config:field.storage.node.field_subtitle'
         - 'config:field.storage.node.field_teaser_image'
   page:
@@ -1066,5 +1282,6 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_canonical_url'
+        - 'config:field.storage.node.field_categories'
         - 'config:field.storage.node.field_subtitle'
         - 'config:field.storage.node.field_teaser_image'

--- a/config/sync/views.view.importable_content.yml
+++ b/config/sync/views.view.importable_content.yml
@@ -1,0 +1,1073 @@
+uuid: fc7958fb-73f0-4fc1-b1c9-6b0ca077893d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_canonical_url
+    - field.storage.node.field_subtitle
+    - field.storage.node.field_teaser_image
+    - image.style.small_preview
+    - taxonomy.vocabulary.categories
+    - taxonomy.vocabulary.tags
+  module:
+    - link
+    - media
+    - node
+    - taxonomy
+    - user
+id: importable_content
+label: 'Importable content'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Importable content'
+      fields:
+        field_teaser_image:
+          id: field_teaser_image
+          table: node__field_teaser_image
+          field: field_teaser_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: media_thumbnail
+          settings:
+            image_link: ''
+            image_style: small_preview
+            image_loading:
+              attribute: lazy
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_subtitle:
+          id: field_subtitle
+          table: node__field_subtitle
+          field: field_subtitle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '{{ field_subtitle__value }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: true
+            text: "<strong>{{ title }}</strong><br>\r\n<small>{{ field_subtitle }}</small>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_canonical_url:
+          id: field_canonical_url
+          table: node__field_canonical_url
+          field: field_canonical_url
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Source
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: null
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+          label: 'Content type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: true
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 1
+              refresh: 0
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        changed_1:
+          id: changed_1
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{{ changed_1 }}<br>\r\n<small>({{ changed }})</small>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: html_date
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: html_date
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        uuid:
+          id: uuid
+          table: node
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: uuid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '{{ uuid__value }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: Import
+          exclude: false
+          alter:
+            alter_text: true
+            text: "<a href=\"{{ url('bnf_server.import_redirect', {'uuid': uuid}) }}\" class=\"button\">\r\n{{ 'Import to my site'|trans({}, {\"context\": \"BNF\"})}}\r\n</a>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content overview'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: node_type
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
+      filters:
+        combine:
+          id: combine
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: combine
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: combine_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+              bnf_graphql_client: '0'
+              go_graphql_client: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          fields:
+            field_subtitle: field_subtitle
+            title: title
+        type_1:
+          id: type_1
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_1_op
+            label: 'Content type'
+            description: ''
+            use_operator: false
+            operator: type_1_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type_1
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+              bnf_graphql_client: '0'
+              go_graphql_client: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_categories_target_id:
+          id: field_categories_target_id
+          table: node__field_categories
+          field: field_categories_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_categories_target_id_op
+            label: Categories
+            description: ''
+            use_operator: false
+            operator: field_categories_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: categories
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+              bnf_graphql_client: '0'
+              go_graphql_client: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: categories
+          type: select
+          hierarchy: true
+          limit: true
+          error_message: true
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: tags
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              local_administrator: '0'
+              editor: '0'
+              mediator: '0'
+              patron: '0'
+              external_system: '0'
+              bnf_graphql_client: '0'
+              go_graphql_client: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: tags
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            field_teaser_image: field_teaser_image
+            field_subtitle: field_subtitle
+            title: title
+            type: type
+            changed: changed
+            changed_1: changed_1
+            uuid: uuid
+            nothing: nothing
+          default: changed_1
+          info:
+            field_teaser_image:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: true
+              responsive: ''
+            field_subtitle:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: true
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: true
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: true
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: true
+              responsive: ''
+            changed_1:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: true
+              responsive: priority-medium
+            uuid:
+              align: ''
+              separator: ''
+              empty_column: true
+              responsive: ''
+            nothing:
+              align: ''
+              separator: ''
+              empty_column: true
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_canonical_url'
+        - 'config:field.storage.node.field_subtitle'
+        - 'config:field.storage.node.field_teaser_image'
+  page:
+    id: page
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: content
+      use_admin_theme: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_canonical_url'
+        - 'config:field.storage.node.field_subtitle'
+        - 'config:field.storage.node.field_teaser_image'

--- a/config/sync/views.view.importable_content.yml
+++ b/config/sync/views.view.importable_content.yml
@@ -10,11 +10,11 @@ dependencies:
     - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.tags
   module:
+    - dpl_admin
     - link
     - media
     - node
     - taxonomy
-    - user
 id: importable_content
 label: 'Importable content'
 module: views
@@ -657,9 +657,8 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
-        options:
-          perm: 'access content overview'
+        type: bnf_server_access
+        options: {  }
       cache:
         type: tag
         options: {  }
@@ -1044,7 +1043,6 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.permissions
       tags:
         - 'config:field.storage.node.field_canonical_url'
         - 'config:field.storage.node.field_subtitle'
@@ -1066,7 +1064,6 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.permissions
       tags:
         - 'config:field.storage.node.field_canonical_url'
         - 'config:field.storage.node.field_subtitle'

--- a/web/modules/custom/bnf/bnf_client/bnf_client.info.yml
+++ b/web/modules/custom/bnf/bnf_client/bnf_client.info.yml
@@ -3,5 +3,6 @@ type: module
 description: 'BNF (Bibliotekernes Nationale Formidling) client, for sharing content with BNF'
 package: 'DPL - BNF'
 core_version_requirement: ^10
+configure: bnf_client.settings
 dependencies:
   - bnf:bnf

--- a/web/modules/custom/bnf/bnf_client/bnf_client.links.menu.yml
+++ b/web/modules/custom/bnf/bnf_client/bnf_client.links.menu.yml
@@ -10,6 +10,9 @@ bnf_client.login:
   parent: system.admin_content
   route_name: bnf_client.server_redirect
   weight: 11
+  options:
+    attributes:
+      target: '_blank'
 
 bnf_client.settings_form:
   title: 'BNF configuration'

--- a/web/modules/custom/bnf/bnf_client/bnf_client.module
+++ b/web/modules/custom/bnf/bnf_client/bnf_client.module
@@ -1,19 +1,35 @@
 <?php
 
 use Drupal\bnf\Exception\AlreadyExistsException;
+use Drupal\bnf\Services\BnfImporter;
 use Drupal\bnf_client\Services\BnfExporter;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\drupal_typed\DrupalTyped;
+use Drupal\node\NodeForm;
+use Drupal\node\NodeInterface;
 
 /**
- * Implements hook_form_FORM_ID_alter().
+ * Implements hook_form_alter().
  *
- * Altering the article form, and adding an option to export the node to BNF.
+ * Altering the node form, and adding an option to export the node to BNF.
  * If checked, a custom form submit handler will take care of the rest.
  *
  * @see bnf_client_form_node_form_submit()
  */
-function bnf_client_form_node_article_edit_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+function bnf_client_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  $form_object = $form_state->getFormObject();
+
+  if (!($form_object instanceof NodeForm)) {
+    return;
+  }
+
+  $node = $form_object->getEntity();
+  $allowed_cts = BnfImporter::ALLOWED_CONTENT_TYPES;
+
+  if ((!$node instanceof NodeInterface) || !in_array($node->bundle(), $allowed_cts)) {
+    return;
+  }
+
   $current_user = \Drupal::currentUser();
 
   if (!$current_user->hasPermission('bnf client export nodes')) {

--- a/web/modules/custom/bnf/bnf_client/src/Form/BnfImportConfirmForm.php
+++ b/web/modules/custom/bnf/bnf_client/src/Form/BnfImportConfirmForm.php
@@ -87,6 +87,7 @@ class BnfImportConfirmForm implements FormInterface, ContainerInjectionInterface
     catch (\Exception $e) {
       $importable = FALSE;
 
+      $this->logger->error('Could not import node from BNF. @message', ['@message' => $e->getMessage()]);
       $this->messenger->addError($this->t('Cannot import this node from BNF.', [], ['context' => 'BNF']));
     }
 

--- a/web/modules/custom/bnf/bnf_server/bnf_server.module
+++ b/web/modules/custom/bnf/bnf_server/bnf_server.module
@@ -1,7 +1,23 @@
 <?php
 
+use Drupal\bnf\Services\BnfImporter;
 use Drupal\bnf_server\Controller\LoginController;
+use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
+use Drupal\views\ViewExecutable;
+
+/**
+ * Implements hook_views_pre_build().
+ *
+ * Setting the allowed importable content types as contextual filter.
+ */
+function bnf_server_views_pre_build(ViewExecutable $view): void {
+  if ($view->id() === 'importable_content') {
+    $allowed_cts = BnfImporter::ALLOWED_CONTENT_TYPES;
+
+    $view->setArguments([implode('+', $allowed_cts)]);
+  }
+}
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -14,7 +30,7 @@ function bnf_server_preprocess_page(array &$variables): void {
   $cookies = \Drupal::request()->cookies;
   $url = $cookies->get(LoginController::COOKIE_CALLBACK_URL);
   $name = $cookies->get(LoginController::COOKIE_SITE_NAME);
-  $allowed_cts = ['article'];
+  $allowed_cts = BnfImporter::ALLOWED_CONTENT_TYPES;
 
   if (!$url || !($node instanceof Node) || !in_array($node->bundle(), $allowed_cts)) {
     return;
@@ -24,7 +40,7 @@ function bnf_server_preprocess_page(array &$variables): void {
     '#theme' => 'bnf_server_import_link',
     '#label' => $node->label(),
     '#name' => $name ?? t('my site', [], ['context' => 'BNF']),
-    '#url' => "$url/admin/bnf/import/{$node->uuid()}",
+    '#url' => Url::fromRoute('bnf_server.import_redirect', ['uuid' => $node->uuid()]),
     '#cache' => ['max-age' => 0],
   ];
 }

--- a/web/modules/custom/bnf/bnf_server/bnf_server.module
+++ b/web/modules/custom/bnf/bnf_server/bnf_server.module
@@ -57,5 +57,10 @@ function bnf_server_theme(): array {
         'label' => NULL,
       ],
     ],
+    'bnf_server_missing_callback' => [
+      'variables' => [
+        'uuid' => NULL,
+      ],
+    ],
   ];
 }

--- a/web/modules/custom/bnf/bnf_server/bnf_server.module
+++ b/web/modules/custom/bnf/bnf_server/bnf_server.module
@@ -27,9 +27,10 @@ function bnf_server_views_pre_build(ViewExecutable $view): void {
  */
 function bnf_server_preprocess_page(array &$variables): void {
   $node = $variables['node'] ?? NULL;
-  $cookies = \Drupal::request()->cookies;
-  $url = $cookies->get(LoginController::COOKIE_CALLBACK_URL);
-  $name = $cookies->get(LoginController::COOKIE_SITE_NAME);
+  $session = \Drupal::request()->getSession();
+
+  $url = $session->get(LoginController::CALLBACK_URL_KEY);
+  $name = $session->get(LoginController::SITE_NAME_KEY);
   $allowed_cts = BnfImporter::ALLOWED_CONTENT_TYPES;
 
   if (!$url || !($node instanceof Node) || !in_array($node->bundle(), $allowed_cts)) {

--- a/web/modules/custom/bnf/bnf_server/bnf_server.module
+++ b/web/modules/custom/bnf/bnf_server/bnf_server.module
@@ -33,17 +33,28 @@ function bnf_server_preprocess_page(array &$variables): void {
   $name = $session->get(LoginController::SITE_NAME_KEY);
   $allowed_cts = BnfImporter::ALLOWED_CONTENT_TYPES;
 
-  if (!$url || !($node instanceof Node) || !in_array($node->bundle(), $allowed_cts)) {
+  if (!$url || !($node instanceof Node)) {
     return;
   }
 
-  $variables['page']['content']['import_link'] = [
-    '#theme' => 'bnf_server_import_link',
-    '#label' => $node->label(),
-    '#name' => $name ?? t('my site', [], ['context' => 'BNF']),
-    '#url' => Url::fromRoute('bnf_server.import_redirect', ['uuid' => $node->uuid()]),
-    '#cache' => ['max-age' => 0],
-  ];
+  if ($name) {
+    $variables['page']['content']['logged_notifier'] = [
+      '#theme' => 'bnf_server_logged_notifier',
+      '#name' => $name,
+      '#url' => Url::fromRoute('view.importable_content.page'),
+      '#cache' => ['max-age' => 0],
+    ];
+  }
+
+  if (in_array($node->bundle(), $allowed_cts)) {
+    $variables['page']['content']['import_link'] = [
+      '#theme' => 'bnf_server_import_link',
+      '#label' => $node->label(),
+      '#name' => $name ?? t('my site', [], ['context' => 'BNF']),
+      '#url' => Url::fromRoute('bnf_server.import_redirect', ['uuid' => $node->uuid()]),
+      '#cache' => ['max-age' => 0],
+    ];
+  }
 }
 
 /**
@@ -61,6 +72,12 @@ function bnf_server_theme(): array {
     'bnf_server_missing_callback' => [
       'variables' => [
         'uuid' => NULL,
+      ],
+    ],
+    'bnf_server_logged_notifier' => [
+      'variables' => [
+        'url' => NULL,
+        'name' => NULL,
       ],
     ],
   ];

--- a/web/modules/custom/bnf/bnf_server/bnf_server.routing.yml
+++ b/web/modules/custom/bnf/bnf_server/bnf_server.routing.yml
@@ -7,3 +7,11 @@ bnf_server.cookie_login:
     _permission: 'access content'
   options:
     no_cache: true
+bnf_server.import_redirect:
+  path: '/bnf/export/{uuid}'
+  defaults:
+    _controller: '\Drupal\bnf_server\Controller\ServerRedirecter::import'
+  requirements:
+    _permission: 'access content'
+  options:
+    no_cache: true

--- a/web/modules/custom/bnf/bnf_server/src/Controller/LoginController.php
+++ b/web/modules/custom/bnf/bnf_server/src/Controller/LoginController.php
@@ -3,7 +3,6 @@
 namespace Drupal\bnf_server\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -16,8 +15,8 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  * a button for importing content.
  */
 class LoginController extends ControllerBase {
-  const COOKIE_CALLBACK_URL = 'bnf_server_login_callback_url';
-  const COOKIE_SITE_NAME = 'bnf_server_login_site_name';
+  const CALLBACK_URL_KEY = 'bnf_server_login_callback_url';
+  const SITE_NAME_KEY = 'bnf_server_login_site_name';
 
   /**
    * Receiving the login.
@@ -31,12 +30,11 @@ class LoginController extends ControllerBase {
       throw new BadRequestHttpException('Callback URL cannot be empty.');
     }
 
-    $response = new RedirectResponse('/');
+    $session = $request->getSession();
+    $session->set(self::CALLBACK_URL_KEY, $url);
+    $session->set(self::SITE_NAME_KEY, $name);
 
-    $response->headers->setCookie(new Cookie(self::COOKIE_CALLBACK_URL, $url));
-    $response->headers->setCookie(new Cookie(self::COOKIE_SITE_NAME, $name));
-
-    return $response;
+    return new RedirectResponse('/');
   }
 
 }

--- a/web/modules/custom/bnf/bnf_server/src/Controller/ServerRedirecter.php
+++ b/web/modules/custom/bnf/bnf_server/src/Controller/ServerRedirecter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\bnf_server\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Redirects from the server to client side.
+ */
+class ServerRedirecter extends ControllerBase {
+
+  /**
+   * Redirecting to the import URL of the client site.
+   */
+  public function import(string $uuid, Request $request): TrustedRedirectResponse {
+    $cookies = $request->cookies;
+    $url = $cookies->get(LoginController::COOKIE_CALLBACK_URL);
+
+    return new TrustedRedirectResponse("$url/admin/bnf/import/{$uuid}");
+  }
+
+}

--- a/web/modules/custom/bnf/bnf_server/src/Controller/ServerRedirecter.php
+++ b/web/modules/custom/bnf/bnf_server/src/Controller/ServerRedirecter.php
@@ -13,10 +13,22 @@ class ServerRedirecter extends ControllerBase {
 
   /**
    * Redirecting to the import URL of the client site.
+   *
+   * @return \Drupal\Core\Routing\TrustedRedirectResponse|array<mixed>
+   *   A redirect, or a notice page.
    */
-  public function import(string $uuid, Request $request): TrustedRedirectResponse {
+  public function import(string $uuid, Request $request): TrustedRedirectResponse|array {
     $cookies = $request->cookies;
     $url = $cookies->get(LoginController::COOKIE_CALLBACK_URL);
+
+    // If we have no URL to redirect to, we'll display a notice template,
+    // with info to the user of how they can manually import the content.
+    if (empty($url)) {
+      return [
+        '#theme' => 'bnf_server_missing_callback',
+        '#uuid' => $uuid,
+      ];
+    }
 
     return new TrustedRedirectResponse("$url/admin/bnf/import/{$uuid}");
   }

--- a/web/modules/custom/bnf/bnf_server/src/Controller/ServerRedirecter.php
+++ b/web/modules/custom/bnf/bnf_server/src/Controller/ServerRedirecter.php
@@ -18,8 +18,8 @@ class ServerRedirecter extends ControllerBase {
    *   A redirect, or a notice page.
    */
   public function import(string $uuid, Request $request): TrustedRedirectResponse|array {
-    $cookies = $request->cookies;
-    $url = $cookies->get(LoginController::COOKIE_CALLBACK_URL);
+    $session = $request->getSession();
+    $url = $session->get(LoginController::CALLBACK_URL_KEY);
 
     // If we have no URL to redirect to, we'll display a notice template,
     // with info to the user of how they can manually import the content.

--- a/web/modules/custom/bnf/bnf_server/templates/bnf-server-logged-notifier.html.twig
+++ b/web/modules/custom/bnf/bnf_server/templates/bnf-server-logged-notifier.html.twig
@@ -1,0 +1,15 @@
+{# Super simple styling, placing the button fixed on the screen. #}
+<style>
+  .bnf-import-logged-in {
+    position: fixed;
+    left: 1em;
+    bottom: 1em;
+    z-index: 999;
+  }
+</style>
+
+<div class="bnf-import-logged-in">
+  <a class="btn-primary btn-filled btn-xsmall" href="{{ url }}">
+      {{ 'Find content for @name'|trans({'@name': name}, {"context": "BNF"}) }}
+  </a>
+</div>

--- a/web/modules/custom/bnf/bnf_server/templates/bnf-server-missing-callback.html.twig
+++ b/web/modules/custom/bnf/bnf_server/templates/bnf-server-missing-callback.html.twig
@@ -1,0 +1,17 @@
+<div class="rich-text mt-24">
+  <h1>{{ 'BNF cannot send you to your library'|trans({}, {"context": "BNF"}) }}</h1>
+  <p>
+    {{ 'It would appear that you have not logged in to BNF through your origin library.'|trans({}, {"context": "BNF"}) }}
+  </p>
+  <p>
+    {{ 'To import this content, you can either:'|trans({}, {"context": "BNF"}) }}
+  </p>
+  <ul>
+    <li>{{ 'Go back to your library site, and choose "log in to BNF", and try again'|trans({}, {"context": "BNF"}) }}</li>
+    <li>{{ 'Or:'|trans({}, {"context": "BNF"}) }}</li>
+    <li>
+      {{ 'Go back to your library site, and press import at:'|trans({}, {"context": "BNF"}) }}
+      <br><strong><em>/admin/bnf/import/{{ uuid }}</em></strong>
+    </li>
+  </ul>
+</div>

--- a/web/modules/custom/bnf/src/Services/BnfImporter.php
+++ b/web/modules/custom/bnf/src/Services/BnfImporter.php
@@ -23,6 +23,10 @@ use Spawnia\Sailor\Configuration;
  */
 class BnfImporter {
 
+  const ALLOWED_CONTENT_TYPES = [
+    'article',
+  ];
+
   /**
    * Constructor.
    */
@@ -53,6 +57,10 @@ class BnfImporter {
    * Importing a node from a GraphQL source endpoint.
    */
   public function importNode(string $uuid, string $endpointUrl, string $nodeType = 'article'): NodeInterface {
+    if (!in_array($nodeType, self::ALLOWED_CONTENT_TYPES)) {
+      throw new \InvalidArgumentException('The requested content type is not allowed.');
+    }
+
     $nodeStorage = $this->entityTypeManager->getStorage('node');
 
     $existingNodes =

--- a/web/modules/custom/dpl_admin/dpl_admin.services.yml
+++ b/web/modules/custom/dpl_admin/dpl_admin.services.yml
@@ -1,3 +1,11 @@
+---
 services:
   dpl_admin.version_helper:
     class: Drupal\dpl_admin\Services\VersionHelper
+  dpl_admin.bnf_server_access:
+    class: Drupal\dpl_admin\Plugin\views\access\BnfServerEnabledAccess
+    arguments:
+      $configuration: []
+      $plugin_id: 'dpl_admin.bnf_server_access'
+      $plugin_definition: []
+      $module_handler: '@module_handler'

--- a/web/modules/custom/dpl_admin/src/Plugin/views/access/BnfServerEnabledAccess.php
+++ b/web/modules/custom/dpl_admin/src/Plugin/views/access/BnfServerEnabledAccess.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\dpl_admin\Plugin\views\access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\views\Plugin\views\access\AccessPluginBase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * A custom access handler, that returns Allowed if bnf_server is enabled.
+ *
+ * This is necessary as we have views and content that should only be available
+ * on the BNF server.
+ *
+ * @ingroup views_access_plugins
+ *
+ * @ViewsAccess(
+ *   id = "bnf_server_access",
+ *   title = @Translation("Allowed if bnf_server is enabled.")
+ * )
+ */
+class BnfServerEnabledAccess extends AccessPluginBase {
+
+  /**
+   * The module handler.
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $module_handler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('module_handler'),
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function access(AccountInterface $account): bool {
+    return $this->moduleHandler->moduleExists('bnf_server');
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function accessRoute(AccountInterface $account): AccessResult {
+    return AccessResult::allowedIf($this->access($account));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function alterRouteDefinition(Route $route): void {
+    $route->setRequirement('_custom_access', 'dpl_admin.bnf_server_access:accessRoute');
+  }
+
+}

--- a/web/modules/custom/dpl_example_content/dpl_example_content.module
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.module
@@ -69,17 +69,4 @@ function dpl_example_content_modules_installed(array $modules) : void {
   $new_front_page = '/frontpage';
   $config_site->set('page.front', '/frontpage')->save();
   $logger->info("Update frontpage link to {$new_front_page}, as part of example content installation.");
-
-  // Set example logo.
-  $config_novel = \Drupal::configFactory()->getEditable('novel.settings');
-  $logo_path = 'public://2024-07/logoeksempelbib.png';
-
-  $config_novel->set('logo_title', 'Eksempel Biblioteket')
-    ->set('logo_place', 'Eksempelvej Bib')
-    ->set('logo.use_default', FALSE)
-    ->set('logo.path', $logo_path)
-    ->save();
-
-  $logger->notice('Updated theme settings for novel theme.');
-
 }


### PR DESCRIPTION
- Fixing Github action, to actually trigger for BNF sites
- Add other logo info on BNF site, to better distinguish the client and server
- Setup a BNF server content view, that editors can use  https://varnish.pr-2070.dpl-bnf.dplplat01.dpl.reload.dk/content
- Update BNF server to use session data, instead of cookie, to avoid problems with anonymous users and varnish