### PR TITLE
Fix GraphQL client test

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -288,8 +288,8 @@ jobs:
       - name: Ensure CMS API package code has not drifted
         run: git diff --ignore-space-at-eol --exit-code packages/cms-api/*
 
-  CheckGraphQlClient:
-    name: Check GraphQL client
+  CheckGraphQlSchema:
+    name: Check GraphQL specification
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -305,8 +305,10 @@ jobs:
         run: task dev:bnf:enable
       - name: Setup site
         run: task ci:reset
-      - name: Generate GraphQL client
+      - name: Extract GraphQL schema and generate client
         run: task dev:bnf:generate-graphql
+      - name: Ensure GraphQL schema has not drifted
+        run: git diff --ignore-space-at-eol --exit-code web/modules/custom/bnf/schema/bnf.graphql
       - name: Ensure GraphQL client code has not drifted
         run: git diff --ignore-space-at-eol --exit-code web/modules/custom/bnf/src/GraphQL/*
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -301,6 +301,8 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable BNF for site
+        run: task dev:bnf:enable
       - name: Setup site
         run: task ci:reset
       - name: Generate GraphQL client

--- a/web/modules/custom/bnf/schema/bnf.graphql
+++ b/web/modules/custom/bnf/schema/bnf.graphql
@@ -39,6 +39,24 @@ type AdgangsplatformenUserToken {
   expire: Int
 }
 
+"""Input for filter exposed with operator "between"."""
+input BetweenFloatInput {
+  """The minimum value of the range."""
+  min: Float
+
+  """The maximum value of the range."""
+  max: Float
+}
+
+"""Input for filter exposed with operator "between"."""
+input BetweenStringInput {
+  """The minimum value of the range."""
+  min: String
+
+  """The maximum value of the range."""
+  max: String
+}
+
 """En CQL søgestreng."""
 type CQLSearch {
   """CQL søgestrengen."""
@@ -80,11 +98,6 @@ type DateTime {
   time: Time!
 }
 
-"""DPL Configuration."""
-type DplConfiguration {
-  unilogin: UniloginConfiguration
-}
-
 type DplTokens {
   adgangsplatformen: AdgangsplatformenTokens
 }
@@ -108,6 +121,33 @@ type File {
 
   """The description of the file."""
   description: String
+}
+
+"""Result for view go_categories display go_categories."""
+type GoCategoriesResult implements View {
+  """The ID of the view."""
+  id: ID!
+
+  """The machine name of the view."""
+  view: String!
+
+  """The machine name of the display."""
+  display: String!
+
+  """The language code of the view."""
+  langcode: String
+
+  """The human friendly label of the view."""
+  label: String
+
+  """Viewets beskrivelse."""
+  description: String
+
+  """Information about the page in the view."""
+  pageInfo: ViewPageInfo!
+
+  """The results of the view."""
+  results: [NodeUnion!]!
 }
 
 type GoConfiguration {
@@ -209,19 +249,19 @@ type MediaAudio implements MediaInterface {
   """The time the media item was created."""
   created: DateTime!
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
   """Audio file"""
   mediaAudioFile: File!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -236,19 +276,19 @@ type MediaDocument implements MediaInterface {
   """The time the media item was created."""
   created: DateTime!
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
-  """Fil"""
+  """File"""
   mediaFile: File!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -258,7 +298,7 @@ type MediaImage implements MediaInterface {
   id: ID!
 
   """
-  Bruges til fotokreditering og info om copyright. Vises som regel ved siden af billedet.
+  Used for public credit and copyright information. Will usually be displayed along with the media.
   """
   byline: String
 
@@ -268,25 +308,24 @@ type MediaImage implements MediaInterface {
   """The time the media item was created."""
   created: DateTime!
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
   """
-  Du kan indstille et fokuspunkt ved at klikke på forhåndsvisningen af
-  billedet og flytte det hvide mål.<br /><br />Ved at indstille et fokuspunkt
-  fortæller du systemet, hvilken del af billedet der skal være i fokus, når
-  det beskæres.<br /><br />Brug funktionen "forhåndsvisning" til at se,
-  hvordan dit billede vil blive beskåret på tværs af billedstil.
+  You can set a focal point, by clicking on the preview on the image, moving the
+  white target.<br /><br />By setting a focal point, you tell the system which
+  part of the image to keep in focus when it gets cropped.<br /><br />Use the
+  "preview" function, to see how your image will be cropped across image styles.
   """
   mediaImage: Image!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -301,16 +340,16 @@ interface MediaInterface {
   """The time the media item was created."""
   created: DateTime!
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -328,19 +367,19 @@ type MediaVideo implements MediaInterface {
   """The time the media item was created."""
   created: DateTime!
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
-  """URL til video"""
+  """Remote video URL"""
   mediaOembedVideo: String!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -355,19 +394,19 @@ type MediaVideotool implements MediaInterface {
   """The time the media item was created."""
   created: DateTime!
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
   """VideoTool URL"""
   mediaVideotool: String!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -383,23 +422,25 @@ type NewContentResponse {
   errors: [Violation]
 }
 
-"""Brug artikler til nyhedspræget indhold med en begrænset levetid."""
+"""
+Use articles for news-worthy content, that does not get updated regularly.
+"""
 type NodeArticle implements NodeInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
-  """Bibliotek"""
+  """Branch"""
   branch: NodeUnion
 
   """
-  Oplys en canonical URL hvis indholdet i artiklen er kopieret fra en anden
-  hjemmeside (fx kopieret fra et andet biblioteks hjemmeside). Dette hjælper
-  med at signalere til søgemaskiner at kilden til indholdet er den
-  specificerede side, og sikrer at den originale kilde krediteres.
+  Please provide a canonical URL if this content has been duplicated from other
+  websites. This helps signal to search engines that the preferred source of
+  this content is the specified canonical URL, preventing potential duplicate
+  content issues and ensuring proper attribution to the original source.
   """
   canonicalUrl: Link
 
-  """Kategorier"""
+  """Categories"""
   categories: TermUnion
 
   """Tidspunktet hvor indholdselementet sidst blev redigeret."""
@@ -408,73 +449,7 @@ type NodeArticle implements NodeInterface {
   """The date and time that the content was created."""
   created: DateTime!
 
-  """Sprog"""
-  langcode: Language!
-
-  """Overskriv forfatter"""
-  overrideAuthor: String
-
-  """Paragraphs"""
-  paragraphs: [ParagraphUnion!]
-
-  """Alternativ URL"""
-  path: String
-
-  """Forfremmet til forside"""
-  promote: Boolean!
-
-  """Udgivelsesdato"""
-  publicationDate: DateTime!
-
-  """
-  Som standard er forfatteren sat til den Drupal-bruger, der ejer indholdet.<br
-  /><br />Hvis du ønsker at tilsidesætte dette med din egen tekst, kan du
-  """
-  showOverrideAuthor: Boolean
-
-  """Publiceret"""
-  status: Boolean!
-
-  """Klæbrig"""
-  sticky: Boolean!
-
-  """Manchet"""
-  subtitle: String
-
-  """Tags"""
-  tags: [TermUnion!]
-
-  """
-  Teaserfelterne bruges til cards som blikfang for indholdet. Hvis der ikke er
-  valgt et teaserbillede, vil teksten vises i stedet.
-  """
-  teaserImage: MediaUnion
-
-  """Teasertekst"""
-  teaserText: String
-
-  """Titel"""
-  title: String!
-  url: String!
-}
-
-"""
-Use Go articles for news-worthy content, that does not get updated regularly.
-"""
-type NodeGoArticle implements NodeInterface {
-  """The Universally Unique IDentifier (UUID)."""
-  id: ID!
-
-  """Tidspunktet hvor indholdselementet sidst blev redigeret."""
-  changed: DateTime!
-
-  """The date and time that the content was created."""
-  created: DateTime!
-
-  """Image"""
-  goArticleImage: MediaUnion
-
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
   """Override author"""
@@ -498,7 +473,74 @@ type NodeGoArticle implements NodeInterface {
   """
   showOverrideAuthor: Boolean
 
-  """Publiceret"""
+  """Published"""
+  status: Boolean!
+
+  """Klæbrig"""
+  sticky: Boolean!
+
+  """Subtitle"""
+  subtitle: String
+
+  """Tags"""
+  tags: [TermUnion!]
+
+  """
+  The teaser fields are used for the card of display.<br />If no image has been
+  selected, the text will be shown instead:<br /><br /><img
+  src="/themes/custom/novel/images/teaser-text-image.jpg" /><br /><br /><hr/>
+  """
+  teaserImage: MediaUnion
+
+  """Teaser text"""
+  teaserText: String
+
+  """Title"""
+  title: String!
+  url: String!
+}
+
+"""
+Use Go articles for news-worthy content, that does not get updated regularly.
+"""
+type NodeGoArticle implements NodeInterface {
+  """The Universally Unique IDentifier (UUID)."""
+  id: ID!
+
+  """Tidspunktet hvor indholdselementet sidst blev redigeret."""
+  changed: DateTime!
+
+  """The date and time that the content was created."""
+  created: DateTime!
+
+  """Image"""
+  goArticleImage: MediaUnion
+
+  """Language"""
+  langcode: Language!
+
+  """Override author"""
+  overrideAuthor: String
+
+  """Paragraphs"""
+  paragraphs: [ParagraphUnion!]
+
+  """Alternativ URL"""
+  path: String
+
+  """Forfremmet til forside"""
+  promote: Boolean!
+
+  """Publication date"""
+  publicationDate: DateTime!
+
+  """
+  By default, the author is set to the Drupal user that owns the content.<br
+  /><br />If you want to override this, with a manual text, you can check this.
+  """
+  showOverrideAuthor: Boolean
+
+  """Published"""
   status: Boolean!
 
   """Klæbrig"""
@@ -517,7 +559,7 @@ type NodeGoArticle implements NodeInterface {
   """Teaser text"""
   teaserText: String
 
-  """Titel"""
+  """Title"""
   title: String!
   url: String!
 }
@@ -554,7 +596,7 @@ type NodeGoCategory implements NodeInterface {
   """Category menu color"""
   goColor: String
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
   """Paragraphs"""
@@ -569,20 +611,21 @@ type NodeGoCategory implements NodeInterface {
   """Publication date"""
   publicationDate: DateTime!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Klæbrig"""
   sticky: Boolean!
 
-  """Titel"""
+  """Title"""
   title: String!
   url: String!
 }
 
 """
-GO-sider bliver brugt til forskellige typer for indhold, som ikke tilhører
-hverken en artikel-side eller en kategori-side. Fx forsiden, informationssider
+GO pages will be used for various types of content, which does not belong to
+either an article page or an category page. Some examples could be the
+frontpage, info pages, etc.
 """
 type NodeGoPage implements NodeInterface {
   """The Universally Unique IDentifier (UUID)."""
@@ -594,10 +637,10 @@ type NodeGoPage implements NodeInterface {
   """The date and time that the content was created."""
   created: DateTime!
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
-  """Paragraffer"""
+  """Paragraphs"""
   paragraphs: [ParagraphUnion!]
 
   """Alternativ URL"""
@@ -606,16 +649,16 @@ type NodeGoPage implements NodeInterface {
   """Forfremmet til forside"""
   promote: Boolean!
 
-  """Publikationsdato"""
+  """Publication date"""
   publicationDate: DateTime!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Klæbrig"""
   sticky: Boolean!
 
-  """Titel"""
+  """Title"""
   title: String!
   url: String!
 }
@@ -631,7 +674,7 @@ interface NodeInterface {
   """The date and time that the content was created."""
   created: DateTime!
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
   """Alternativ URL"""
@@ -640,34 +683,35 @@ interface NodeInterface {
   """Forfremmet til forside"""
   promote: Boolean!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Klæbrig"""
   sticky: Boolean!
 
-  """Titel"""
+  """Title"""
   title: String!
   url: String!
 }
 
 """
-Sider kan anvendes til en bred vifte af indhold af mere eller mindre blivende
-karakter. En side kan være simpel og indeholde tekst om fx. låneregler, men
-kan også være en strukturerende enhed, hvis formål er at udstille andre sider
-i en sektion med henblik på formidling eller navigation.
+Pages can be used for various types of content, either temporary or permanent. A
+page can be simple, containing text about, for example, loan rules, or it can
+serve as a structural unit designed to display other pages in a section for
+communication or navigation.
 """
 type NodePage implements NodeInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
-  """Bibliotek"""
+  """Branch"""
   branch: NodeUnion
 
   """
-  Hvis du vil gøre denne side til en strukturerende side, skal du gemme siden
-  først og  <a href="/admin/structure/taxonomy/manage/breadcrumb_structure/add"
-  target="_blank">tilføje den som en reference i strukturtræet.
+  TODO: A text about how the structure tree works.<br><br />"If you want to make
+  this page central, you need to save it first, and then <a
+  href="/admin/structure/taxonomy/manage/breadcrumb_structure/add"
+  target="_blank">add it as a reference in the content structure tree</a>
   """
   breadcrumbParent: TermUnion
 
@@ -686,17 +730,18 @@ type NodePage implements NodeInterface {
   created: DateTime!
 
   """
-  Som standard vises titel og manchettekst ikke på indholdstypen sider.  Hvis
-  du vil have dem vist, kan du slå det til her.
+  By default, titles and subtitles are not displayed on pages. If you wish to
+  have it displayed, you can enable this setting.
   """
   displayTitles: Boolean
 
   """
-  Titlen, der er vist øverst på siden.<br /><br /> <strong>Hvis den er tom, bliver standardsiden brugt i stedet.</strong>.
+  The title that is shown at the top of the page.<br /><br /><strong>If this is
+  empty, the standard page title will be used instead.</strong>
   """
   heroTitle: String
 
-  """Sprog"""
+  """Language"""
   langcode: Language!
 
   """Paragraphs"""
@@ -708,28 +753,29 @@ type NodePage implements NodeInterface {
   """Forfremmet til forside"""
   promote: Boolean!
 
-  """Udgivelsesdato"""
+  """Publication date"""
   publicationDate: DateTime!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Klæbrig"""
   sticky: Boolean!
 
-  """Manchet"""
+  """Subtitle"""
   subtitle: String
 
   """
-  Teaserfelterne bruges til cards som blikfang for indholdet. Hvis der ikke er
-  valgt et teaserbillede, vil teksten vises i stedet.
+  The teaser fields are used for the card of display.<br />If no image has been
+  selected, the text will be shown instead:<br /><br /><img
+  src="/themes/custom/novel/images/teaser-text-image.jpg" /><br /><br /><hr/>
   """
   teaserImage: MediaUnion
 
-  """Teasertekst"""
+  """Teaser text"""
   teaserText: String
 
-  """Titel"""
+  """Title"""
   title: String!
 }
 
@@ -741,10 +787,10 @@ type ParagraphAccordion implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
-  """Accordion beskrivelse"""
+  """Accordion description"""
   accordionDescription: Text
 
-  """Accordion titel"""
+  """Accordion title"""
   accordionTitle: Text!
 
   """The time that the Paragraph was created."""
@@ -753,24 +799,24 @@ type ParagraphAccordion implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
 """
-Bannerets funktion er at linke til internt indhold, og kan bruges med eller uden baggrundsbillede.
+Banner's purpose is to link internally or externally and can be used with or without a background image.
 """
 type ParagraphBanner implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
-  """Bannerbeskrivelse"""
+  """Banner description"""
   bannerDescription: String
 
-  """Bannerbillede"""
+  """Banner Image"""
   bannerImage: MediaUnion
 
-  """Bannerlink"""
+  """Banner Link"""
   bannerLink: Link!
 
   """The time that the Paragraph was created."""
@@ -779,22 +825,23 @@ type ParagraphBanner implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
-  """Understreget titel"""
+  """Underlined title"""
   underlinedTitle: Text
 }
 
 """
-Vis automatisk alt indhold, som refererer til dit valgte brødkrumme element.
+Automatically display all content that is referencing your chosen breadcrumb item.
 """
 type ParagraphBreadcrumbChildren implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
   """
-  Vælg en sideforælder i brødkrummestrukturen, hvis sidebørn skal vises. Kun ét niveau af sidebørn kan vises.
+  Choose a parent in the breadcrumb structure, from which the children will be
+  displayed. <br><br />Only one level of children will be shown.
   """
   breadcrumbTarget: TermUnion
 
@@ -804,14 +851,14 @@ type ParagraphBreadcrumbChildren implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Vis undertekster"""
+  """Show subtitles"""
   showSubtitles: Boolean
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""En regel til at vælge en matchende kampagne"""
+"""A rule for selecting a matching campaign"""
 type ParagraphCampaignRule implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -828,7 +875,7 @@ type ParagraphCampaignRule implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -840,31 +887,31 @@ type ParagraphCardGridAutomatic implements ParagraphInterface {
   """The time that the Paragraph was created."""
   created: DateTime!
 
-  """Hvis der ikke vælges noget, vil ALT automatisk blive valgt."""
+  """If nothing is selected, all will be chosen."""
   filterBranches: [NodeUnion!]
 
-  """Filter efter kategorier"""
+  """Filter by categories"""
   filterCategories: [TermUnion!]
 
-  """Tilstandstype"""
+  """Condition type"""
   filterCondType: String!
 
-  """Hvis intet er valgt, vil alt blive valgt."""
+  """If nothing is selected, all will be chosen."""
   filterContentTypes: [String!]
 
-  """Filter efter tags"""
+  """Filter by tags"""
   filterTags: [TermUnion!]
 
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Flere links"""
+  """More link"""
   moreLink: Link
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
-  """Titel"""
+  """Title"""
   title: String
 }
 
@@ -876,23 +923,23 @@ type ParagraphCardGridManual implements ParagraphInterface {
   """The time that the Paragraph was created."""
   created: DateTime!
 
-  """Indhold"""
+  """Content"""
   gridContent: [ParagraphCardGridManualGridContentUnion!]
 
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Flere links"""
+  """More link"""
   moreLink: Link
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
-  """Overskrift"""
+  """Title"""
   title: String
 }
 
-"""Indhold"""
+"""Content"""
 union ParagraphCardGridManualGridContentUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPage | NodePage
 
 """Entity type paragraph."""
@@ -900,7 +947,7 @@ type ParagraphContentSlider implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
-  """Indhold"""
+  """Contents"""
   contentReferences: [ParagraphContentSliderContentReferencesUnion!]
 
   """The time that the Paragraph was created."""
@@ -909,13 +956,13 @@ type ParagraphContentSlider implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
-  """forældet"""
+  """deprecated"""
   title: String
 
-  """Titel"""
+  """Title"""
   underlinedTitle: Text
 }
 
@@ -927,38 +974,38 @@ type ParagraphContentSliderAutomatic implements ParagraphInterface {
   """The time that the Paragraph was created."""
   created: DateTime!
 
-  """Hvis der ikke vælges noget, vil ALT automatisk blive valgt."""
+  """If nothing is selected, all will be chosen."""
   filterBranches: [NodeUnion!]
 
-  """Filtrer efter kategori"""
+  """Filter by categories"""
   filterCategories: [TermUnion!]
 
-  """Tilstandstype"""
+  """Condition type"""
   filterCondType: String!
 
-  """Hvis intet er valgt, vil alt blive valgt."""
+  """If nothing is selected, all will be chosen."""
   filterContentTypes: [String!]
 
-  """Filtrer efter tags"""
+  """Filter by tags"""
   filterTags: [TermUnion!]
 
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
-  """Titel (forældet)"""
+  """deprecated"""
   title: String
 
-  """Titel"""
+  """Title"""
   underlinedTitle: Text
 }
 
-"""Indhold"""
+"""Contents"""
 union ParagraphContentSliderContentReferencesUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPage | NodePage
 
-"""En kombination af navn på billetkategori og pris på et arrangement. """
+"""A combination of ticket category name and price for an event. """
 type ParagraphEventTicketCategory implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -969,15 +1016,15 @@ type ParagraphEventTicketCategory implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
-  """Navn"""
+  """Name"""
   ticketCategoryName: String!
 }
 
 """
-Link med ikoner. Designet til jpg, jpeg, png, pdf, mp3, mov, mp4, og mpeg filer
+Links with icons. Designed for jpg, jpeg, png, pdf, mp3, mov, mp4, mpeg files
 """
 type ParagraphFiles implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
@@ -986,55 +1033,55 @@ type ParagraphFiles implements ParagraphInterface {
   """The time that the Paragraph was created."""
   created: DateTime!
 
-  """Filer"""
+  """Files"""
   files: [MediaUnion!]
 
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
 """
-Denne paragraph viser en liste af arrangementer filtreret på kategori, tags og filialer.
+This paragraph displays a generated a list of events, based on specified filters for tags, categories and branches. 
 """
 type ParagraphFilteredEventList implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
-  """Dette felt bruges ikke længere og vil blive slettet i fremtiden."""
+  """This field is no longer in use, and will be deleted in the future."""
   amountOfEvents: Int
 
   """The time that the Paragraph was created."""
   created: DateTime!
 
-  """Hvis der ikke vælges noget, vil ALT automatisk blive valgt."""
+  """If nothing is selected, all will be chosen."""
   filterBranches: [NodeUnion!]
 
-  """Tilføj en kategori, du vil inkludere"""
+  """Add a category you want to include"""
   filterCategories: [TermUnion!]
 
-  """Tilstandstype"""
+  """Condition type"""
   filterCondType: String!
 
-  """Tilføj et tag, du vil inkludere"""
+  """Add a tag you want to include"""
   filterTags: [TermUnion!]
 
   """The paragraphs entity language code."""
   langcode: Language!
 
   """
-  Vælg antallet af arrangementer, du ønsker at vise. <br /><br />Hvis antallet
-  vist er mindre end det, du har angivet her, skyldes det sandsynligvis, at der
-  ikke er nok resultater baseret på dine valgte filtre.
+  Select the amount of events you want to display. <br /><br />If the amount
+  displayed is less than what you put here, it is likely because there are not
+  enough results based on your selected filters.
   """
   maxItemAmount: String!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
-  """Titel"""
+  """Title"""
   title: String
 }
 
@@ -1054,7 +1101,7 @@ type ParagraphGoImages implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -1079,7 +1126,7 @@ type ParagraphGoLink implements ParagraphInterface {
   """Link"""
   link: Link!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Open link in a new window"""
@@ -1109,7 +1156,7 @@ type ParagraphGoLinkbox implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Title"""
@@ -1141,7 +1188,7 @@ type ParagraphGoMaterialSliderAutomatic implements ParagraphInterface {
   """Amount of materials"""
   sliderAmountOfMaterials: Int!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Title"""
@@ -1169,7 +1216,7 @@ type ParagraphGoMaterialSliderManual implements ParagraphInterface {
   """
   materialSliderWorkIds: [WorkId!]!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Title"""
@@ -1194,11 +1241,11 @@ type ParagraphGoTextBody implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""Angiv URL-en for den video, der skal vises"""
+"""Enter the URL for the video you want to include."""
 type ParagraphGoVideo implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -1206,16 +1253,16 @@ type ParagraphGoVideo implements ParagraphInterface {
   """The time that the Paragraph was created."""
   created: DateTime!
 
-  """Indlagt video"""
+  """Embed video"""
   embedVideo: MediaUnion!
 
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
-  """Titl"""
+  """Title"""
   title: String!
 }
 
@@ -1248,7 +1295,7 @@ type ParagraphGoVideoBundleAutomatic implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """The amount of related materials that should be shown."""
@@ -1275,7 +1322,7 @@ type ParagraphGoVideoBundleManual implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """
@@ -1287,7 +1334,7 @@ type ParagraphGoVideoBundleManual implements ParagraphInterface {
 }
 
 """
-En Hero til placering øverst på forsiden med et billede, informativ tekst, kategori og et link til fremhævet indhold.
+A hero section with an image, informative text, category, and a "call to action" link.
 """
 type ParagraphHero implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
@@ -1296,31 +1343,31 @@ type ParagraphHero implements ParagraphInterface {
   """The time that the Paragraph was created."""
   created: DateTime!
 
-  """Hero kategori"""
+  """Hero categories"""
   heroCategories: TermUnion
 
-  """Hero indholdstype"""
+  """Hero content type"""
   heroContentType: String
 
-  """Hero dato"""
+  """Hero date"""
   heroDate: DateTime
 
-  """Hero beskrivelse"""
+  """Hero description"""
   heroDescription: Text
 
-  """Hero billede"""
+  """Hero image"""
   heroImage: MediaUnion
 
   """Hero link"""
   heroLink: Link
 
-  """Overskrift"""
+  """Hero title"""
   heroTitle: String!
 
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -1335,11 +1382,11 @@ interface ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""Giver besøgende på sitet mulighed for at vælge foretrukket sprog"""
+"""Enables website visitors to choose their preferred language."""
 type ParagraphLanguageSelector implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -1350,15 +1397,15 @@ type ParagraphLanguageSelector implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Sprogikon"""
+  """Language icon"""
   languageIcon: Image!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
 """
-Links med ikoner. Designet til interne/eksterne links og links til søgeresultater ␣.
+Links with icons. Designed for internal/external links and links to search results. 
 """
 type ParagraphLinks implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
@@ -1373,13 +1420,11 @@ type ParagraphLinks implements ParagraphInterface {
   """Link"""
   link: [Link!]!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""
-Dette afsnit vil vise en liste over arrangementer, der er manuelt valgt.
-"""
+"""This paragraph will show a list of events that are manually selected."""
 type ParagraphManualEventList implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -1387,38 +1432,41 @@ type ParagraphManualEventList implements ParagraphInterface {
   """The time that the Paragraph was created."""
   created: DateTime!
 
-  """Arrangementer"""
+  """Events"""
   events: [UnsupportedType!]
 
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
-  """Titel"""
+  """Title"""
   title: String
 }
 
-"""En visning af fremhævede værker, baseret på en CQL søgestreng."""
+"""
+Please use the "Material grid link automatically" instead! This paragraph will be deprecated in the future.
+A grid representation of recommended materials, based on a CQL search string. 
+"""
 type ParagraphMaterialGridAutomatic implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
   """
-  Bestemmer mængden af materialer, der vil blive vist, baseret på
-  CQL-strengen. <br /><br />Obs: Hvis for eksempel en CQL-streng har 11
-  resultater, og en redaktør vælger 12. Listen vil vise 8 i stedet for 11, da
-  gitteret skal kunne øges med 4.
+  Determines the amount of materials that will be shown, based on the CQL
+  string. <br /><br />Obs: If for example a CQL string has 11 results, and an
+  editor chooses 12. The list will display 8 instead of 11, since the grid
+  should be able to increment by 4.
   """
   amountOfMaterials: Int!
 
   """
-  Dette felt er til indsættelse af en CQL-streng baseret på en søgning. <br
-  /><br />Vær opmærksom på, at det er nødvendigt at kopiere den nøjagtige
-  CQL-streng, inklusive anførselstegnene. dvs: ('harry potter')<br /><br />En
-  gyldig CQL-søgestreng kan genereres ved at udføre en forespørgsel gennem
-  den avancerede søgning og kopiere CQL-strengen derfra.
+  This field is for inserting a CQL string based on a search. <br /><br />Please
+  be aware, that it is necessary to copy the exact CQL string, including the
+  quotations. i.e: ( 'harry potter')<br /><br />A valid CQL search string can be
+  generated, by performing a query through the advanced search, and copying the
+  CQL string from there.
   """
   cqlSearch: CQLSearch!
 
@@ -1429,17 +1477,16 @@ type ParagraphMaterialGridAutomatic implements ParagraphInterface {
   langcode: Language!
 
   """
-  Dette er en valgfri beskrivelsestekst, der kan ledsage materiale grid'et. Lad
-  feltet være tomt, hvis du ikke ønsker en beskrivelse.
+  This is the optional description for the material grid. <br />Leave blank if you do not want a description.
   """
   materialGridDescription: String
 
   """
-  Titel på materialekomponenten. Efterlad dette felt blankt, hvis du ikke vil give den en overskrift.
+  The title for the material grid. Leave this blank if you do not want a title. 
   """
   materialGridTitle: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -1482,11 +1529,11 @@ type ParagraphMaterialGridLinkAutomatic implements ParagraphInterface {
   """
   materialGridTitle: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""En komponent som viser en liste af manuelt udvalgte værker."""
+"""A grid displaying a list of recommended materials selected manually."""
 type ParagraphMaterialGridManual implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -1498,29 +1545,28 @@ type ParagraphMaterialGridManual implements ParagraphInterface {
   langcode: Language!
 
   """
-  Dette er en valgfri beskrivelsestekst, der kan ledsage materiale grid'et. Lad
-  feltet være tomt, hvis du ikke ønsker en beskrivelse.
+  This is the optional description for the material grid. <br />Leave blank if you do not want a description.
   """
   materialGridDescription: String
 
   """
-  Titel på materialekomponenten. Efterlad dette felt blankt, hvis du ikke vil give den en overskrift.
+  The title for the material grid. Leave this blank if you do not want a title. 
   """
   materialGridTitle: String
 
   """
-  Gitteret vil kun vise materialer i intervaller af 4. <br /><br />Eksempel
-  arbejds ID: work-of:870970-basis:136336282.<br /><br />Hvis du skal linke til
-  en specifik type, vælg den fra dropdown-menuen og systemet vil vise den, hvis
-  den er tilgængelig.
+  The grid will only display materials in internvals of 4. <br /><br />Example
+  work ID: work-of:870970-basis:136336282.<br /><br />If you need to link to a
+  specific type, select it from the dropdown and the system will display that,
+  if it is available.
   """
   materialGridWorkIds: [WorkId!]
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """
-  Dette felt vil blive slettet i fremtiden. Brug venligst det andet VærkID felt.
+  This field will be deleted in the future. Please use another work id field.
   """
   workId: [WorkId!]
 }
@@ -1536,10 +1582,10 @@ type ParagraphMedias implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Billeder"""
+  """Medias"""
   medias: [MediaUnion!]!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -1548,7 +1594,7 @@ type ParagraphNavGridManual implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
-  """Indhold"""
+  """Contents"""
   contentReferences: [ParagraphNavGridManualContentReferencesUnion!]
 
   """The time that the Paragraph was created."""
@@ -1557,14 +1603,14 @@ type ParagraphNavGridManual implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Vis manchettekster"""
+  """Show subtitles"""
   showSubtitles: Boolean
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""Indhold"""
+"""Contents"""
 union ParagraphNavGridManualContentReferencesUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPage | NodePage
 
 """Entity type paragraph."""
@@ -1578,7 +1624,7 @@ type ParagraphNavSpotsManual implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -1597,11 +1643,11 @@ type ParagraphOpeningHours implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""Denne paragraph bruges til at anbefale et enkelt materiale."""
+"""This paragraph is used to recommend a material. """
 type ParagraphRecommendation implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -1610,9 +1656,9 @@ type ParagraphRecommendation implements ParagraphInterface {
   created: DateTime!
 
   """
-  Dette bestemmer om, et billede skal positioneres til venstre eller højre. <br
-  />Hvis den ikke er slået til (standardadfærd), placeres billedet til
-  venstre, hvis den er slået til, placeres billedet til højre.␣
+  This determines whether the image should be positioned to the left or right.
+  <br />If left untoggled (default behaviour) the image is positioned to the
+  left, if toggled on, the image will be positioned to the right.
   """
   imagePositionRight: Boolean
 
@@ -1620,31 +1666,31 @@ type ParagraphRecommendation implements ParagraphInterface {
   langcode: Language!
 
   """
-  Dette er beskrivelsen af det anbefalede materiale. Hvis du tilføjer en
-  beskrivelsestekst, vil titlen på materialet ikke blive autoudfyldt.
+  This is the description for a recommendation. <br /><br />If you add a
+  description, the title of the the material will not be automatically
   """
   recommendationDescription: String
 
   """
-  Titlen på det anbefalede materiale. Hvis du tilføjer en titel, vil
-  beskrivelsesteksten af materialet ikke blive autoudfyldt.
+  The title of the recommended material.<br /><br />If you add a title, the
+  description for the material will not be automatically generated.
   """
   recommendationTitle: Text
 
   """
-  Dette er det arbejds-ID, der bruges til at hente materialeoplysningerne.
-  Eksempel: work-of:870970-basis:136336282.<br />I øjeblikket hentes dette ved
-  at udføre en søgning efter et materiale manuelt og kopiere denne værdi fra
-  URL'en.<br />Hvis du har brug for at linke til en bestemt type, skal du vælge
-  den fra rullemenuen, og systemet vil vise den, hvis den er tilgængelig.
+  This is the work ID used to retrieve the material information. Example:
+  work-of:870970-basis:136336282.<br />Currently this is retrieved by performing
+  a search for a material manually, and copying this value from the URL.<br />If
+  you need to link to a specific type, select it from the dropdown and the
+  system will display that, if it is available.
   """
   recommendationWorkId: WorkId
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""Denne paragraph viser links uden ikoner."""
+"""This is paragraph that will display links without icons. """
 type ParagraphSimpleLinks implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -1658,16 +1704,16 @@ type ParagraphSimpleLinks implements ParagraphInterface {
   """Link"""
   link: [Link!]!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""En basal, formateret brødtekst"""
+"""A basic, formatted body of text."""
 type ParagraphTextBody implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
-  """Brødtekst"""
+  """Body"""
   body: Text!
 
   """The time that the Paragraph was created."""
@@ -1676,7 +1722,7 @@ type ParagraphTextBody implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -1684,23 +1730,23 @@ type ParagraphTextBody implements ParagraphInterface {
 union ParagraphUnion = ParagraphAccordion | ParagraphBanner | ParagraphBreadcrumbChildren | ParagraphCampaignRule | ParagraphCardGridAutomatic | ParagraphCardGridManual | ParagraphContentSlider | ParagraphContentSliderAutomatic | ParagraphEventTicketCategory | ParagraphFiles | ParagraphFilteredEventList | ParagraphGoImages | ParagraphGoLink | ParagraphGoLinkbox | ParagraphGoMaterialSliderAutomatic | ParagraphGoMaterialSliderManual | ParagraphGoTextBody | ParagraphGoVideo | ParagraphGoVideoBundleAutomatic | ParagraphGoVideoBundleManual | ParagraphHero | ParagraphLanguageSelector | ParagraphLinks | ParagraphManualEventList | ParagraphMaterialGridAutomatic | ParagraphMaterialGridLinkAutomatic | ParagraphMaterialGridManual | ParagraphMedias | ParagraphNavGridManual | ParagraphNavSpotsManual | ParagraphOpeningHours | ParagraphRecommendation | ParagraphSimpleLinks | ParagraphTextBody | ParagraphUserRegistrationItem | ParagraphUserRegistrationLinklist | ParagraphUserRegistrationSection | ParagraphVideo | ParagraphWebform
 
 """
-"Brugerregistreringselement" anvendes til at vise relevant information om brugerregistreringsprocessen.
+The "User registration item" paragraph type is used to display relevant information about the user registration process.
 """
 type ParagraphUserRegistrationItem implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
 
-  """Anker"""
+  """Anchor"""
   anchor: String
 
-  """Brødtekst"""
+  """Body"""
   body: Text!
 
   """The time that the Paragraph was created."""
   created: DateTime!
 
   """
-  Aktivér denne indstilling for at få vist en knap øverst på siden, så det er nemmere at navigere.
+  Enable this option to display a button at the top of the page for easier navigation.
   """
   displayInNavigation: Boolean
 
@@ -1708,26 +1754,26 @@ type ParagraphUserRegistrationItem implements ParagraphInterface {
   langcode: Language!
 
   """
-  Angiv hvordan et linket dokument skal åbne når en bruger klikker på linket.
+  Specify how a linked document should be opened when clicked by a user.
   """
   linkTarget: String!
 
   """
-  Hvis titelfeltet på navigationsknappen ikke udfyldes, vil den automatisk få titlen på denne Paragraph.
+  If the navigation button title is left blank, it will automatically default to the paragraph title.
   """
   navigationTitle: String
 
-  """Registreringslink"""
+  """Registration Link"""
   registrationLink: Link
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
 """
-Denne paragraph bestemmer placeringen af genveje til
-"Brugeregistreingsparagraphs". Paragraphen tillader redaktører at specificere,
-om disse genveje skal vises.
+This paragraph determines the placement of shortcuts to individual User
+Registration Section paragraphs. It allows administrators to specify where these
+shortcuts should appear.
 """
 type ParagraphUserRegistrationLinklist implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
@@ -1739,12 +1785,12 @@ type ParagraphUserRegistrationLinklist implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
 """
-"Brugerregistreringsparagraph" bruges til at vise "Brugerregistreringselementer".
+The "User registration section" paragraph type is used to display "User registration item" paragraphs.
 """
 type ParagraphUserRegistrationSection implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
@@ -1756,11 +1802,11 @@ type ParagraphUserRegistrationSection implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""Indtast URL'en til den video, du vil indlejre."""
+"""Enter the URL for the video you want to include."""
 type ParagraphVideo implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -1768,17 +1814,17 @@ type ParagraphVideo implements ParagraphInterface {
   """The time that the Paragraph was created."""
   created: DateTime!
 
-  """Indlejr video"""
+  """Embed video"""
   embedVideo: MediaUnion!
 
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
-"""Paragraph brugt til indlejring af en webformular."""
+"""Paragraph used for embedding a webform."""
 type ParagraphWebform implements ParagraphInterface {
   """The Universally Unique IDentifier (UUID)."""
   id: ID!
@@ -1789,7 +1835,7 @@ type ParagraphWebform implements ParagraphInterface {
   """The paragraphs entity language code."""
   langcode: Language!
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 }
 
@@ -1830,9 +1876,6 @@ type Query {
     revision: ID
   ): NodeUnion
 
-  """DPL Configuration"""
-  dplConfiguration: DplConfiguration
-
   """Schema information."""
   info: SchemaInformation!
 
@@ -1852,6 +1895,12 @@ type Query {
     """
     langcode: String
   ): RouteUnion
+
+  """Query for view go_categories display go_categories."""
+  goCategories(
+    """The page number to display."""
+    page: Int = 0
+  ): GoCategoriesResult
 }
 
 """Routes represent incoming requests that resolve to content."""
@@ -1951,11 +2000,11 @@ type TermBreadcrumbStructure implements TermInterface {
   changed: DateTime!
 
   """
-  Titlen, der vises over listen af refereret indhold. Vil ikke blive vist, hvis der ikke vises nogen børn.
+  The title that is shown above the list of referenced content. Will not be shown, if there are no children displayed.
   """
   childrenTitle: String
 
-  """Indhold der linkes til"""
+  """Content"""
   content: NodeUnion!
 
   """Beskrivelse"""
@@ -1964,7 +2013,7 @@ type TermBreadcrumbStructure implements TermInterface {
   """Term sprogkode."""
   langcode: Language!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Denne terms overordnede termer."""
@@ -1974,16 +2023,16 @@ type TermBreadcrumbStructure implements TermInterface {
   path: String
 
   """
-  Vis en automatisk liste med indhold, som refererer til dette brødkrumme element, på denne side.
+  Should a list of contents that reference this breadcrumb, be shown automatically on this page?
   """
   showChildren: Boolean
 
   """
-  Sæt hak her, hvis børnebrødkrummen skal udfoldes med eventuelle undertitel
+  If this is checked, the children teasers will be expanded with possible subtitle descriptions.
   """
   showChildrenSubtitles: Boolean
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Vægten af denne term i forhold til andre termer."""
@@ -2004,7 +2053,7 @@ type TermCategories implements TermInterface {
   """Term sprogkode."""
   langcode: Language!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Denne terms overordnede termer."""
@@ -2013,7 +2062,7 @@ type TermCategories implements TermInterface {
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Vægten af denne term i forhold til andre termer."""
@@ -2034,7 +2083,7 @@ interface TermInterface {
   """Term sprogkode."""
   langcode: Language!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Denne terms overordnede termer."""
@@ -2043,7 +2092,7 @@ interface TermInterface {
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Vægten af denne term i forhold til andre termer."""
@@ -2066,7 +2115,7 @@ type TermOpeningHoursCategories implements TermInterface {
   """Term sprogkode."""
   langcode: Language!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Denne terms overordnede termer."""
@@ -2075,7 +2124,7 @@ type TermOpeningHoursCategories implements TermInterface {
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Vægten af denne term i forhold til andre termer."""
@@ -2096,7 +2145,7 @@ type TermScreenName implements TermInterface {
   """Term sprogkode."""
   langcode: Language!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Denne terms overordnede termer."""
@@ -2105,7 +2154,7 @@ type TermScreenName implements TermInterface {
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Vægten af denne term i forhold til andre termer."""
@@ -2126,7 +2175,7 @@ type TermTags implements TermInterface {
   """Term sprogkode."""
   langcode: Language!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Denne terms overordnede termer."""
@@ -2135,7 +2184,7 @@ type TermTags implements TermInterface {
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Vægten af denne term i forhold til andre termer."""
@@ -2158,13 +2207,13 @@ type TermWebformEmailCategories implements TermInterface {
   """Beskrivelse"""
   description: Text!
 
-  """Tilføj den e-mail, som henvendelser i denne kategori skal sendes til."""
+  """Add which email to send form submissions of this category to."""
   email: Email!
 
   """Term sprogkode."""
   langcode: Language!
 
-  """Navn"""
+  """Name"""
   name: String!
 
   """Denne terms overordnede termer."""
@@ -2173,7 +2222,7 @@ type TermWebformEmailCategories implements TermInterface {
   """Alternativ URL"""
   path: String
 
-  """Publiceret"""
+  """Published"""
   status: Boolean!
 
   """Vægten af denne term i forhold til andre termer."""
@@ -2254,6 +2303,104 @@ scalar UntypedStructuredData
 
 """A string that will have a value of format ±hh:mm"""
 scalar UtcOffset
+
+"""Views represent collections of curated data from the CMS."""
+interface View {
+  """The ID of the view."""
+  id: ID!
+
+  """The machine name of the view."""
+  view: String!
+
+  """The machine name of the display."""
+  display: String!
+
+  """The language code of the view."""
+  langcode: String
+
+  """The human friendly label of the view."""
+  label: String
+
+  """Viewets beskrivelse."""
+  description: String
+
+  """Information about the page in the view."""
+  pageInfo: ViewPageInfo!
+}
+
+"""An exposed filter option for the view."""
+type ViewFilter {
+  """The filter identifier."""
+  id: ID!
+
+  """The filter plugin type."""
+  plugin: String!
+
+  """The filter element type."""
+  type: String!
+
+  """The filter operator."""
+  operator: String!
+
+  """The filter element label."""
+  label: String
+
+  """The filter element description."""
+  description: String
+
+  """Whether the filter is required."""
+  required: Boolean!
+
+  """Whether the filter allows multiple values."""
+  multiple: Boolean!
+
+  """The value for the filter. Could be an array for multiple values."""
+  value: UntypedStructuredData
+
+  """The filter element options if any are defined."""
+  options: UntypedStructuredData
+
+  """The filter element attributes."""
+  attributes: UntypedStructuredData!
+}
+
+"""Information about the page in a view."""
+type ViewPageInfo {
+  """Any result offset being used."""
+  offset: Int!
+
+  """The current page being returned."""
+  page: Int!
+
+  """How many results per page."""
+  pageSize: Int!
+
+  """How many results total."""
+  total: Int!
+}
+
+"""A reference to an embedded view"""
+type ViewReference {
+  """The machine name of the view."""
+  view: String!
+
+  """The machine name of the display."""
+  display: String!
+
+  """The contextual filter values used."""
+  contextualFilter: [String!]
+
+  """How many results per page."""
+  pageSize: Int
+
+  """
+  The name of the query used to fetch the data, if the view is a GraphQL display.
+  """
+  query: String
+}
+
+"""All available view result types."""
+union ViewResultUnion = GoCategoriesResult
 
 scalar Violation
 


### PR DESCRIPTION
#### Description

Currently the test to ensure GraphQL schema and client code integrity introduced in #2215 does not work. The tests do nothing as the tested site has not been enabled for BNF workflows.

To address this we:

- Enable BNF before running tasks that require it
- Include the schema file in what is being tested
- Update the stored schema to match the actual code

This matches our workflow for OpenAPI.