### PR TITLE
Update editorial search to never show unpublished content. DDFSAL-25

### DIFF
--- a/config/sync/search_api.index.content_events.yml
+++ b/config/sync/search_api.index.content_events.yml
@@ -86,6 +86,15 @@ field_settings:
     dependencies:
       config:
         - field.storage.eventseries.field_teaser_text
+  status:
+    label: 'Status (Aggregrated)'
+    property_path: aggregated_field
+    type: boolean
+    configuration:
+      type: union
+      fields:
+        - 'entity:eventseries/status'
+        - 'entity:node/status'
   tags:
     label: 'Tags (Aggregrated)'
     property_path: aggregated_field
@@ -159,6 +168,7 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
 server: db_search

--- a/config/sync/views.view.editorial_search.yml
+++ b/config/sync/views.view.editorial_search.yml
@@ -204,6 +204,44 @@ display:
           parse_mode: terms
           min_length: null
           fields: {  }
+        status:
+          id: status
+          table: search_api_index_content_events
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
       row:


### PR DESCRIPTION
- Updating the search API, to create an common, aggrevated status field, that is available for both eventseries and nodes
- Update the editorial search view to only show published

https://reload.atlassian.net/browse/DDFSAL-25