### PR TITLE
Add update hook to make sure LibraryToken has correct format.

### DIFF
--- a/web/modules/custom/dpl_library_token/dpl_library_token.install
+++ b/web/modules/custom/dpl_library_token/dpl_library_token.install
@@ -5,7 +5,11 @@
  * DPL Library Token install procedures.
  */
 
+use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
 use Drupal\Core\Url;
+use Drupal\dpl_library_token\LibraryTokenHandler;
+use Drupal\dpl_login\Adgangsplatformen\Config;
+use Drupal\drupal_typed\DrupalTyped;
 
 /**
  * Implements hook_requirements().
@@ -38,4 +42,34 @@ function dpl_library_token_requirements($phase) : array {
   }
 
   return ['dpl_library_token' => $requirement];
+}
+
+/**
+ * Delete LibraryToken if it is invalid and retrieve a new one.
+ *
+ * If the LibraryToken is not in the correct format (string), it is considered
+ * invalid. If this is the case, we delete the token and retrieve a new one.
+ */
+function dpl_library_token_update_10000(): string {
+  $handler = DrupalTyped::service(LibraryTokenHandler::class, 'dpl_library_token.handler');
+  $config = DrupalTyped::service(Config::class, 'dpl_login.adgangsplatformen.config');
+  $keyValueFactory = DrupalTyped::service(KeyValueExpirableFactoryInterface::class, 'keyvalue.expirable');
+
+  $tokenCollection = $keyValueFactory->get(LibraryTokenHandler::TOKEN_COLLECTION_KEY);
+  $token = $tokenCollection->get(LibraryTokenHandler::LIBRARY_TOKEN_KEY);
+
+  if (is_string($token)) {
+    $tokenCollection->delete('library_token');
+
+    $handler->retrieveAndStoreToken(
+      $config->getAgencyId(),
+      $config->getClientId(),
+      $config->getClientSecret(),
+      $config->getTokenEndpoint()
+    );
+
+    return "Invalid token deleted and new token retrieved.";
+  }
+
+  return "Token already valid. No action taken.";
 }


### PR DESCRIPTION
#### Link to issue

N/A

#### Description

After updating the signature of the LibraryToken to also contain expire time, it is no longer saved as a string but as a object instead, containing the token and expire time. 

However, this is causing trouble for already existing LibraryTokens saved in the KeyValueStore. To make sure all libraries are using a LibraryToken with the correct format, we add an update hook that checks if the current token is valid, and if not, we delete it and fetch a new one.