### PR TITLE
Ddfsal 15 login logout

### DIFF
--- a/web/modules/custom/dpl_login/dpl_login.services.yml
+++ b/web/modules/custom/dpl_login/dpl_login.services.yml
@@ -18,6 +18,8 @@ services:
     arguments:
       - '@dpl_login.registered_user_tokens'
       - '@dpl_login.unregistered_user_tokens'
+  Drupal\dpl_login\UserTokens: '@dpl_login.user_tokens'
+
   dpl_login.authentication.user_token:
     class: Drupal\dpl_login\UserTokenAuthProvider
     arguments:
@@ -46,6 +48,8 @@ services:
   dpl_login.adgangsplatformen.config:
     class: Drupal\dpl_login\Adgangsplatformen\Config
     arguments: ['@config.manager']
+  Drupal\dpl_login\Adgangsplatformen\Config: '@dpl_login.adgangsplatformen.config'
+
   dpl_login.openid_user_info:
     class: Drupal\dpl_login\OpenIdUserInfoService
     arguments: ['@settings']

--- a/web/modules/custom/dpl_login/src/Controller/DplLoginController.php
+++ b/web/modules/custom/dpl_login/src/Controller/DplLoginController.php
@@ -3,7 +3,6 @@
 namespace Drupal\dpl_login\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
@@ -12,7 +11,6 @@ use Drupal\dpl_login\Exception\MissingConfigurationException;
 use Drupal\dpl_login\UserTokens;
 use Drupal\openid_connect\OpenIDConnectClaims;
 use Drupal\openid_connect\OpenIDConnectSessionInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,28 +30,7 @@ class DplLoginController extends ControllerBase {
     protected Config $config,
     protected OpenIDConnectClaims $claims,
     protected OpenIDConnectSessionInterface $session,
-    protected EntityTypeManagerInterface $entity_type_manager,
-  ) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
-
-  /**
-   * {@inheritdoc}
-   *
-   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-   *   The Drupal service container.
-   *
-   * @return static
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('dpl_login.user_tokens'),
-      $container->get('dpl_login.adgangsplatformen.config'),
-      $container->get('openid_connect.claims'),
-      $container->get('openid_connect.session'),
-      $container->get('entity_type.manager'),
-    );
-  }
+  ) {}
 
   /**
    * Logs out user externally and internally.

--- a/web/modules/custom/dpl_login/src/Controller/DplLoginController.php
+++ b/web/modules/custom/dpl_login/src/Controller/DplLoginController.php
@@ -6,6 +6,7 @@ namespace Drupal\dpl_login\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Routing\LocalRedirectResponse;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
@@ -120,6 +121,11 @@ class DplLoginController extends ControllerBase {
       ]);
 
       user_logout();
+
+      // As we just nuked the session above, trying to save `current-path` in
+      // session isn't going to work, so redirect to ourselves to get a fresh
+      // session.
+      return new LocalRedirectResponse($request->getUri());
     }
 
     $this->session->saveOp('login');

--- a/web/modules/custom/dpl_login/src/Controller/DplLoginController.php
+++ b/web/modules/custom/dpl_login/src/Controller/DplLoginController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\dpl_login\Controller;
 
 use Drupal\Core\Controller\ControllerBase;

--- a/web/modules/custom/dpl_patron_reg/dpl_patron_reg.routing.yml
+++ b/web/modules/custom/dpl_patron_reg/dpl_patron_reg.routing.yml
@@ -21,7 +21,7 @@ dpl_patron_reg.auth:
 dpl_patron_reg.create:
   path: '/user/registration/create'
   defaults:
-    _controller: '\Drupal\dpl_patron_reg\Controller\DplPatronRegController::userRegistrationReactAppLoad'
+    _controller: '\Drupal\dpl_patron_reg\Controller\DplPatronRegReactController::userRegistrationReactAppLoad'
   requirements:
     _permission: 'access content'
   options:

--- a/web/modules/custom/dpl_patron_reg/dpl_patron_reg.services.yml
+++ b/web/modules/custom/dpl_patron_reg/dpl_patron_reg.services.yml
@@ -2,3 +2,4 @@ services:
   dpl_patron_reg.settings:
     class: Drupal\dpl_patron_reg\DplPatronRegSettings
     arguments: ['@config.manager']
+  Drupal\dpl_patron_reg\DplPatronRegSettings: '@dpl_patron_reg.settings'

--- a/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
+++ b/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
@@ -8,7 +8,6 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
 use Drupal\openid_connect\OpenIDConnectClaims;
 use Drupal\openid_connect\OpenIDConnectSession;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -23,16 +22,6 @@ class DplPatronRegController extends ControllerBase {
     protected OpenIDConnectSession $session,
     protected OpenIDConnectClaims $claims,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container): DplPatronRegController|static {
-    return new static(
-      $container->get('openid_connect.session'),
-      $container->get('openid_connect.claims'),
-    );
-  }
 
   /**
    * Redirect callback that redirects to log in service.

--- a/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
+++ b/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
@@ -8,7 +8,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
 use Drupal\openid_connect\OpenIDConnectClaims;
-use Drupal\openid_connect\OpenIDConnectSession;
+use Drupal\openid_connect\OpenIDConnectSessionInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -25,7 +25,7 @@ class DplPatronRegController extends ControllerBase {
    * {@inheritdoc}
    */
   public function __construct(
-    protected OpenIDConnectSession $session,
+    protected OpenIDConnectSessionInterface $session,
     protected OpenIDConnectClaims $claims,
   ) {
     $this->clientStorage = $this->entityTypeManager()->getStorage('openid_connect_client');

--- a/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
+++ b/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
@@ -5,7 +5,6 @@ namespace Drupal\dpl_patron_reg\Controller;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
@@ -37,10 +36,7 @@ class DplPatronRegController extends ControllerBase {
     protected BlockManagerInterface $blockManager,
     protected RendererInterface $renderer,
     protected DplReactConfigInterface $patronRegSettings,
-    protected EntityTypeManagerInterface $entity_type_manager,
-  ) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  ) {}
 
   /**
    * {@inheritdoc}
@@ -56,7 +52,6 @@ class DplPatronRegController extends ControllerBase {
       $container->get('plugin.manager.block'),
       $container->get('renderer'),
       $container->get('dpl_patron_reg.settings'),
-      $container->get('entity_type.manager'),
     );
   }
 
@@ -77,7 +72,7 @@ class DplPatronRegController extends ControllerBase {
     $this->session->saveDestination();
 
     /** @var \Drupal\openid_connect\OpenIDConnectClientEntityInterface $client */
