### PR TITLE
Update DateFormatter to match other event filter logic. DDFSAL-27

### DIFF
--- a/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
+++ b/web/modules/custom/dpl_event/src/ReoccurringDateFormatter.php
@@ -105,7 +105,7 @@ class ReoccurringDateFormatter {
     $query = $this->entityTypeManager->getStorage('eventinstance')->getQuery();
     $upcoming_ids = $query
       ->condition('eventseries_id', $event_series->id())
-      ->condition('date.value', $formatted, '>=')
+      ->condition('date.end_value', $formatted, '>=')
       ->accessCheck(TRUE)
       ->condition('status', TRUE)
       ->sort('date.value', 'ASC')


### PR DESCRIPTION
Our various views and other queries, filter out expired events, by the logic of: "We must be past the *end* date".

The logic in ReoccuringDateFormatter instead looked at the *start* date. This is a problem if you have a series with a single active eventinstance, that spans over several days: It'll show as expired.

DDFSAL-27
