### PR TITLE
Patch recurring events module to handle deleted owner users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -383,7 +383,8 @@
                 "3468521: (4/4)": "https://git.drupalcode.org/project/recurring_events/-/commit/ad99ae79f5c55fc2db17427e9936ab141314609d.patch",
                 "3468300: Update EventSeriesSettings to use datetime form element.": "https://git.drupalcode.org/project/recurring_events/-/commit/5d9bc3b1cf7c00972f053f3d14873012b1ad7140.patch",
                 "3487412: Fix WSOD when EventInstance has invalid translation.": "https://git.drupalcode.org/project/recurring_events/-/commit/996052eeb7518ce591df968a0bb12c4819fb4edf.patch",
-                "3504806: Clean up orphaned eventinstances automatically": "https://www.drupal.org/files/issues/2025-02-06/reccuring_events_auto_delete_orphaned.patch"
+                "3504806: Clean up orphaned eventinstances automatically": "https://www.drupal.org/files/issues/2025-02-06/reccuring_events_auto_delete_orphaned.patch",
+                "3515976: EventUserTrait may return NULL if owner has been deleted": "https://git.drupalcode.org/issue/recurring_events-3515976/-/commit/4bf78bde6378b01367c4f57b0d5c40b51e8dc53f.patch"
             },
             "drupal/state_log": {
                 "3501178: Call to undefined method Drupal\\state_log\\StateLog::destruct()": "https://git.drupalcode.org/project/state_log/-/commit/8d63dd4827a930f5294004a1d13f051487ec4269.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6dd31552ea5c61394ab6277f82464fc",
+    "content-hash": "a761cc415bfb299bb151be0ddff35451",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-74

#### Description

Currently our `RediaEvent` class expects `getOwner()` on event instances to return a `UserInterface` in accordance with the implemented `EntityOwnerInterface`.

However this is currently not the case if the owner user has been deleted. In this case `getOwner()` will return `NULL` which in turn causes an exception to be thrown in our own code.

The core error here is the fact that the Recurring Events module does not respect the return value specified by Drupal Core. To address this we patch the Recurring Events module to return the anonymous user instead of `NULL`.

This approach is in accordance with similar discussions elsewhere. See https://www.drupal.org/project/drupal/issues/3335025.