### PR TITLE
DDFBRA-416 - Adjust the placement of the "Published" checkbox for events

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4663,17 +4663,17 @@
         },
         {
             "name": "drupal/gin",
-            "version": "3.0.0-rc16",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/gin.git",
-                "reference": "8.x-3.0-rc16"
+                "reference": "8.x-3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/gin-8.x-3.0-rc16.zip",
-                "reference": "8.x-3.0-rc16",
-                "shasum": "29fecc9fbcf40b77ffde6b2e5e4400ba938ab3ee"
+                "url": "https://ftp.drupal.org/files/projects/gin-8.x-3.0.zip",
+                "reference": "8.x-3.0",
+                "shasum": "bb1c660e85577d49db1deedfefe1ed3a91370aeb"
             },
             "require": {
                 "drupal/core": "^9 || ^10 || ^11",
@@ -4682,11 +4682,11 @@
             "type": "drupal-theme",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.0-rc16",
-                    "datestamp": "1734527306",
+                    "version": "8.x-3.0",
+                    "datestamp": "1734771812",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "RC releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -20674,6 +20674,6 @@
         "php": "8.1.*",
         "ext-dom": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -313,7 +313,7 @@ function dpl_event_entity_query_taxonomy_vocabulary_alter(QueryInterface $query)
 /**
  * Implements hook_form_alter().
  *
- * - Move the "Published" checkbox below "Create new revision" on edit forms.
+ * - Move the "Published" checkbox gin sticky action header.
  * - Hide screen names if the feature is disabled.
  */
 function dpl_event_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
@@ -328,9 +328,9 @@ function dpl_event_form_alter(array &$form, FormStateInterface $form_state, stri
     return;
   }
 
-  // Move the "Published" checkbox below "Create new revision".
-  if (isset($form['status']) && isset($form['revision_information'])) {
-    $form['status']['#group'] = 'revision_information';
+  // Move the "Published" checkbox to the gin sticky action header.
+  if (isset($form['status'])) {
+    $form['status']['#group'] = 'status';
   }
 
   if (!isset($form['field_screen_names'])) {

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -313,7 +313,8 @@ function dpl_event_entity_query_taxonomy_vocabulary_alter(QueryInterface $query)
 /**
  * Implements hook_form_alter().
  *
- * Alter event forms to hide screen names when the feature is disabled.
+ * - Move the "Published" checkbox below "Create new revision" on edit forms.
+ * - Hide screen names if the feature is disabled.
  */
 function dpl_event_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   $forms = [
@@ -322,8 +323,16 @@ function dpl_event_form_alter(array &$form, FormStateInterface $form_state, stri
     'eventinstance_default_edit_form',
     'eventinstance_default_add_form',
   ];
+
   if (!in_array($form_id, $forms)) {
     return;
+  }
+
+  // Move the "Published" checkbox below "Create new revision".
+  if (in_array($form_id, ['eventseries_default_edit_form', 'eventinstance_default_edit_form'])) {
+    if (isset($form['status']) && isset($form['revision_information'])) {
+      $form['status']['#group'] = 'revision_information';
+    }
   }
 
   if (!isset($form['field_screen_names'])) {

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -329,10 +329,8 @@ function dpl_event_form_alter(array &$form, FormStateInterface $form_state, stri
   }
 
   // Move the "Published" checkbox below "Create new revision".
-  if (in_array($form_id, ['eventseries_default_edit_form', 'eventinstance_default_edit_form'])) {
-    if (isset($form['status']) && isset($form['revision_information'])) {
-      $form['status']['#group'] = 'revision_information';
-    }
+  if (isset($form['status']) && isset($form['revision_information'])) {
+    $form['status']['#group'] = 'revision_information';
   }
 
   if (!isset($form['field_screen_names'])) {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-416

#### Description
Moved the "Published" checkbox inside the `revision_information` section.

This update ensures that the checkbox appears directly below "Create new revision" in the top-right "meta" area, aligning it with related settings.
<img width="1840" alt="Skærmbillede 2025-03-03 kl  14 37 23" src="https://github.com/user-attachments/assets/e0d1f952-6091-47bb-a543-9d3f08c612f4" />
<img width="1840" alt="Skærmbillede 2025-03-03 kl  14 37 19" src="https://github.com/user-attachments/assets/9151c80d-c3e5-490d-9675-afd5e1b1d14b" />
