### PR TITLE
Remove diff check for GraphQL schema changes

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -307,8 +307,6 @@ jobs:
         run: task ci:reset
       - name: Extract GraphQL schema and generate client
         run: task dev:bnf:generate-graphql
-      - name: Ensure GraphQL schema has not drifted
-        run: git diff --ignore-space-at-eol --exit-code web/modules/custom/bnf/schema/bnf.graphql
       - name: Ensure GraphQL client code has not drifted
         run: git diff --ignore-space-at-eol --exit-code web/modules/custom/bnf/src/GraphQL/*
 


### PR DESCRIPTION
#### Description

For whatever reason the schema generated in CI has elements in a different order than what is exported locally. Since this difference does not have any meaning regarding the sematics of the schema we disable the check for now.

For now the check that the generated code remains is sufficient.

Later on we may look into a more intelligent approach for detecting changes to the schema.