### PR TITLE
Add `field_tags` to `node.page`.

### DIFF
--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_publication_date
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_image
     - field.field.node.page.field_teaser_text
     - node.type.page
@@ -33,7 +34,7 @@ third_party_settings:
       label: 'Teaser card'
       region: content
       parent_name: ''
-      weight: 13
+      weight: 14
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -49,12 +50,29 @@ third_party_settings:
       label: 'Author & Date'
       region: content
       parent_name: ''
-      weight: 12
+      weight: 13
       format_type: details_sidebar
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
+    group_tagging:
+      children:
+        - field_tags
+      label: Tagging
+      region: content
+      parent_name: ''
+      weight: 15
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
         open: true
         description: ''
         required_fields: true
@@ -144,6 +162,16 @@ content:
       rows: 3
       placeholder: ''
     third_party_settings: {  }
+  field_tags:
+    type: select2_entity_reference
+    weight: 8
+    region: content
+    settings:
+      width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
   field_teaser_image:
     type: media_library_widget
     weight: 10
@@ -163,7 +191,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 14
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -175,6 +203,11 @@ content:
     third_party_settings: {  }
   scheduler_settings:
     weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -195,12 +228,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 15
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.page.card.yml
+++ b/config/sync/core.entity_view_display.node.page.card.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_publication_date
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_image
     - field.field.node.page.field_teaser_text
     - node.type.page
@@ -57,5 +58,6 @@ hidden:
   field_hero_title: true
   field_paragraphs: true
   field_publication_date: true
+  field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_publication_date
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_image
     - field.field.node.page.field_teaser_text
     - node.type.page
@@ -45,6 +46,14 @@ content:
       format_type: medium
     third_party_settings: {  }
     weight: 113
+    region: content
+  field_tags:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 111
     region: content
   field_teaser_image:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.page.full.yml
+++ b/config/sync/core.entity_view_display.node.page.full.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_publication_date
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_image
     - field.field.node.page.field_teaser_text
     - node.type.page
@@ -52,6 +53,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_tags:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.page.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.list_teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_publication_date
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_image
     - field.field.node.page.field_teaser_text
     - node.type.page
@@ -34,6 +35,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_tags:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_teaser_image:
     type: entity_reference_entity_view

--- a/config/sync/core.entity_view_display.node.page.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.page.nav_spot.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_publication_date
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_image
     - field.field.node.page.field_teaser_text
     - node.type.page
@@ -57,5 +58,6 @@ hidden:
   field_hero_title: true
   field_paragraphs: true
   field_publication_date: true
+  field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.nav_teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_publication_date
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_image
     - field.field.node.page.field_teaser_text
     - node.type.page
@@ -40,6 +41,7 @@ hidden:
   field_hero_title: true
   field_paragraphs: true
   field_publication_date: true
+  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.page.field_paragraphs
     - field.field.node.page.field_publication_date
     - field.field.node.page.field_subtitle
+    - field.field.node.page.field_tags
     - field.field.node.page.field_teaser_image
     - field.field.node.page.field_teaser_text
     - node.type.page
@@ -29,6 +30,7 @@ hidden:
   field_paragraphs: true
   field_publication_date: true
   field_subtitle: true
+  field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   langcode: true

--- a/config/sync/field.field.node.page.field_tags.yml
+++ b/config/sync/field.field.node.page.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: ce6de663-3927-4cea-8034-595190a1804f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.page
+    - taxonomy.vocabulary.tags
+id: node.page.field_tags
+field_name: field_tags
+entity_type: node
+bundle: page
+label: Tags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/themes/custom/novel/templates/layout/node--page--full.html.twig
+++ b/web/themes/custom/novel/templates/layout/node--page--full.html.twig
@@ -6,6 +6,7 @@
       <h1 class="article-header__title">{{ title }}</h1>
 
       {{ content.field_subtitle }}
+
     </header>
   {% else %}
     {# We want the title to still be available for SEO/Accessibility. #}
@@ -13,4 +14,9 @@
   {% endif %}
 
   {{ content.field_paragraphs }}
+  {% if (content.field_tags.0) %}
+    <div class="page__tags">
+      {{ content.field_tags }}
+    </div>
+  {% endif %}
 </article>


### PR DESCRIPTION
Similarly to the eventseries/instances and articles, these should be displayed in a `tagging` details siderbar form group.

Categories have not been added, only tags.

DDFSAL-73

#### Link to issue

[jira.](https://reload.atlassian.net/jira/software/c/projects/DDFSAL/boards/539?selectedIssue=DDFSAL-73&useStoredSettings=true)


Design system pr: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/876

#### Description

This PR Adds a sidebar group "tagging" with the option to add tags to regular pages. 

Categories are not included. 

#### Screenshot of the result

![image](https://github.com/user-attachments/assets/4ef18cf9-00f5-412d-a865-dbbfade68d5d)

![image](https://github.com/user-attachments/assets/18c7ee3c-3f7c-4dc2-8fa1-2913a7565ac2)

