### PR TITLE
DDFSAL-30 - Align the way we specify which paragraphs are available

### DIFF
--- a/config/sync/field.field.node.article.field_paragraphs.yml
+++ b/config/sync/field.field.node.article.field_paragraphs.yml
@@ -5,18 +5,33 @@ dependencies:
   config:
     - field.storage.node.field_paragraphs
     - node.type.article
-    - paragraphs.paragraphs_type.campaign_rule
-    - paragraphs.paragraphs_type.event_ticket_category
-    - paragraphs.paragraphs_type.go_images
-    - paragraphs.paragraphs_type.go_link
-    - paragraphs.paragraphs_type.go_linkbox
-    - paragraphs.paragraphs_type.go_material_slider_automatic
-    - paragraphs.paragraphs_type.go_material_slider_manual
-    - paragraphs.paragraphs_type.go_text_body
-    - paragraphs.paragraphs_type.go_video
-    - paragraphs.paragraphs_type.go_video_bundle_automatic
-    - paragraphs.paragraphs_type.go_video_bundle_manual
-    - paragraphs.paragraphs_type.opening_hours
+    - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.breadcrumb_children
+    - paragraphs.paragraphs_type.card_grid_automatic
+    - paragraphs.paragraphs_type.card_grid_manual
+    - paragraphs.paragraphs_type.content_slider
+    - paragraphs.paragraphs_type.content_slider_automatic
+    - paragraphs.paragraphs_type.files
+    - paragraphs.paragraphs_type.filtered_event_list
+    - paragraphs.paragraphs_type.hero
+    - paragraphs.paragraphs_type.language_selector
+    - paragraphs.paragraphs_type.links
+    - paragraphs.paragraphs_type.manual_event_list
+    - paragraphs.paragraphs_type.material_grid_automatic
+    - paragraphs.paragraphs_type.material_grid_link_automatic
+    - paragraphs.paragraphs_type.material_grid_manual
+    - paragraphs.paragraphs_type.medias
+    - paragraphs.paragraphs_type.nav_grid_manual
+    - paragraphs.paragraphs_type.nav_spots_manual
+    - paragraphs.paragraphs_type.recommendation
+    - paragraphs.paragraphs_type.simple_links
+    - paragraphs.paragraphs_type.text_body
+    - paragraphs.paragraphs_type.user_registration_item
+    - paragraphs.paragraphs_type.user_registration_linklist
+    - paragraphs.paragraphs_type.user_registration_section
+    - paragraphs.paragraphs_type.video
+    - paragraphs.paragraphs_type.webform
   module:
     - entity_reference_revisions
 id: node.article.field_paragraphs
@@ -33,135 +48,150 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      campaign_rule: campaign_rule
-      event_ticket_category: event_ticket_category
-      opening_hours: opening_hours
-      go_linkbox: go_linkbox
-      go_material_slider_automatic: go_material_slider_automatic
-      go_material_slider_manual: go_material_slider_manual
-      go_video: go_video
-      go_video_bundle_automatic: go_video_bundle_automatic
-      go_link: go_link
-      go_video_bundle_manual: go_video_bundle_manual
-      go_images: go_images
-      go_text_body: go_text_body
-    negate: 1
+      text_body: text_body
+      links: links
+      medias: medias
+      accordion: accordion
+      card_grid_automatic: card_grid_automatic
+      card_grid_manual: card_grid_manual
+      content_slider: content_slider
+      files: files
+      hero: hero
+      language_selector: language_selector
+      material_grid_automatic: material_grid_automatic
+      material_grid_manual: material_grid_manual
+      banner: banner
+      nav_grid_manual: nav_grid_manual
+      breadcrumb_children: breadcrumb_children
+      nav_spots_manual: nav_spots_manual
+      recommendation: recommendation
+      user_registration_item: user_registration_item
+      content_slider_automatic: content_slider_automatic
+      user_registration_section: user_registration_section
+      video: video
+      filtered_event_list: filtered_event_list
+      manual_event_list: manual_event_list
+      simple_links: simple_links
+      material_grid_link_automatic: material_grid_link_automatic
+      user_registration_linklist: user_registration_linklist
+      webform: webform
+    negate: 0
     target_bundles_drag_drop:
       accordion:
         weight: 22
-        enabled: false
+        enabled: true
       banner:
         weight: 35
-        enabled: false
+        enabled: true
       breadcrumb_children:
         weight: 36
