### PR TITLE
Ignore all.services.yml in sites/default

### DIFF
--- a/web/sites/default/.gitignore
+++ b/web/sites/default/.gitignore
@@ -1,4 +1,5 @@
 /all.settings.php
+/all.services.yml
 /development.settings.php
 /default.development.services.yml
 /default.services.yml


### PR DESCRIPTION
#### Description

This file is copied from `/assets` during scaffolding and currently shows up as a new file in `/web/sites/default` when running `task dev:reset`.

As a scaffolded file it should not be committed here so we ignore it like we do for other scaffolded files.

#### Additional comments or questions

This has is byproduct of #2080.

To test this try to run `task dev:reset`. There should not be a file in `/web/sites/default/all.services.yml`afterwards.