### PR TITLE
DDFSAL-77 - Exclude selected routes from Mapp tracking logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,10 @@
             "type": "package",
             "package": {
                 "name": "danskernesdigitalebibliotek/dpl-react",
-                "version": "2025.18.0",
+                "version": "0.0.0-dev",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/2025.18.0/dist-2025-18-0-4245be666dcc0486df3ede1db1e0b107e7b6a410.zip",
+                    "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/branch-DDFSAL-77-fix-page-parameters/dist-ddfsal-77-fix-page-parameters.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -92,7 +92,7 @@
         "cweagans/composer-patches": "1.7.3",
         "danskernesdigitalebibliotek/cms-api": "*",
         "danskernesdigitalebibliotek/dpl-design-system": "2025.18.0",
-        "danskernesdigitalebibliotek/dpl-react": "2025.18.0",
+        "danskernesdigitalebibliotek/dpl-react": "0.0.0-dev",
         "danskernesdigitalebibliotek/fbs-client": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
         "deoliveiralucas/array-keys-case-transform": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86ae3628f43f29311247fc4a165b609f",
+    "content-hash": "0f82866221cfd10a90de1e0103916a34",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -1175,10 +1175,10 @@
         },
         {
             "name": "danskernesdigitalebibliotek/dpl-react",
-            "version": "2025.18.0",
+            "version": "0.0.0-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/2025.18.0/dist-2025-18-0-4245be666dcc0486df3ede1db1e0b107e7b6a410.zip"
+                "url": "https://github.com/danskernesdigitalebibliotek/dpl-react/releases/download/branch-DDFSAL-77-fix-page-parameters/dist-ddfsal-77-fix-page-parameters.zip"
             },
             "require": {
                 "composer/installers": "^1.2.0"
@@ -20797,6 +20797,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "danskernesdigitalebibliotek/dpl-react": 20,
         "drupal/default_content": 15,
         "drupal/gin": 5,
         "drupal/gin_toolbar": 5,

--- a/web/modules/custom/dpl_mapp/dpl_mapp.module
+++ b/web/modules/custom/dpl_mapp/dpl_mapp.module
@@ -14,9 +14,16 @@ use Drupal\Core\Cache\Cache;
  *   The page render array.
  */
 function dpl_mapp_page_attachments(array &$page): void {
-  // Disable tracking on admin pages. We interested in patron - not editor -
-  // behavior.
-  if (\Drupal::routeMatch()->getRouteObject()?->getOption('_admin_route')) {
+  $is_admin_route = \Drupal::service('router.admin_context')->isAdminRoute();
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $is_excluded_route = in_array($route_name, [
+    'dpl_react_apps.search_result',
+    'dpl_react_apps.work',
+  ]);
+
+  // Disable tracking on admin pages (we are only interested in patron behavior)
+  // and on specific routes (some pages should only track data from React apps)
+  if ($is_admin_route || $is_excluded_route) {
     return;
   }
 

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -33,6 +33,7 @@ class DplReactAppsController extends ControllerBase {
     protected BranchRepositoryInterface $branchRepository,
     protected DplInstantLoanSettings $instantLoanSettings,
     protected GeneralSettings $generalSettings,
+    protected $configFactory,
   ) {}
 
   /**
@@ -51,6 +52,7 @@ class DplReactAppsController extends ControllerBase {
       $container->get('dpl_library_agency.branch.repository'),
       $container->get('dpl_instant_loan.settings'),
       $container->get('dpl_library_agency.general_settings'),
+      $container->get('config.factory'),
     );
   }
 
@@ -271,6 +273,8 @@ class DplReactAppsController extends ControllerBase {
       'sms-notifications-for-reservations-enabled-config' => (int) $this->reservationSettings->smsNotificationsIsEnabled(),
       'instant-loan-config' => $this->instantLoanSettings->getConfig(),
       'interest-periods-config' => json_encode($this->generalSettings->getInterestPeriodsConfig()),
+      'mapp-domain-config' => $this->configFactory->get('dpl_mapp.settings')->get('domain'),
+      'mapp-id-config' => $this->configFactory->get('dpl_mapp.settings')->get('id'),
 
       // Texts.
       'already-reserved-text' => $this->t('Already reserved', [], ['context' => 'Work Page']),


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-77

#### Description
This pull request disables tracking for the `search_result` and `work` pages. 
Tracking should instead be handled within the React application, where the necessary data is available. This change also helps avoid unnecessary calls.

#### Test
https://varnish.pr-2305.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2305