### PR TITLE
DDFSAL-55 - Use "Nav spot" view mode for page nav spots.

### DIFF
--- a/config/sync/core.entity_view_display.node.page.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.page.nav_spot.yml
@@ -32,7 +32,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: hero_wide
+      view_mode: nav_spot
       link: false
     third_party_settings: {  }
     weight: 2


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-55

#### Description

In an earlier [PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2137), we made sure to remove the "Byline" field on nav spots by creating a new view mode called "Nav spots". However this was only added for the article and event content types. 

This PR make sure to also use the "Nav Spot" view mode for page nav spots. This view does not contain the byline field.