-        enabled: false
+        enabled: true
       campaign_rule:
         weight: 2
-        enabled: true
+        enabled: false
       card_grid_automatic:
         weight: 24
-        enabled: false
+        enabled: true
       card_grid_manual:
         weight: 25
-        enabled: false
+        enabled: true
       content_slider:
         weight: 26
-        enabled: false
+        enabled: true
       content_slider_automatic:
         weight: 41
-        enabled: false
+        enabled: true
       event_ticket_category:
         weight: 7
-        enabled: true
+        enabled: false
       files:
         weight: 28
-        enabled: false
+        enabled: true
       filtered_event_list:
         weight: 44
-        enabled: false
+        enabled: true
       go_images:
         weight: 51
-        enabled: true
+        enabled: false
       go_link:
         weight: 50
-        enabled: true
+        enabled: false
       go_linkbox:
         weight: 45
-        enabled: true
+        enabled: false
       go_material_slider_automatic:
         weight: 46
-        enabled: true
+        enabled: false
       go_material_slider_manual:
         weight: 47
-        enabled: true
+        enabled: false
       go_text_body:
         weight: 54
-        enabled: true
+        enabled: false
       go_video:
         weight: 48
-        enabled: true
+        enabled: false
       go_video_bundle_automatic:
         weight: 49
-        enabled: true
+        enabled: false
       go_video_bundle_manual:
         weight: 50
-        enabled: true
+        enabled: false
       hero:
         weight: 29
-        enabled: false
+        enabled: true
       language_selector:
         weight: 30
-        enabled: false
+        enabled: true
       links:
         weight: 8
-        enabled: false
+        enabled: true
       manual_event_list:
         weight: 52
-        enabled: false
+        enabled: true
       material_grid_automatic:
         weight: 32
-        enabled: false
+        enabled: true
       material_grid_link_automatic:
         weight: 63
-        enabled: false
+        enabled: true
       material_grid_manual:
         weight: 33
-        enabled: false
+        enabled: true
       medias:
         weight: 9
-        enabled: false
+        enabled: true
       nav_grid_manual:
         weight: 35
-        enabled: false
+        enabled: true
       nav_spots_manual:
         weight: 36
-        enabled: false
+        enabled: true
       opening_hours:
         weight: 37
-        enabled: true
+        enabled: false
       recommendation:
         weight: 38
-        enabled: false
+        enabled: true
       simple_links:
         weight: 60
-        enabled: false
+        enabled: true
       text_body:
         weight: 4
-        enabled: false
+        enabled: true
       user_registration_item:
         weight: 40
-        enabled: false
+        enabled: true
       user_registration_linklist:
         weight: 63
-        enabled: false
+        enabled: true
       user_registration_section:
         weight: 41
-        enabled: false
+        enabled: true
       video:
         weight: 42
-        enabled: false
+        enabled: true
       webform:
         weight: 66
-        enabled: false
+        enabled: true
 field_type: entity_reference_revisions

--- a/config/sync/field.field.node.branch.field_paragraphs.yml
+++ b/config/sync/field.field.node.branch.field_paragraphs.yml
@@ -5,17 +5,34 @@ dependencies:
   config:
     - field.storage.node.field_paragraphs
     - node.type.branch
-    - paragraphs.paragraphs_type.campaign_rule
-    - paragraphs.paragraphs_type.event_ticket_category
-    - paragraphs.paragraphs_type.go_images
-    - paragraphs.paragraphs_type.go_link
-    - paragraphs.paragraphs_type.go_linkbox
-    - paragraphs.paragraphs_type.go_material_slider_automatic
-    - paragraphs.paragraphs_type.go_material_slider_manual
-    - paragraphs.paragraphs_type.go_text_body
-    - paragraphs.paragraphs_type.go_video
-    - paragraphs.paragraphs_type.go_video_bundle_automatic
-    - paragraphs.paragraphs_type.go_video_bundle_manual
+    - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.breadcrumb_children
+    - paragraphs.paragraphs_type.card_grid_automatic
+    - paragraphs.paragraphs_type.card_grid_manual
+    - paragraphs.paragraphs_type.content_slider
+    - paragraphs.paragraphs_type.content_slider_automatic
+    - paragraphs.paragraphs_type.files
+    - paragraphs.paragraphs_type.filtered_event_list
+    - paragraphs.paragraphs_type.hero
+    - paragraphs.paragraphs_type.language_selector
+    - paragraphs.paragraphs_type.links
+    - paragraphs.paragraphs_type.manual_event_list
+    - paragraphs.paragraphs_type.material_grid_automatic
+    - paragraphs.paragraphs_type.material_grid_link_automatic
+    - paragraphs.paragraphs_type.material_grid_manual
+    - paragraphs.paragraphs_type.medias
+    - paragraphs.paragraphs_type.nav_grid_manual
+    - paragraphs.paragraphs_type.nav_spots_manual
+    - paragraphs.paragraphs_type.opening_hours
+    - paragraphs.paragraphs_type.recommendation
+    - paragraphs.paragraphs_type.simple_links
+    - paragraphs.paragraphs_type.text_body
+    - paragraphs.paragraphs_type.user_registration_item
+    - paragraphs.paragraphs_type.user_registration_linklist
+    - paragraphs.paragraphs_type.user_registration_section
+    - paragraphs.paragraphs_type.video
+    - paragraphs.paragraphs_type.webform
   module:
     - entity_reference_revisions
 id: node.branch.field_paragraphs
