### PR TITLE
Reintroduce access to BNF for normal library roles

### DIFF
--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -27,6 +27,7 @@ dependencies:
   module:
     - administerusersbyrole
     - block
+    - bnf
     - config_perms
     - content_lock
     - cookieinformation
@@ -125,6 +126,7 @@ permissions:
   - 'administer webform'
   - 'administer webform element access'
   - 'administer webform submission'
+  - 'bnf import nodes'
   - 'break content lock'
   - 'cancel users by role'
   - 'change own username'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -25,6 +25,7 @@ dependencies:
     - taxonomy.vocabulary.webform_email_categories
   module:
     - administerusersbyrole
+    - bnf
     - content_lock
     - dpl_admin
     - dpl_footer
@@ -72,6 +73,7 @@ permissions:
   - 'administer menu'
   - 'administer nodes'
   - 'administer redirects'
+  - 'bnf import nodes'
   - 'break content lock'
   - 'change own username'
   - 'clone eventinstance entity'

--- a/config/sync/user.role.local_administrator.yml
+++ b/config/sync/user.role.local_administrator.yml
@@ -26,6 +26,7 @@ dependencies:
     - taxonomy.vocabulary.webform_email_categories
   module:
     - administerusersbyrole
+    - bnf
     - content_lock
     - dpl_admin
     - dpl_cache_settings
@@ -98,6 +99,7 @@ permissions:
   - 'administer themes'
   - 'administer themes novel'
   - 'administer url proxy configuration'
+  - 'bnf import nodes'
   - 'break content lock'
   - 'cancel users by role'
   - 'change own username'

--- a/config/sync/user.role.mediator.yml
+++ b/config/sync/user.role.mediator.yml
@@ -18,6 +18,7 @@ dependencies:
     - taxonomy.vocabulary.tags
   module:
     - administerusersbyrole
+    - bnf
     - content_lock
     - dpl_admin
     - entity_clone
@@ -53,6 +54,7 @@ permissions:
   - 'add eventseries entity'
   - 'administer entity field inheritance'
   - 'administer redirects'
+  - 'bnf import nodes'
   - 'break content lock'
   - 'change own username'
   - 'clone eventinstance entity'


### PR DESCRIPTION
Reverts danskernesdigitalebibliotek/dpl-cms#2273

Let's try again now that we have a working staging environment for the BNF site to use with the normal staging site.