### PR TITLE
Separate goConfiguration graphql into public and private

### DIFF
--- a/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
+++ b/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
@@ -7,9 +7,16 @@ type GoLogoutUrls {
   adgangsplatformen: String
 }
 
-type GoConfiguration {
+type GoConfigurationPrivate {
   unilogin: UniloginConfiguration
+}
+
+type GoConfigurationPublic {
   loginUrls: GoLoginUrls
   logoutUrls: GoLogoutUrls
 }
 
+type GoConfiguration {
+  public: GoConfigurationPublic
+  private: GoConfigurationPrivate
+}

--- a/web/modules/custom/dpl_go/src/Plugin/GraphQL/SchemaExtension/GoConfigurationExtension.php
+++ b/web/modules/custom/dpl_go/src/Plugin/GraphQL/SchemaExtension/GoConfigurationExtension.php
@@ -24,22 +24,22 @@ class GoConfigurationExtension extends SdlSchemaExtensionPluginBase {
   public function registerResolvers(ResolverRegistryInterface $registry): void {
     $builder = new ResolverBuilder();
     $registry->addFieldResolver('Query', 'goConfiguration', $builder->callback(fn () => TRUE));
-    $registry->addFieldResolver('GoConfiguration', 'adgangsplatformen', $builder->callback(fn () => TRUE));
+    $registry->addFieldResolver('GoConfiguration', 'public', $builder->callback(fn () => TRUE));
+    $registry->addFieldResolver('GoConfiguration', 'private', $builder->callback(fn () => TRUE));
 
-    $registry->addFieldResolver('GoConfiguration', 'unilogin',
-      $builder->produce('unilogin_info_producer')
-    );
-
-    $registry->addFieldResolver('GoConfiguration', 'loginUrls', $builder->callback(fn () => TRUE));
+    $registry->addFieldResolver('GoConfigurationPublic', 'loginUrls', $builder->callback(fn () => TRUE));
     $registry->addFieldResolver('GoLoginUrls', 'adgangsplatformen',
       $builder->produce('go_adgangsplatformen_login_url')
     );
 
-    $registry->addFieldResolver('GoConfiguration', 'logoutUrls', $builder->callback(fn () => TRUE));
+    $registry->addFieldResolver('GoConfigurationPublic', 'logoutUrls', $builder->callback(fn () => TRUE));
     $registry->addFieldResolver('GoLogoutUrls', 'adgangsplatformen',
       $builder->produce('go_adgangsplatformen_logout_url')
     );
 
+    $registry->addFieldResolver('GoConfigurationPrivate', 'unilogin',
+    $builder->produce('unilogin_info_producer')
+    );
   }
 
 }


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-572

#### Description

Separate goConfiguration graphql into public and private to emphasize what is considered to be sensitive and what is not.

