### PR TITLE
DDFBRA-497 - Remove ByLine from Nav Spots

### DIFF
--- a/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
@@ -32,7 +32,7 @@ mode: nav_spot
 content:
   branch:
     type: entity_reference_label
-    label: visible
+    label: above
     settings:
       link: true
     third_party_settings: {  }
@@ -57,7 +57,7 @@ content:
     region: content
   event_screen_names:
     type: entity_reference_label
-    label: visible
+    label: above
     settings:
       link: true
     third_party_settings: {  }
@@ -67,7 +67,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: hero_wide
+      view_mode: nav_spot
       link: false
     third_party_settings: {  }
     weight: 1
@@ -82,7 +82,7 @@ content:
     region: content
   event_ticket_capacity:
     type: number_integer
-    label: visible
+    label: above
     settings:
       thousand_separator: ''
       prefix_suffix: true

--- a/config/sync/core.entity_view_display.eventseries.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.nav_spot.yml
@@ -33,7 +33,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: list_teaser
+      view_mode: nav_spot
       link: false
     third_party_settings: {  }
     weight: 2

--- a/config/sync/core.entity_view_display.media.image.nav_spot.yml
+++ b/config/sync/core.entity_view_display.media.image.nav_spot.yml
@@ -1,0 +1,36 @@
+uuid: 3784e48f-e99f-4231-9314-c1a5e54e7b71
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.nav_spot
+    - field.field.media.image.field_byline
+    - field.field.media.image.field_media_image
+    - image.style.nav_spot
+    - media.type.image
+  module:
+    - image
+id: media.image.nav_spot
+targetEntityType: media
+bundle: image
+mode: nav_spot
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: nav_spot
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_byline: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.node.article.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.article.nav_spot.yml
@@ -34,7 +34,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: hero_wide
+      view_mode: nav_spot
       link: false
     third_party_settings: {  }
     weight: 2

--- a/config/sync/core.entity_view_mode.media.nav_spot.yml
+++ b/config/sync/core.entity_view_mode.media.nav_spot.yml
@@ -1,0 +1,11 @@
+uuid: 3cd843bd-c566-4948-94fc-12d524d23b40
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.nav_spot
+label: 'Nav spot'
+description: ''
+targetEntityType: media
+cache: true

--- a/config/sync/image.style.nav_spot.yml
+++ b/config/sync/image.style.nav_spot.yml
@@ -1,0 +1,17 @@
+uuid: eaaf71b1-3cdf-4364-9156-b2321e621bc7
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: nav_spot
+label: 'Nav spot'
+effects:
+  e1fea627-ba4d-4d26-954f-3b0edfa6f911:
+    uuid: e1fea627-ba4d-4d26-954f-3b0edfa6f911
+    id: focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: 800
+      height: 600
+      crop_type: focal_point


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-497

#### Description
This commit adds the following:

1. A new image style called "Nav spot", basically a copy of "Hero wide".
2. A new view mode called "Nav spot" to the media image type.
3. Changes eventinstance, eventseries and articles to have the image field use the new "Nav spot" view mode.

#### Screenshot of the result

![Screenshot 2025-03-04 at 14 03 09](https://github.com/user-attachments/assets/60f62e26-760f-4b35-82d0-b3024cbf2f44)


