### PR TITLE
Ignore bnf modules usenng `config_exclude_modules`

### DIFF
--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -54,8 +54,9 @@ if (getenv('MARIADB_DATABASE_OVERRIDE')) {
   ];
 }
 
-// Exclude development modules from configuration export.
+// Exclude certain modules from configuration export.
 $settings['config_exclude_modules'] = [
+  // Development modules that is only enabled in development environment.
   'dpl_related_content_tests',
   'dpl_example_content',
   'dpl_example_breadcrumb',
@@ -68,6 +69,9 @@ $settings['config_exclude_modules'] = [
   'restui',
   'upgrade_status',
   'uuid_url',
+  // These are enabled as needed, so exclude them from export.
+  'bnf_client',
+  'bnf_server',
 ];
 
 // Defines where the sync folder of your configuration lives. In this case it's

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -3,7 +3,6 @@ _core:
 mode: intermediate
 ignored_config_entities:
   import:
-    - bnf_client.settings
     - core.extension
     - dpl_dashboard.settings
     - dpl_event.settings
@@ -28,7 +27,6 @@ ignored_config_entities:
     - system.site
     - 'webform.webform.*'
   export:
-    - bnf_client.settings
     - dpl_dashboard.settings
     - dpl_event.settings
     - dpl_favorites_list.settings


### PR DESCRIPTION
This not only ignores their configuration, but ensures they're never added to `core.extension` when exporting.
