### PR TITLE
Re-added the logging of LibraryToken errors and fixing the LibraryTok…

### DIFF
--- a/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
+++ b/web/modules/custom/dpl_library_token/tests/src/Unit/LibraryTokenHandlerTest.php
@@ -135,7 +135,14 @@ class LibraryTokenHandlerTest extends UnitTestCase {
       ->willReturn($collection->reveal())
       ->shouldBeCalledTimes(1);
 
-    $this->expectExceptionMessage($message);
+    $logger = $this->prophesize(LoggerChannelInterface::class);
+    $logger->log(LogLevel::ERROR, Argument::any(), Argument::that(function(array $context) use ($message) {
+      return $context['@error_message'] == $message;
+    }))->shouldBeCalledTimes(1);
+    $logger_factory = $this->prophesize(LoggerChannelFactoryInterface::class);
+    $logger_factory->get(LibraryTokenHandler::LOGGER_KEY)->willReturn($logger->reveal());
+
+    //$this->expectExceptionMessage($message);
 
     $client = $this->prophesize(ClientInterface::class);
 
@@ -145,7 +152,7 @@ class LibraryTokenHandlerTest extends UnitTestCase {
     $handler = $this->createTokenHandler(
       $key_value_factory->reveal(),
       $client->reveal(),
-      NULL,
+      $logger->reveal(),
       $config->reveal()
     );
 


### PR DESCRIPTION
#### Description

Re-added the logging of LibraryToken errors and fixing the LibraryTokenHandler Unit test, that were removed as part of [updating the 'openid_connect' module](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2043) and making some changes to our custom code.


