### PR TITLE
Ensure generated GraphQL client has not drifted from VCS

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -288,6 +288,26 @@ jobs:
       - name: Ensure CMS API package code has not drifted
         run: git diff --ignore-space-at-eol --exit-code packages/cms-api/*
 
+  CheckGraphQlClient:
+    name: Check GraphQL client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Our Taskfile requires a proper checkout to function because of
+          # certain vars.
+          fetch-depth: 0
+      - name: Install go-task
+        uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup site
+        run: task ci:reset
+      - name: Generate GraphQL client
+        run: task dev:bnf:generate-graphql
+      - name: Ensure GraphQL client code has not drifted
+        run: git diff --ignore-space-at-eol --exit-code web/modules/custom/bnf/src/GraphQL/*
+
   CheckDrupalConfig:
     name: Check Drupal Config
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Description

Regenerate code from GraphQL queries and check whether this results in any deviations from what is currency committed.

This helps identify changes to our GraphQL queries that developers may have forgotten to commit or changes to third party code that affects the generated code.

Both situations should be raised related to the change instead of the next time around when a developer generates client code in relation to other work.

This approach is consistent with what we do for other generated code.

#### Additional comments or questions

My initial reasoning for adding this is the update to Sailor in #2211.