### PR TITLE
Ensure that neither library nor user token are cached

### DIFF
--- a/web/modules/custom/dpl_library_token/src/LibraryToken.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryToken.php
@@ -21,7 +21,7 @@ class LibraryToken {
    *
    * @var int
    */
-  public int $expire;
+  public int $expiresIn;
 
   /**
    * Named constructor that create a Library Token object.
@@ -51,7 +51,7 @@ class LibraryToken {
 
     $token = new static();
     $token->token = $token_data['access_token'];
-    $token->expire = $token_data['expires_in'];
+    $token->expiresIn = $token_data['expires_in'];
 
     return $token;
   }

--- a/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
+++ b/web/modules/custom/dpl_library_token/src/LibraryTokenHandler.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\dpl_library_token;
 
-use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use GuzzleHttp\ClientInterface;
@@ -98,12 +97,11 @@ class LibraryTokenHandler {
     }
 
     $expireDateTime = (new DateTime("now"))->add($expireInterval);
-    $dateTime = DrupalDateTime::createFromDateTime($expireDateTime);
 
     $this->tokenCollection
       ->setWithExpire(
         self::LIBRARY_TOKEN_KEY,
-        (object) ['token' => $token->token, 'expiresAt' => $dateTime->format(\DateTime::RFC3339)],
+        (object) ['token' => $token->token, 'expiresAt' => $expireDateTime->format(\DateTime::RFC3339)],
         (int) round($expire)
       );
   }

--- a/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLibraryTokenProducer.php
+++ b/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLibraryTokenProducer.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\dpl_library_token\Plugin\GraphQL\DataProducer;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dpl_library_token\LibraryTokenHandler;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
 use Safe\DateTime;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -82,9 +84,11 @@ class AdgangsplatformenLibraryTokenProducer extends DataProducerPluginBase imple
   /**
    * Resolves the library access token.
    *
-   *   The library access token.
+   * @param \Drupal\graphql\GraphQL\Execution\FieldContext $field_context
+   *   Field context.
    */
-  public function resolve(): object | null {
+  public function resolve(FieldContext $field_context): object | null {
+    $field_context->addCacheableDependency((new CacheableMetadata())->setCacheMaxAge(0));
     $token = $this->libraryTokenHandler->getToken();
     return $token ? (object) [
       'token' => $token->token,

--- a/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLibraryTokenProducer.php
+++ b/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLibraryTokenProducer.php
@@ -8,7 +8,6 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dpl_library_token\LibraryTokenHandler;
 use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
-use Safe\DateTime;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -56,23 +55,16 @@ class AdgangsplatformenLibraryTokenProducer extends DataProducerPluginBase imple
   }
 
   /**
-   * Adds expire seconds to current time (now()).
+   * Transforms an RFC3339 formatted date string into Drupal GraphQL datetime.
    *
-   * And transforms the result into a Drupal graphql Datetime array.
-   *
-   * @param int $expire
-   *   The expire date in seconds.
+   * @param string $expire
+   *   The date the token expires in RFC3339 format.
    *
    * @return mixed[]
    *   The formatted date array.
    */
-  protected function formatExpireDate(int $expire): array {
-    if (!$expireInterval = \DateInterval::createFromDateString(sprintf('%d seconds', $expire))) {
-      throw new \InvalidArgumentException('Invalid expire date.');
-    }
-    $expireDateTime = (new DateTime("now"))->add($expireInterval);
-    $dateTime = DrupalDateTime::createFromDateTime($expireDateTime);
-
+  protected function formatExpireDate(string $expire): array {
+    $dateTime = new DrupalDateTime($expire);
     return [
       'timestamp' => $dateTime->getTimestamp(),
       'timezone' => $dateTime->getTimezone()->getName(),
@@ -92,7 +84,7 @@ class AdgangsplatformenLibraryTokenProducer extends DataProducerPluginBase imple
     $token = $this->libraryTokenHandler->getToken();
     return $token ? (object) [
       'token' => $token->token,
-      'expire' => $this->formatExpireDate($token->expire),
+      'expire' => $this->formatExpireDate($token->expiresAt),
     ] : NULL;
   }
 

--- a/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLibraryTokenProducer.php
+++ b/web/modules/custom/dpl_library_token/src/Plugin/GraphQL/DataProducer/AdgangsplatformenLibraryTokenProducer.php
@@ -3,11 +3,11 @@
 namespace Drupal\dpl_library_token\Plugin\GraphQL\DataProducer;
 
 use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dpl_library_token\LibraryTokenHandler;
 use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Safe\DateTime;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -64,7 +64,8 @@ class AdgangsplatformenLibraryTokenProducer extends DataProducerPluginBase imple
    *   The formatted date array.
    */
   protected function formatExpireDate(string $expire): array {
-    $dateTime = new DrupalDateTime($expire);
+    $dateTime = new DateTime($expire);
+
     return [
       'timestamp' => $dateTime->getTimestamp(),
       'timezone' => $dateTime->getTimezone()->getName(),

--- a/web/modules/custom/dpl_login/graphql/dpl_tokens.base.graphqls
+++ b/web/modules/custom/dpl_login/graphql/dpl_tokens.base.graphqls
@@ -1,6 +1,6 @@
 type AdgangsplatformenUserToken {
   token: String
-  expire: Int
+  expire: DateTime
 }
 
 type AdgangsplatformenTokens {

--- a/web/modules/custom/dpl_login/src/Plugin/GraphQL/DataProducer/AdgangsplatformenUserTokenProducer.php
+++ b/web/modules/custom/dpl_login/src/Plugin/GraphQL/DataProducer/AdgangsplatformenUserTokenProducer.php
@@ -3,11 +3,11 @@
 namespace Drupal\dpl_login\Plugin\GraphQL\DataProducer;
 
 use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dpl_login\UserTokens;
 use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Safe\DateTime;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -64,7 +64,9 @@ class AdgangsplatformenUserTokenProducer extends DataProducerPluginBase implemen
    *   The formatted date array.
    */
   protected function formatExpireDate(int $expire): array {
-    $dateTime = DrupalDateTime::createFromTimestamp($expire);
+    $dateTime = new DateTime();
+    $dateTime->setTimeStamp($expire);
+
     return [
       'timestamp' => $dateTime->getTimestamp(),
       'timezone' => $dateTime->getTimezone()->getName(),

--- a/web/modules/custom/dpl_login/src/Plugin/GraphQL/DataProducer/AdgangsplatformenUserTokenProducer.php
+++ b/web/modules/custom/dpl_login/src/Plugin/GraphQL/DataProducer/AdgangsplatformenUserTokenProducer.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\dpl_login\Plugin\GraphQL\DataProducer;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dpl_login\AccessToken;
 use Drupal\dpl_login\UserTokens;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -55,7 +57,8 @@ class AdgangsplatformenUserTokenProducer extends DataProducerPluginBase implemen
   /**
    * Resolves the access token based on the token type.
    */
-  public function resolve(): AccessToken | null {
+  public function resolve(FieldContext $field_context): AccessToken | null {
+    $field_context->addCacheableDependency((new CacheableMetadata())->setCacheMaxAge(0));
     return $this->userTokens->getCurrent();
   }
 

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -10,6 +10,8 @@
  */
 
 use Drupal\Core\Extension\ModuleInstallerInterface;
+use Drupal\dpl_library_token\LibraryTokenHandler;
+use Drupal\dpl_login\Adgangsplatformen\Config;
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\locale\SourceString;
 use Drupal\locale\StringDatabaseStorage;
@@ -571,4 +573,38 @@ function dpl_update_update_10046(): string {
  */
 function dpl_update_update_10047(): string {
   return _dpl_update_install_modules(['graphql_compose_views']);
+}
+
+/**
+ * Force a new library token to be fetched because token signature has changed.
+ */
+function dpl_update_update_10048(): string {
+  $handler = DrupalTyped::service(LibraryTokenHandler::class, 'dpl_library_token.handler');
+  $config = DrupalTyped::service(Config::class, 'dpl_login.adgangsplatformen.config');
+  $oldToken = $handler->getToken();
+  $success_output = [];
+
+  if ($oldToken) {
+    $success_output[] = t('Old token that was not deleted: Token: @token, properties: @props', [
+      '@token' => $oldToken->token,
+      '@props' => implode(', ', array_keys((array) $oldToken)),
+    ]);
+  }
+
+  if (!$newToken = $handler->fetchToken(
+    $config->getAgencyId(),
+    $config->getClientId(),
+    $config->getClientSecret(),
+    $config->getTokenEndpoint()
+  )) {
+    return 'Failed to fetch new library token.';
+  }
+  $handler->setToken(token: $newToken);
+
+  $success_output[] = t('New token: Token: @token, properties: @props', [
+    '@token' => $newToken->token,
+    '@props' => implode(', ', array_keys((array) $newToken)),
+  ]);
+
+  return implode(' | ', $success_output);
 }


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-562

#### Description

Ensure that neither library nor user token are cached in graphql data producers.
