### PR TITLE
Never show unpublished content on /search/web/CATEGORY.

### DIFF
--- a/config/sync/views.view.editorial_search.yml
+++ b/config/sync/views.view.editorial_search.yml
@@ -365,7 +365,45 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-      filters: {  }
+      filters:
+        status:
+          id: status
+          table: search_api_index_content_events
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
This has previously been fixed (by me) on the /search/web, but apparantly I've forgotten to add the same filter to the other view display, that is shown on tag and category pages.

DDFSAL-82
