### PR TITLE
DDFBRA-516 - Setup URL prefixes for GO content

### DIFF
--- a/config/sync/pathauto.pattern.breadcrumb_pattern.yml
+++ b/config/sync/pathauto.pattern.breadcrumb_pattern.yml
@@ -8,7 +8,18 @@ id: breadcrumb_pattern
 label: 'Breadcrumb pattern'
 type: 'canonical_entities:node'
 pattern: '[dpl_breadcrumb:breadcrumb-url-alias]'
-selection_criteria: {  }
+selection_criteria:
+  f8e93f99-e638-4c48-9901-278f15d59aa1:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: f8e93f99-e638-4c48-9901-278f15d59aa1
+    context_mapping:
+      node: node
+    bundles:
+      article: article
+      branch: branch
+      campaign: campaign
+      page: page
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/config/sync/pathauto.pattern.go_articles.yml
+++ b/config/sync/pathauto.pattern.go_articles.yml
@@ -1,0 +1,22 @@
+uuid: 6e8e4db7-e7ca-4ddd-9695-c1e3ff5cbe86
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: go_articles
+label: 'GO Articles'
+type: 'canonical_entities:node'
+pattern: '/artikel/[node:title]'
+selection_criteria:
+  ae79b54a-b5dd-4ca5-b327-01942d70bb17:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: ae79b54a-b5dd-4ca5-b327-01942d70bb17
+    context_mapping:
+      node: node
+    bundles:
+      go_article: go_article
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/sync/pathauto.pattern.go_categories.yml
+++ b/config/sync/pathauto.pattern.go_categories.yml
@@ -1,0 +1,22 @@
+uuid: e60d9ab4-5a58-4eaf-bced-db201c8dfd90
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: go_categories
+label: 'GO Categories'
+type: 'canonical_entities:node'
+pattern: '/kategori/[node:title]'
+selection_criteria:
+  83711c44-314c-4bc3-b32f-3784b07107a3:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 83711c44-314c-4bc3-b32f-3784b07107a3
+    context_mapping:
+      node: node
+    bundles:
+      go_category: go_category
+selection_logic: and
+weight: -5
+relationships: {  }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-516

#### Description

This PR adds url prefixes to the `GO Article` and `GO Category` content types:

GO Article - `/artikel/<title>`
GO Category - `/kategori/<title>`


#### Screenshot of the result

Category example:
![Screenshot 2025-04-04 at 15 41 31](https://github.com/user-attachments/assets/4215d1fe-9482-459f-b2f5-6460552d2f63)

Category GraphQL query example:
```graphql
query MyQuery {
  route(path: "/kategori/gyser") {
    ... on RouteInternal {
      __typename
      entity {
        ... on NodeGoCategory {
          id
          path
        }
      }
    }
  }
}
```

Category GraphQL result example:

```graphql
{
  "data": {
    "route": {
      "__typename": "RouteInternal",
      "entity": {
        "id": "aad51dfc-6bf5-4a8f-a6af-ec67c5a1c8ce",
        "path": "/kategori/gyser"
      }
    }
  }
}
```