@@ -32,134 +49,151 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      campaign_rule: campaign_rule
-      event_ticket_category: event_ticket_category
-      go_link: go_link
-      go_images: go_images
-      go_linkbox: go_linkbox
-      go_material_slider_automatic: go_material_slider_automatic
-      go_material_slider_manual: go_material_slider_manual
-      go_text_body: go_text_body
-      go_video: go_video
-      go_video_bundle_automatic: go_video_bundle_automatic
-      go_video_bundle_manual: go_video_bundle_manual
-    negate: 1
+      text_body: text_body
+      links: links
+      medias: medias
+      accordion: accordion
+      card_grid_automatic: card_grid_automatic
+      card_grid_manual: card_grid_manual
+      content_slider: content_slider
+      files: files
+      hero: hero
+      nav_grid_manual: nav_grid_manual
+      nav_spots_manual: nav_spots_manual
+      recommendation: recommendation
+      video: video
+      banner: banner
+      breadcrumb_children: breadcrumb_children
+      content_slider_automatic: content_slider_automatic
+      filtered_event_list: filtered_event_list
+      language_selector: language_selector
+      manual_event_list: manual_event_list
+      material_grid_automatic: material_grid_automatic
+      material_grid_link_automatic: material_grid_link_automatic
+      material_grid_manual: material_grid_manual
+      opening_hours: opening_hours
+      simple_links: simple_links
+      user_registration_item: user_registration_item
+      user_registration_linklist: user_registration_linklist
+      user_registration_section: user_registration_section
+      webform: webform
+    negate: 0
     target_bundles_drag_drop:
       accordion:
         weight: 16
-        enabled: false
+        enabled: true
       banner:
         weight: 40
-        enabled: false
+        enabled: true
       breadcrumb_children:
         weight: 41
-        enabled: false
+        enabled: true
       campaign_rule:
         weight: 2
-        enabled: true
+        enabled: false
       card_grid_automatic:
         weight: 18
-        enabled: false
+        enabled: true
       card_grid_manual:
         weight: 19
-        enabled: false
+        enabled: true
       content_slider:
         weight: 20
-        enabled: false
+        enabled: true
       content_slider_automatic:
         weight: 46
-        enabled: false
+        enabled: true
       event_ticket_category:
         weight: 7
-        enabled: true
+        enabled: false
       files:
         weight: 22
-        enabled: false
+        enabled: true
       filtered_event_list:
         weight: 49
-        enabled: false
+        enabled: true
       go_images:
         weight: 51
-        enabled: true
+        enabled: false
       go_link:
         weight: 50
-        enabled: true
+        enabled: false
       go_linkbox:
         weight: 51
-        enabled: true
+        enabled: false
       go_material_slider_automatic:
         weight: 52
-        enabled: true
+        enabled: false
       go_material_slider_manual:
         weight: 53
-        enabled: true
+        enabled: false
       go_text_body:
         weight: 54
-        enabled: true
+        enabled: false
       go_video:
         weight: 55
-        enabled: true
+        enabled: false
       go_video_bundle_automatic:
         weight: 56
-        enabled: true
+        enabled: false
       go_video_bundle_manual:
         weight: 57
-        enabled: true
+        enabled: false
       hero:
         weight: 23
-        enabled: false
+        enabled: true
       language_selector:
         weight: 59
-        enabled: false
+        enabled: true
       links:
         weight: 8
-        enabled: false
+        enabled: true
       manual_event_list:
         weight: 61
