### PR TITLE
Extend library token with expire information

### DIFF
--- a/web/modules/custom/dpl_library_agency/src/Branch/FbsBranchRepository.php
+++ b/web/modules/custom/dpl_library_agency/src/Branch/FbsBranchRepository.php
@@ -33,11 +33,7 @@ class FbsBranchRepository implements BranchRepositoryInterface {
   public function getBranches(): array {
     // Use an empty token if we don't have one. This may cause the API to throw
     // an exception, but that is acceptable.
-    if (!$token = $this->tokenHandler->getToken()) {
-      return [];
-    }
-
-    $api = $this->apiFactory->getAgencyApi($token->token ?? '');
+    $api = $this->apiFactory->getAgencyApi($this->tokenHandler->getToken()?->token ?? '');
     return array_map(function (AgencyBranch $branch) {
       return new Branch($branch->getBranchId(), $branch->getTitle());
     }, $api->getBranches());

--- a/web/modules/custom/dpl_library_agency/src/Branch/FbsBranchRepository.php
+++ b/web/modules/custom/dpl_library_agency/src/Branch/FbsBranchRepository.php
@@ -33,7 +33,11 @@ class FbsBranchRepository implements BranchRepositoryInterface {
   public function getBranches(): array {
     // Use an empty token if we don't have one. This may cause the API to throw
     // an exception, but that is acceptable.
-    $api = $this->apiFactory->getAgencyApi($this->tokenHandler->getToken() ?? '');
+    if (!$token = $this->tokenHandler->getToken()) {
+      return [];
+    }
+
+    $api = $this->apiFactory->getAgencyApi($token->token ?? '');
     return array_map(function (AgencyBranch $branch) {
       return new Branch($branch->getBranchId(), $branch->getTitle());
     }, $api->getBranches());

--- a/web/modules/custom/dpl_library_token/graphql/dpl_library_token.base.graphqls
+++ b/web/modules/custom/dpl_library_token/graphql/dpl_library_token.base.graphqls
@@ -1,3 +1,5 @@
+
 type AdgangsplatformenLibraryToken {
   token: String
+  expire: DateTime
 }

--- a/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
@@ -92,15 +92,18 @@ class LibraryTokenHandler {
     $this->tokenCollection
       ->setWithExpire(
         self::LIBRARY_TOKEN_KEY,
-        $token->token,
+        (object) ['token' => $token->token, 'expire' => $token->expire],
         (int) round($token->expire / 2)
       );
   }
 
   /**
    * Get stored library token.
+   *
+   * @return object{'token': string, "expire": int}|null
+   *   The stored token or NULL if no token is stored.
    */
-  public function getToken(): ?string {
+  public function getToken(): ?object {
     return $this->tokenCollection->get(self::LIBRARY_TOKEN_KEY);
   }
 

--- a/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLibraryTokenProducer.php
+++ b/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLibraryTokenProducer.php
@@ -6,6 +6,7 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dpl_library_token\LibraryTokenHandler;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Safe\DateTime;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -53,11 +54,21 @@ class AdgangsplatformenLibraryTokenProducer extends DataProducerPluginBase imple
   }
 
   /**
+   * Adds expire seconds to current time (now()).
    *
+   * And transforms the result into a Drupal graphql Datetime array.
+   *
+   * @param int $expire
+   *   The expire date in seconds.
+   *
+   * @return mixed[]
+   *   The formatted date array.
    */
-  protected function formatExpireDate(int $expire) {
-    $expireInterval = \DateInterval::createFromDateString(sprintf('%d seconds', $expire));
-    $expireDateTime = (new \DateTime("now"))->add($expireInterval);
+  protected function formatExpireDate(int $expire): array {
+    if (!$expireInterval = \DateInterval::createFromDateString(sprintf('%d seconds', $expire))) {
+      throw new \InvalidArgumentException('Invalid expire date.');
+    }
+    $expireDateTime = (new DateTime("now"))->add($expireInterval);
     $dateTime = DrupalDateTime::createFromDateTime($expireDateTime);
 
     return [
@@ -79,7 +90,6 @@ class AdgangsplatformenLibraryTokenProducer extends DataProducerPluginBase imple
       'token' => $token->token,
       'expire' => $this->formatExpireDate($token->expire),
     ] : NULL;
-
   }
 
 }

--- a/web/modules/custom/dpl_login/src/Plugin/GraphQL/SchemaExtension/DplTokensExtension.php
+++ b/web/modules/custom/dpl_login/src/Plugin/GraphQL/SchemaExtension/DplTokensExtension.php
@@ -26,7 +26,7 @@ class DplTokensExtension extends SdlSchemaExtensionPluginBase {
     $registry->addFieldResolver('Query', 'dplTokens', $builder->callback(fn () => TRUE));
     $registry->addFieldResolver('DplTokens', 'adgangsplatformen', $builder->callback(fn () => TRUE));
     $registry->addFieldResolver('AdgangsplatformenTokens', 'user',
-    $builder->produce('adgangsplatformen_user_token_producer')
+      $builder->produce('adgangsplatformen_user_token_producer')
     );
 
   }

--- a/web/modules/custom/dpl_react/src/Controller/DplReactController.php
+++ b/web/modules/custom/dpl_react/src/Controller/DplReactController.php
@@ -68,7 +68,7 @@ class DplReactController extends ControllerBase {
   public function user() {
     $content_lines = ['window.dplReact = window.dplReact || {};'];
 
-    if ($token_agency = $this->libraryTokenHandler->getToken()) {
+    if ($token_agency = $this->libraryTokenHandler->getToken()->token ?? FALSE) {
       $content_lines[] = sprintf('window.dplReact.setToken("library", "%s")', $token_agency);
     }
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-402

#### Description

Since we need the expire information about the library token in the graphql API we do two things:
* Store the expire value we get from Adgangsplatformen in the library-token-key/value-store along the token value
* Expose the token expire time as a DateTime graphql scalar in the same way as other dates are returned eg.: Entity::created time.
