### PR TITLE
Make clearing varnis work in bnf

### DIFF
--- a/docker-compose.bnf.yml
+++ b/docker-compose.bnf.yml
@@ -64,6 +64,7 @@ services:
       # Is used by [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) or [dory](https://github.com/FreedomBen/dory)
       VIRTUAL_HOST: ${COMPOSE_PROJECT_NAME}-bnfvarnish.${DEV_TLD:-docker}
       VIRTUAL_PORT: 8080
+      SERVICE_NAME: bnfvarnish
 
   bnfcli: # cli container, will be used for executing composer and any local commands (drush, drupal, etc.)
     # https://docs.lagoon.sh/lagoon/docker-images/nginx/nginx-drupal

--- a/web/sites/bnf/settings.php
+++ b/web/sites/bnf/settings.php
@@ -8,6 +8,12 @@
  * settings.lagoon.php that contains Lagoon-specific settings.
  */
 
+// Override the configured varnish hostname so Drupal will purge the right
+// instance. The hex numbers is the ID of the configured purgers, these should
+// follow the ones in the exported configuration.
+$config['varnish_purger.settings.30cd45a1b1']['hostname'] = 'bnfvarnish';
+$config['varnish_purger.settings.65fc931232']['hostname'] = 'bnfvarnish';
+
 /**
  * Load services definition file.
  */


### PR DESCRIPTION
Make `drush cache:rebuild-external` work for `bnfcli`.