-        enabled: false
+        enabled: true
       material_grid_automatic:
         weight: 62
-        enabled: false
+        enabled: true
       material_grid_link_automatic:
         weight: 63
-        enabled: false
+        enabled: true
       material_grid_manual:
         weight: 64
-        enabled: false
+        enabled: true
       medias:
         weight: 9
-        enabled: false
+        enabled: true
       nav_grid_manual:
         weight: 26
-        enabled: false
+        enabled: true
       nav_spots_manual:
         weight: 27
-        enabled: false
+        enabled: true
       opening_hours:
         weight: 68
-        enabled: false
+        enabled: true
       recommendation:
         weight: 28
-        enabled: false
+        enabled: true
       simple_links:
         weight: 70
-        enabled: false
+        enabled: true
       text_body:
         weight: 4
-        enabled: false
+        enabled: true
       user_registration_item:
         weight: 72
-        enabled: false
+        enabled: true
       user_registration_linklist:
         weight: 73
-        enabled: false
+        enabled: true
       user_registration_section:
         weight: 74
-        enabled: false
+        enabled: true
       video:
         weight: 30
-        enabled: false
+        enabled: true
       webform:
         weight: 76
-        enabled: false
+        enabled: true
 field_type: entity_reference_revisions

--- a/config/sync/field.field.node.page.field_paragraphs.yml
+++ b/config/sync/field.field.node.page.field_paragraphs.yml
@@ -5,18 +5,33 @@ dependencies:
   config:
     - field.storage.node.field_paragraphs
     - node.type.page
-    - paragraphs.paragraphs_type.campaign_rule
-    - paragraphs.paragraphs_type.event_ticket_category
-    - paragraphs.paragraphs_type.go_images
-    - paragraphs.paragraphs_type.go_link
-    - paragraphs.paragraphs_type.go_linkbox
-    - paragraphs.paragraphs_type.go_material_slider_automatic
-    - paragraphs.paragraphs_type.go_material_slider_manual
-    - paragraphs.paragraphs_type.go_text_body
-    - paragraphs.paragraphs_type.go_video
-    - paragraphs.paragraphs_type.go_video_bundle_automatic
-    - paragraphs.paragraphs_type.go_video_bundle_manual
-    - paragraphs.paragraphs_type.opening_hours
+    - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.breadcrumb_children
+    - paragraphs.paragraphs_type.card_grid_automatic
+    - paragraphs.paragraphs_type.card_grid_manual
+    - paragraphs.paragraphs_type.content_slider
+    - paragraphs.paragraphs_type.content_slider_automatic
+    - paragraphs.paragraphs_type.files
+    - paragraphs.paragraphs_type.filtered_event_list
+    - paragraphs.paragraphs_type.hero
+    - paragraphs.paragraphs_type.language_selector
+    - paragraphs.paragraphs_type.links
+    - paragraphs.paragraphs_type.manual_event_list
+    - paragraphs.paragraphs_type.material_grid_automatic
+    - paragraphs.paragraphs_type.material_grid_link_automatic
+    - paragraphs.paragraphs_type.material_grid_manual
+    - paragraphs.paragraphs_type.medias
+    - paragraphs.paragraphs_type.nav_grid_manual
+    - paragraphs.paragraphs_type.nav_spots_manual
+    - paragraphs.paragraphs_type.recommendation
+    - paragraphs.paragraphs_type.simple_links
+    - paragraphs.paragraphs_type.text_body
+    - paragraphs.paragraphs_type.user_registration_item
+    - paragraphs.paragraphs_type.user_registration_linklist
+    - paragraphs.paragraphs_type.user_registration_section
+    - paragraphs.paragraphs_type.video
+    - paragraphs.paragraphs_type.webform
   module:
     - entity_reference_revisions
 id: node.page.field_paragraphs
