### PR TITLE
Remove access to BNF for standard library employee roles

### DIFF
--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -27,7 +27,6 @@ dependencies:
   module:
     - administerusersbyrole
     - block
-    - bnf
     - config_perms
     - content_lock
     - cookieinformation
@@ -126,7 +125,6 @@ permissions:
   - 'administer webform'
   - 'administer webform element access'
   - 'administer webform submission'
-  - 'bnf import nodes'
   - 'break content lock'
   - 'cancel users by role'
   - 'change own username'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -25,7 +25,6 @@ dependencies:
     - taxonomy.vocabulary.webform_email_categories
   module:
     - administerusersbyrole
-    - bnf
     - content_lock
     - dpl_admin
     - dpl_footer
@@ -73,7 +72,6 @@ permissions:
   - 'administer menu'
   - 'administer nodes'
   - 'administer redirects'
-  - 'bnf import nodes'
   - 'break content lock'
   - 'change own username'
   - 'clone eventinstance entity'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -26,7 +26,6 @@ dependencies:
     - taxonomy.vocabulary.webform_email_categories
   module:
     - administerusersbyrole
-    - bnf
     - content_lock
     - dpl_admin
     - dpl_cache_settings
@@ -99,7 +98,6 @@ permissions:
   - 'administer themes'
   - 'administer themes novel'
   - 'administer url proxy configuration'
-  - 'bnf import nodes'
   - 'break content lock'
   - 'cancel users by role'
   - 'change own username'

--- a/config/sync/user.role.mediator.yml
+++ b/config/sync/user.role.mediator.yml
@@ -18,7 +18,6 @@ dependencies:
     - taxonomy.vocabulary.tags
   module:
     - administerusersbyrole
-    - bnf
     - content_lock
     - dpl_admin
     - entity_clone
@@ -54,7 +53,6 @@ permissions:
   - 'add eventseries entity'
   - 'administer entity field inheritance'
   - 'administer redirects'
-  - 'bnf import nodes'
   - 'break content lock'
   - 'change own username'
   - 'clone eventinstance entity'


### PR DESCRIPTION
#### Description

Remove access to BNF for standard library employee roles. We would like to restrict access to the BNF pilot role for now.

This is a partial revert of what was added in #2224 
