### PR TITLE
DDFBRA-558 - Change validation of VideoTool URL's to include both valid formats

### DIFF
--- a/web/modules/custom/media_videotool/src/Form/VideoToolMediaLibraryAddForm.php
+++ b/web/modules/custom/media_videotool/src/Form/VideoToolMediaLibraryAddForm.php
@@ -42,7 +42,7 @@ class VideoToolMediaLibraryAddForm extends AddFormBase {
       '#title' => $this->t('Add @type video via URL', [
         '@type' => $media_type->label(),
       ]),
-      '#description' => $this->t('VideoTool URL example: https://media.videotool.dk?vn=557_2023103014511477700668916683'),
+      '#description' => $this->t('VideoTool URL examples: https://media.videotool.dk?vn=557_2023103014511477700668916683 or https://media.videotool.dk/?vn=557_2023103014511477700668916683'),
       '#required' => TRUE,
       '#attributes' => [
         'placeholder' => 'https://',

--- a/web/modules/custom/media_videotool/src/Plugin/Field/FieldWidget/VideoToolWidget.php
+++ b/web/modules/custom/media_videotool/src/Plugin/Field/FieldWidget/VideoToolWidget.php
@@ -28,7 +28,7 @@ class VideoToolWidget extends StringTextfieldWidget {
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
 
-    $message = $this->t('VideoTool URL example: https://media.videotool.dk?vn=557_2023103014511477700668916683');
+    $message = $this->t('VideoTool URL examples: https://media.videotool.dk?vn=557_2023103014511477700668916683 or https://media.videotool.dk/?vn=557_2023103014511477700668916683');
 
     if (!empty($element['value']['#description'])) {
       $element['value']['#description'] = [

--- a/web/modules/custom/media_videotool/src/Traits/HasVideoToolFeaturesTrait.php
+++ b/web/modules/custom/media_videotool/src/Traits/HasVideoToolFeaturesTrait.php
@@ -17,7 +17,8 @@ trait HasVideoToolFeaturesTrait {
    * Function for checking if a URL match the VideoTool URL format.
    */
   protected static function isValidVideoToolUrl(string $url): bool {
-    return (bool) preg_match('/^https:\/\/media\.videotool\.dk\?vn=\d+_\d+$/', $url);
+    return (bool) preg_match('/^https:\/\/media\.videotool\.dk\/?\?vn=\d+_\d+$/', $url);
+
   }
 
   /**


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-558

#### Description

This PR changes the RegEx validation of VideoTool URL's.
Depending on where the editors copy the URL for a VideoTool, it can have 2 different formats with and without an `/`

`https://media.videotool.dk?vn=557_2023103014511477700668916683`
`https://media.videotool.dk/?vn=557_2023103014511477700668916683`

It is now possible to use both formats.