### PR TITLE
Add Drupal as a dependency for Mapp script

### DIFF
--- a/web/modules/custom/dpl_mapp/dpl_mapp.libraries.yml
+++ b/web/modules/custom/dpl_mapp/dpl_mapp.libraries.yml
@@ -10,4 +10,5 @@ dpl_mapp:
     js/dpl_mapp.js: {}
   dependencies:
     - dpl_mapp/mapp_tag_integration
+    - core/drupal
     - core/once


### PR DESCRIPTION
#### Description

[Our Mapp integration script uses `Drupal.behaviors`](https://github.com/danskernesdigitalebibliotek/dpl-cms/blob/4b949fd7c1706961aa8782408f6bab6ae6f1a5a1/web/modules/custom/dpl_mapp/js/dpl_mapp.js#L17-L17). If this is not defined then errors will be thrown. For whatever reason this has not occurred previously but it does now.

Deactivating JS aggregation fixes this but it is not a long term solution at the moment.

To address this we add the `core/drupal` library as a dependency.

#### Screenshot of the result

Before:

![Monosnap | DPL CMS — Privat browsing 2025-03-25 22-16-38](https://github.com/user-attachments/assets/72efc925-0090-4826-b819-929bd766c863)
