### PR TITLE
DDFBRA-487 - Make sure to set plugin_id

### DIFF
--- a/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
+++ b/web/modules/custom/dpl_login/src/UserTokenAuthProvider.php
@@ -78,8 +78,8 @@ class UserTokenAuthProvider implements AuthenticationProviderInterface {
       // Allow modules to alter the user info.
       // This allows this module to add a "sub" entry denoting the unique
       // end-user (subject) identifier. This is needed for us to load the
-      // associated Drupal user from the OpenID Connect authmap.
-      $context = [];
+      // associated Drupal user from the ExternalAuth authmap.
+      $context['plugin_id'] = $this->client->getPluginId();
       try {
         $this->moduleHandler->alter('openid_connect_userinfo', $user_info, $context);
       }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-487

#### Description

Made sure to add 'plugin_id' to the $context passed when calling `openid_connect_userinfo_alter` hooks.