### PR TITLE
Ensure long links in material grid links don't break the layout

### DIFF
--- a/web/modules/custom/dpl_admin/assets/dpl_admin.css
+++ b/web/modules/custom/dpl_admin/assets/dpl_admin.css
@@ -136,7 +136,6 @@
   display: none;
 }
 
-
 /* Hiding the ability to place main menu items in levels. */
 .menu-edit-form[action="/admin/structure/menu/manage/main"] {
   .menu-link-content-form .form-item--menu-parent,
@@ -206,4 +205,11 @@ body:has(.eventseries-form--confirm) .form-actions {
   color: #d80404;
   font-weight: bold;
   max-width: 500px;
+}
+
+/**
+ Long URLs in the material grid automatic link field are breaking the layout.
+*/
+.paragraph-type--material-grid-link-automatic {
+  word-break: break-all;
 }


### PR DESCRIPTION
#### Link to issue

[DDFSAL-72](https://reload.atlassian.net/browse/DDFSAL-72)

#### Description

Long links were breaking in layout in material grid automatic. See images.

#### Screenshot of the result

See ticket for a before imag.e 

After image: 
![image](https://github.com/user-attachments/assets/1fb7071b-ac90-47fe-8f1a-b381d68fed9b)



[DDFSAL-72]: https://reload.atlassian.net/browse/DDFSAL-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