### PR TITLE
Ignore additional state changes

### DIFF
--- a/config/sync/state_log.settings.yml
+++ b/config/sync/state_log.settings.yml
@@ -20,10 +20,14 @@ log_ignored_state:
   36: search_api.index.events.has_reindexed
   38: system.cron_key
   40: system.cron_last
-  42: system.private_key
-  44: system.profile.files
-  46: update.last_check
-  48: update.last_email_notification
-  50: views.view_route_names
-  52: webform.element.message
-  54: webform.version
+  42: system.javascript_parsed
+  44: system.module.files
+  46: system.private_key
+  48: system.profile.files
+  50: system.theme.files
+  52: twig_extension_hash_prefix
+  54: update.last_check
+  56: update.last_email_notification
+  58: views.view_route_names
+  60: webform.element.message
+  62: webform.version


### PR DESCRIPTION
#### Description

Practice has shown that more states are updated during deployments. This creates some noise in the process.

Ignore these state changes as they are not relevant for us.

The states added are:
- system.javascript_parsed
- system.module.files
- system.theme.files
- twig_extension_hash_prefix
