### PR TITLE
Add support for overriding MariaDB database configuration

### DIFF
--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -45,9 +45,9 @@ if (getenv('MARIADB_DATABASE_OVERRIDE')) {
     'username' => getenv('MARIADB_USERNAME_OVERRIDE'),
     'password' => getenv('MARIADB_PASSWORD_OVERRIDE'),
     'host' => getenv('MARIADB_HOST_OVERRIDE'),
-    'port' => getenv('MARIADB_PORT_OVERRIDE'),
     // These settings intentionally have defaults. It is not likely that they
     // will be defined when overriding the database.
+    'port' => getenv('MARIADB_PORT_OVERRIDE') ?: 3306,
     'charset' => getenv('MARIADB_CHARSET_OVERRIDE') ?: 'utf8mb4',
     'collation' => getenv('MARIADB_COLLATION_OVERRIDE') ?: 'utf8mb4_general_ci',
     'prefix' => '',

--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -33,6 +33,27 @@ if (InstallerKernel::installationAttempted()) {
   $config['jsonlog.settings']['jsonlog_severity_threshold'] = 0;
 }
 
+// Support overriding the database configuration using non-standard Lagoon
+// environment variables.
+// This is explicitly added to support migration between databases.
+if (getenv('MARIADB_DATABASE_OVERRIDE')) {
+  $databases['default']['default'] = [
+    'driver' => 'mysql',
+    // These settings intentionally do not have defaults. If overriding the
+    // database configuration then all standard configuration must be defined.
+    'database' => getenv('MARIADB_DATABASE_OVERRIDE'),
+    'username' => getenv('MARIADB_USERNAME_OVERRIDE'),
+    'password' => getenv('MARIADB_PASSWORD_OVERRIDE'),
+    'host' => getenv('MARIADB_HOST_OVERRIDE'),
+    'port' => getenv('MARIADB_PORT_OVERRIDE'),
+    // These settings intentionally have defaults. It is not likely that they
+    // will be defined when overriding the database.
+    'charset' => getenv('MARIADB_CHARSET_OVERRIDE') ?: 'utf8mb4',
+    'collation' => getenv('MARIADB_COLLATION_OVERRIDE') ?: 'utf8mb4_general_ci',
+    'prefix' => '',
+  ];
+}
+
 // Exclude development modules from configuration export.
 $settings['config_exclude_modules'] = [
   'dpl_related_content_tests',


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFDRIFT-317

#### Description

Currently Drupal gets database connection information from environment variables set by Lagoon - or Docker Compose for local development.

When migrating to a new database setup we want to be able to override this configuration for select sites. Lagoon does not provide a simple way to achieve this. Consequently we have opted for an approach where we can override the database configuration per site by setting additional environment environment variables. If set these will override any value set by Lagoon by default for all sites.

The actual definition of these environment variables will also occur within Lagoon but set for individual projects as the migration process is underway.

We expect that this code can be removed once the migration is complete and Lagoon is updated to point to the new database setup. This should inject the correct values into projects by default.

#### Additional comments or questions

You can test this by updating `x-environment` in `docker-compose.yml`:

```yaml
x-environment:
  &default-environment
    # Lagoon ensures that Drush knows the local site URI using this variable.
    LAGOON_ROUTE: &default-url https://${COMPOSE_PROJECT_NAME}.${DEV_TLD:-docker}
    # Environment variables which mimic what will be set in a Lagoon cluster locally
    LAGOON_PROJECT: 'dplcms'
    LAGOON_ENVIRONMENT: 'local'
    LAGOON_ENVIRONMENT_TYPE: ${LAGOON_ENVIRONMENT_TYPE:-local}
    WEBROOT: web
    # Uncomment if you like to have the system behave like in production
    #LAGOON_ENVIRONMENT_TYPE: production
    MARIADB_DATABASE_OVERRIDE: 'mydb'
    MARIADB_USERNAME_OVERRIDE: 'myusername'
    MARIADB_PASSWORD_OVERRIDE: 'mypassword'
    MARIADB_HOST_OVERRIDE: 'myhost'
    MARIADB_PORT_OVERRIDE: 'myport'
```

Then start a CLI and run `drush sql:connect`. This should output `mysql --user=myusername --password=mypassword --database=mydb --host=myhost --port=myport -A`.