### PR TITLE
BNF: Mapping of files should have correct fallback.

### DIFF
--- a/web/modules/custom/bnf/src/Plugin/Traits/FileTrait.php
+++ b/web/modules/custom/bnf/src/Plugin/Traits/FileTrait.php
@@ -92,7 +92,7 @@ trait FileTrait {
       'field_media_file' => [
         'target_id' => $file->id(),
         'display' => TRUE,
-        'description' => $document->mediaFile->description,
+        'description' => $document->mediaFile->description ?? '',
       ],
       'name' => $document->mediaFile->name,
     ];

--- a/web/modules/custom/bnf/src/Plugin/Traits/ImageTrait.php
+++ b/web/modules/custom/bnf/src/Plugin/Traits/ImageTrait.php
@@ -42,10 +42,10 @@ trait ImageTrait {
       'bundle' => 'image',
       'name' => $file->getFilename(),
       'status' => TRUE,
-      'field_byline' => $image->byline,
+      'field_byline' => $image->byline ?? '',
       'field_media_image' => [
         'target_id' => $file->id(),
-        'alt' => $alt,
+        'alt' => $alt ?? '',
       ],
     ];
 


### PR DESCRIPTION
If the fallback is NULL, the LoadByProperties fail hard, with a SQL query error.
