### PR TITLE
Set sorting by `changed` on `/search/web/TERM` page.

### DIFF
--- a/config/sync/search_api.index.content_events.yml
+++ b/config/sync/search_api.index.content_events.yml
@@ -29,6 +29,15 @@ field_settings:
       fields:
         - 'entity:eventseries/field_categories'
         - 'entity:node/field_categories'
+  changed:
+    label: 'Changed (Aggregrated)'
+    property_path: aggregated_field
+    type: date
+    configuration:
+      type: union
+      fields:
+        - 'entity:eventseries/changed'
+        - 'entity:node/changed'
   field_branch:
     label: Branch
     datasource_id: 'entity:node'

--- a/config/sync/views.view.editorial_search.yml
+++ b/config/sync/views.view.editorial_search.yml
@@ -304,6 +304,20 @@ display:
     display_plugin: block
     position: 2
     display_options:
+      sorts:
+        changed:
+          id: changed
+          table: search_api_index_content_events
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments:
         categories:
           id: categories
@@ -409,6 +423,7 @@ display:
         groups:
           1: AND
       defaults:
+        sorts: false
         arguments: false
         filters: false
         filter_groups: false


### PR DESCRIPTION
The category/tag search, that is shown on the canonical page, is currently being sorted by `relevance`, just like the  `/search/web` page
- but, it makes no sense, as there is no user input. Instead, we'd like this page to be sorted by the latest updated content (`changed`).
This includes creating an aggregrated field in search API, as we both have eventseries and node entity types.
DDFSAL-71
