### PR TITLE
Bnf example content

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "**/web/themes/custom/novel/assets/",
     "**/web/themes/contrib/",
     "**/web/modules/local/",
+    "**/web/modules/custom/bnf/bnf_example_content/content/",
     "**/web/modules/custom/dpl_example_content/content/",
     "**/web/modules/custom/dpl_static_content/content/"
   ]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -178,7 +178,7 @@ tasks:
       # Install site.
       - task dev:cli -- ./dev-scripts/install-site.sh {{ if .SKIP_LANGUAGE_IMPORT }}--skip-language-import{{ end }}
       # Possibly install the BNF site.
-      - task dev:bnfcli -- ./dev-scripts/install-site.sh --no-content {{ if .SKIP_LANGUAGE_IMPORT }}--skip-language-import{{ end }}
+      - task dev:bnfcli -- ./dev-scripts/install-site.sh --bnf-content {{ if .SKIP_LANGUAGE_IMPORT }}--skip-language-import{{ end }}
       - task dev:bnfcli -- drush --yes config:set system.site name BNF
       # Show a one-time login to the local site(s).
       - task dev:cli -- drush user-login

--- a/assets/all.settings.php
+++ b/assets/all.settings.php
@@ -57,6 +57,7 @@ if (getenv('MARIADB_DATABASE_OVERRIDE')) {
 // Exclude certain modules from configuration export.
 $settings['config_exclude_modules'] = [
   // Development modules that is only enabled in development environment.
+  'bnf_example_content',
   'dpl_related_content_tests',
   'dpl_example_content',
   'dpl_example_breadcrumb',

--- a/dev-scripts/install-site.sh
+++ b/dev-scripts/install-site.sh
@@ -7,7 +7,7 @@ SKIP_LANGUAGE_IMPORT=""
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --skip-language-import) SKIP_LANGUAGE_IMPORT="true" ;;
-    --no-content) SKIP_CONTENT="true" ;;
+    --bnf-content) BNF_CONTENT="true" ;;
     *) echo "Unknown parameter passed: $1"; exit 1 ;;
   esac
   shift
@@ -42,8 +42,10 @@ curl --silent --show-error --fail --output /dev/null http://varnish:8080/
 # Enable dev modules (see task dev:enable-dev-tools).
 MODULES=(devel field_ui purge_ui restui uuid_url views_ui dblog)
 
-if [[ $SKIP_CONTENT != "true" ]]; then
+if [[ $BNF_CONTENT != "true" ]]; then
   MODULES=("${MODULES[@]}" dpl_example_content)
+else
+  MODULES=("${MODULES[@]}" bnf_example_content)
 fi
 drush install -y "${MODULES[@]}"
 

--- a/web/modules/custom/bnf/bnf_client/bnf_client.info.yml
+++ b/web/modules/custom/bnf/bnf_client/bnf_client.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^10
 configure: bnf_client.settings
 dependencies:
   - bnf:bnf
+  - drupal_typed:drupal_typed

--- a/web/modules/custom/bnf/bnf_example_content/bnf_example_content.info.yml
+++ b/web/modules/custom/bnf/bnf_example_content/bnf_example_content.info.yml
@@ -1,0 +1,12 @@
+name: Example content for BNF
+type: module
+description: Provides example content for Delingstjenesten
+package: DPL
+core_version_requirement: ^9 || ^10
+dependencies:
+  - default_content:default_content
+  - drupal_typed:drupal_typed
+default_content:
+  node:
+    - a631dbb7-c6b2-4d99-a4b8-ca56a318140f
+    - 5b747546-8f54-41bb-87b6-0a87c1a1ea32

--- a/web/modules/custom/bnf/bnf_example_content/bnf_example_content.module
+++ b/web/modules/custom/bnf/bnf_example_content/bnf_example_content.module
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\drupal_typed\DrupalTyped;
+
+/**
+ * Implements hook_modules_installed().
+ *
+ * @param string[] $modules
+ *   The names of the modules that were installed.
+ */
+function bnf_example_content_modules_installed(array $modules): void {
+  // Only react to our own installation.
+  if (!in_array('bnf_example_content', $modules)) {
+    return;
+  }
+
+  $logger = DrupalTyped::service(LoggerChannelFactoryInterface::class, LoggerChannelFactoryInterface::class)->get('bnf_example_content');
+
+  // Set page.front link to /delingstjenesten, our front page stand-in.
+  $config_site = DrupalTyped::service(ConfigFactoryInterface::class, ConfigFactoryInterface::class)->getEditable('system.site');
+  $front_page = '/delingstjenesten';
+  $config_site->set('page.front', $front_page)->save();
+  $logger->info("Update frontpage link to {$front_page}, as part of Delingstjenesten dev content installation.");
+}

--- a/web/modules/custom/bnf/bnf_example_content/content/node/5b747546-8f54-41bb-87b6-0a87c1a1ea32.yml
+++ b/web/modules/custom/bnf/bnf_example_content/content/node/5b747546-8f54-41bb-87b6-0a87c1a1ea32.yml
@@ -1,0 +1,83 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 5b747546-8f54-41bb-87b6-0a87c1a1ea32
+  bundle: article
+  default_langcode: da
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Eksempel indhold'
+  created:
+    -
+      value: 1744185350
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Eksempel indhold | BNF'
+  path:
+    -
+      alias: /articles/eksempel-indhold
+      langcode: und
+      pathauto: 1
+  field_paragraphs:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: e8836eab-29b1-4cfd-8c2c-ab7f8a13cb08
+          bundle: text_body
+          default_langcode: da
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1744185350
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_body:
+            -
+              value: '<p>Her er et stykke indhold der kan deles til et bibliotek.</p>'
+              format: basic
+  field_publication_date:
+    -
+      value: '2025-04-09'
+  field_show_override_author:
+    -
+      value: false
+  field_subtitle:
+    -
+      value: 'Til deling.'

--- a/web/modules/custom/bnf/bnf_example_content/content/node/a631dbb7-c6b2-4d99-a4b8-ca56a318140f.yml
+++ b/web/modules/custom/bnf/bnf_example_content/content/node/a631dbb7-c6b2-4d99-a4b8-ca56a318140f.yml
@@ -1,0 +1,80 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: a631dbb7-c6b2-4d99-a4b8-ca56a318140f
+  bundle: page
+  default_langcode: da
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Delingstjenesten
+  created:
+    -
+      value: 1744183713
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Delingstjenesten | BNF'
+  path:
+    -
+      alias: /delingstjenesten
+      langcode: und
+      pathauto: 1
+  field_display_titles:
+    -
+      value: false
+  field_paragraphs:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 044feedc-01e6-49a8-8ebe-0c57d06c7d7b
+          bundle: text_body
+          default_langcode: da
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1744183713
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_body:
+            -
+              value: '<p>Dette er et Delingstjenesten udviklingsmiljø.</p>'
+              format: basic
+  field_publication_date:
+    -
+      value: '2025-04-09'


### PR DESCRIPTION
Add a BNF example content module for development.

Without any front page, "Login to BNF" will just end up at the login of the BNF site, without any indication that you're in fact "logged in". 