### PR TITLE
Use production unilogin SSO

### DIFF
--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -135,8 +135,8 @@ if (getenv('LAGOON_ENVIRONMENT_TYPE') !== 'production') {
   $settings['skip_permissions_hardening'] = TRUE;
 
   // Set default Unilogin configuration on non-production environments.
-  $config['dpl_unilogin.settings']['unilogin_api_endpoint'] = 'https://et-broker.unilogin.dk';
-  $config['dpl_unilogin.settings']['unilogin_api_wellknown_endpoint'] = 'https://et-broker.unilogin.dk/auth/realms/broker/.well-known/openid-configuration';
+  $config['dpl_unilogin.settings']['unilogin_api_endpoint'] = 'https://broker.unilogin.dk';
+  $config['dpl_unilogin.settings']['unilogin_api_wellknown_endpoint'] = 'https://broker.unilogin.dk/auth/realms/broker/.well-known/openid-configuration';
 }
 
 // Setup Redis.


### PR DESCRIPTION
Since we can only test properly the connection with other services with real Unilogin users.