@@ -33,135 +48,150 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      campaign_rule: campaign_rule
-      event_ticket_category: event_ticket_category
-      opening_hours: opening_hours
-      go_linkbox: go_linkbox
-      go_material_slider_automatic: go_material_slider_automatic
-      go_material_slider_manual: go_material_slider_manual
-      go_video: go_video
-      go_video_bundle_automatic: go_video_bundle_automatic
-      go_link: go_link
-      go_video_bundle_manual: go_video_bundle_manual
-      go_images: go_images
-      go_text_body: go_text_body
-    negate: 1
+      text_body: text_body
+      links: links
+      medias: medias
+      card_grid_automatic: card_grid_automatic
+      card_grid_manual: card_grid_manual
+      content_slider: content_slider
+      files: files
+      video: video
+      accordion: accordion
+      hero: hero
+      language_selector: language_selector
+      material_grid_automatic: material_grid_automatic
+      material_grid_manual: material_grid_manual
+      banner: banner
+      nav_grid_manual: nav_grid_manual
+      breadcrumb_children: breadcrumb_children
+      nav_spots_manual: nav_spots_manual
+      recommendation: recommendation
+      user_registration_item: user_registration_item
+      content_slider_automatic: content_slider_automatic
+      user_registration_section: user_registration_section
+      filtered_event_list: filtered_event_list
+      manual_event_list: manual_event_list
+      simple_links: simple_links
+      material_grid_link_automatic: material_grid_link_automatic
+      user_registration_linklist: user_registration_linklist
+      webform: webform
+    negate: 0
     target_bundles_drag_drop:
       accordion:
         weight: 22
-        enabled: false
+        enabled: true
       banner:
         weight: 35
-        enabled: false
+        enabled: true
       breadcrumb_children:
         weight: 36
-        enabled: false
+        enabled: true
       campaign_rule:
         weight: 2
-        enabled: true
+        enabled: false
       card_grid_automatic:
         weight: 12
-        enabled: false
+        enabled: true
       card_grid_manual:
         weight: 13
-        enabled: false
+        enabled: true
       content_slider:
         weight: 14
-        enabled: false
+        enabled: true
       content_slider_automatic:
         weight: 41
-        enabled: false
+        enabled: true
       event_ticket_category:
         weight: 7
-        enabled: true
+        enabled: false
       files:
         weight: 16
-        enabled: false
+        enabled: true
       filtered_event_list:
         weight: 44
-        enabled: false
+        enabled: true
       go_images:
         weight: 51
-        enabled: true
+        enabled: false
       go_link:
         weight: 50
-        enabled: true
+        enabled: false
       go_linkbox:
         weight: 45
-        enabled: true
+        enabled: false
       go_material_slider_automatic:
         weight: 46
-        enabled: true
+        enabled: false
       go_material_slider_manual:
         weight: 47
-        enabled: true
+        enabled: false
       go_text_body:
         weight: 54
-        enabled: true
+        enabled: false
       go_video:
         weight: 48
-        enabled: true
+        enabled: false
       go_video_bundle_automatic:
         weight: 49
-        enabled: true
+        enabled: false
       go_video_bundle_manual:
         weight: 50
-        enabled: true
+        enabled: false
       hero:
         weight: 29
-        enabled: false
+        enabled: true
       language_selector:
         weight: 30
-        enabled: false
+        enabled: true
       links:
         weight: 8
-        enabled: false
+        enabled: true
       manual_event_list:
         weight: 52
-        enabled: false
+        enabled: true
       material_grid_automatic:
         weight: 32
-        enabled: false
+        enabled: true
       material_grid_link_automatic:
         weight: 63
-        enabled: false
+        enabled: true
       material_grid_manual:
         weight: 33
-        enabled: false
+        enabled: true
       medias:
         weight: 9
-        enabled: false
+        enabled: true
       nav_grid_manual:
         weight: 35
-        enabled: false
+        enabled: true
       nav_spots_manual:
         weight: 36
-        enabled: false
+        enabled: true
       opening_hours:
         weight: 37
-        enabled: true
+        enabled: false
       recommendation:
         weight: 38
-        enabled: false
+        enabled: true
       simple_links:
         weight: 60
-        enabled: false
+        enabled: true
       text_body:
         weight: 4
-        enabled: false
+        enabled: true
       user_registration_item:
         weight: 40
-        enabled: false
+        enabled: true
       user_registration_linklist:
         weight: 63
-        enabled: false
+        enabled: true
       user_registration_section:
         weight: 41
-        enabled: false
+        enabled: true
       video:
         weight: 20
-        enabled: false
+        enabled: true
       webform:
         weight: 66
-        enabled: false
+        enabled: true
 field_type: entity_reference_revisions


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-30

#### Description

This PR aligns the way we specify what paragraphs is available on the different content types. The PR makes sure that all content types are now using an include list.

The paragraph field has been updated on the following content types:
- Article
- Branch
- Page

Instead of specifying an exclude list of paragraphs that should not be available, we now instead use an include list to specify which paragraphs should be available.