-    $client = $this->entityTypeManager->getStorage('openid_connect_client')->loadByProperties(['id' => $client_name])[$client_name];
+    $client = $this->entityTypeManager()->getStorage('openid_connect_client')->loadByProperties(['id' => $client_name])[$client_name];
 
     $plugin = $client->getPlugin();
     $scopes = $this->claims->getScopes($plugin);

--- a/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
+++ b/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
@@ -6,9 +6,6 @@ use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
-use Drupal\dpl_library_agency\Branch\BranchRepositoryInterface;
-use Drupal\dpl_library_agency\BranchSettings;
-use Drupal\dpl_login\UserTokensProviderInterface;
 use Drupal\openid_connect\OpenIDConnectClaims;
 use Drupal\openid_connect\OpenIDConnectSession;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -23,12 +20,8 @@ class DplPatronRegController extends ControllerBase {
    * {@inheritdoc}
    */
   public function __construct(
-    protected UserTokensProviderInterface $userTokensProvider,
-    protected UserTokensProviderInterface $unregisteredUserTokensProvider,
     protected OpenIDConnectSession $session,
     protected OpenIDConnectClaims $claims,
-    protected BranchSettings $branchSettings,
-    protected BranchRepositoryInterface $branchRepository,
   ) {}
 
   /**
@@ -36,12 +29,8 @@ class DplPatronRegController extends ControllerBase {
    */
   public static function create(ContainerInterface $container): DplPatronRegController|static {
     return new static(
-      $container->get('dpl_login.registered_user_tokens'),
-      $container->get('dpl_login.unregistered_user_tokens'),
       $container->get('openid_connect.session'),
       $container->get('openid_connect.claims'),
-      $container->get('dpl_library_agency.branch_settings'),
-      $container->get('dpl_library_agency.branch.repository'),
     );
   }
 

--- a/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
+++ b/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegController.php
@@ -45,6 +45,12 @@ class DplPatronRegController extends ControllerBase {
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function authRedirect(Request $request, string $client_name): TrustedRedirectResponse {
+    // If we're logged in, logout the current user, else openid_connect will
+    // throw an exception on return.
+    if ($this->currentUser()->isAuthenticated()) {
+      user_logout();
+    }
+
     $this->session->saveDestination();
 
     /** @var null|\Drupal\openid_connect\OpenIDConnectClientEntityInterface $client */

--- a/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegReactController.php
+++ b/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegReactController.php
@@ -7,7 +7,7 @@ namespace Drupal\dpl_patron_reg\Controller;
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Render\RendererInterface;
-use Drupal\dpl_react\DplReactConfigInterface;
+use Drupal\dpl_patron_reg\DplPatronRegSettings;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
@@ -21,7 +21,7 @@ class DplPatronRegReactController extends ControllerBase {
   public function __construct(
     protected BlockManagerInterface $blockManager,
     protected RendererInterface $renderer,
-    protected DplReactConfigInterface $patronRegSettings,
+    protected DplPatronRegSettings $patronRegSettings,
   ) {}
 
   /**

--- a/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegReactController.php
+++ b/web/modules/custom/dpl_patron_reg/src/Controller/DplPatronRegReactController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\dpl_patron_reg\Controller;
+
+use Drupal\Core\Block\BlockManagerInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\dpl_react\DplReactConfigInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Patron registration Controller.
+ */
+class DplPatronRegReactController extends ControllerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    protected BlockManagerInterface $blockManager,
+    protected RendererInterface $renderer,
+    protected DplReactConfigInterface $patronRegSettings,
+  ) {}
+
+  /**
+   * Load the user registration react application.
+   *
+   * @return mixed[]
+   *   Render array with registration block.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   */
+  public function userRegistrationReactAppLoad(): array {
+    /** @var \Drupal\dpl_patron_reg\Plugin\Block\PatronRegistrationBlock $plugin_block */
+    $plugin_block = $this->blockManager->createInstance('dpl_patron_reg_block', []);
+
+    // @todo create service for access check.
+    // Some blocks might implement access check.
+    $access_result = $plugin_block->access($this->currentUser());
+    if (is_object($access_result) && $access_result->isForbidden() || is_bool($access_result) && !$access_result) {
+      throw new AccessDeniedHttpException();
+    }
+
+    // Add the cache tags/contexts.
+    $render = $plugin_block->build();
+    $this->renderer->addCacheableDependency($render, $plugin_block);
+    $this->renderer->addCacheableDependency($render, $this->patronRegSettings);
+
+    return $render;
+  }
+
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-15 and to some extent https://reload.atlassian.net/browse/DDFSAL-29 .

#### Description

In short: ensure that there's no Drupal user logged in when redirecting to Adgangsplatformen, as it will make `openid_connect` throw an exception on return. 

The GraphQL check failure is unrelated, of course.
