### PR TITLE
DDFBRA-577 - Add Go Categories example content

### DIFF
--- a/web/modules/custom/dpl_example_content/content/media/109347b3-c3df-4b2d-a8fb-d4e379c2cc50.yml
+++ b/web/modules/custom/dpl_example_content/content/media/109347b3-c3df-4b2d-a8fb-d4e379c2cc50.yml
@@ -1,0 +1,42 @@
+_meta:
+  version: '1.0'
+  entity_type: media
+  uuid: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  bundle: image
+  default_langcode: da
+  depends:
+    015ef902-9c25-45fa-8a2a-d6e06ca2c40d: file
+default:
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  name:
+    -
+      value: 'Go Category example image.png'
+  created:
+    -
+      value: 1746516963
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: '| DPL CMS'
+  path:
+    -
+      alias: ''
+      langcode: da
+      pathauto: 0
+  field_media_image:
+    -
+      entity: 015ef902-9c25-45fa-8a2a-d6e06ca2c40d
+      alt: 'Go Category example image'
+      title: ''
+      width: 201
+      height: 201

--- a/web/modules/custom/dpl_example_content/content/node/0c18c225-af99-45d5-b6d5-73eb2dabbba1.yml
+++ b/web/modules/custom/dpl_example_content/content/node/0c18c225-af99-45d5-b6d5-73eb2dabbba1.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 0c18c225-af99-45d5-b6d5-73eb2dabbba1
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Gaming
+  created:
+    -
+      value: 1746540555
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Gaming | DPL CMS'
+  path:
+    -
+      alias: /kategori/gaming
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Gaming
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/16f740f1-0040-40af-a59e-6925fc9bac0d.yml
+++ b/web/modules/custom/dpl_example_content/content/node/16f740f1-0040-40af-a59e-6925fc9bac0d.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 16f740f1-0040-40af-a59e-6925fc9bac0d
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Sport
+  created:
+    -
+      value: 1746540495
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Sport | DPL CMS'
+  path:
+    -
+      alias: /kategori/sport
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Sport
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/37fcfc9e-5925-4fe5-987d-62b144045440.yml
+++ b/web/modules/custom/dpl_example_content/content/node/37fcfc9e-5925-4fe5-987d-62b144045440.yml
@@ -1,0 +1,188 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 37fcfc9e-5925-4fe5-987d-62b144045440
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+    d219e4de-4984-487e-8e21-9f56c0a0335c: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Gys
+  created:
+    -
+      value: 1746516803
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Gys | DPL CMS'
+  path:
+    -
+      alias: /kategori/gys
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Gys
+  field_paragraphs:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 71da71c1-0e3e-486c-9f31-28100c3bc63e
+          bundle: go_material_slider_automatic
+          default_langcode: da
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1746517459
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_cql_search:
+            -
+              value: "'gys'"
+          field_slider_amount_of_materials:
+            -
+              value: 8
+          field_title:
+            -
+              value: 'Material Slider Automatic - Anbefalede gyser bøger'
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 0991479f-9003-432b-ad15-ccf2cd55cc06
+          bundle: go_video_bundle_automatic
+          default_langcode: da
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1746517514
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_cql_search:
+            -
+              value: "'horror'"
+          field_embed_video:
+            -
+              entity: d219e4de-4984-487e-8e21-9f56c0a0335c
+          field_go_video_title:
+            -
+              value: 'Video Bundle Automatic - De uhyggeligeste anbefalinger'
+          field_video_amount_of_materials:
+            -
+              value: 5
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 32fec344-5b92-48c4-ac2d-b603beb82f7a
+          bundle: go_linkbox
+          default_langcode: da
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1746517652
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_go_description:
+            -
+              value: 'Det er ikke for sarte sjæle, men hvis du er modig, så klik på dette link.'
+          field_go_link_paragraph:
+            -
+              entity:
+                _meta:
+                  version: '1.0'
+                  entity_type: paragraph
+                  uuid: 3037e01b-a26a-495e-a8a8-207ba55eecf9
+                  bundle: go_link
+                  default_langcode: da
+                default:
+                  status:
+                    -
+                      value: true
+                  created:
+                    -
+                      value: 1746517652
+                  behavior_settings:
+                    -
+                      value: {  }
+                  revision_translation_affected:
+                    -
+                      value: true
+                  field_aria_label:
+                    -
+                      value: 'Tør du besøge dette link?'
+                  field_go_link:
+                    -
+                      uri: 'https://www.google.dk'
+                      title: Uhyggeligt!
+                      options:
+                        href: 'https://www.google.dk'
+                        data-entity-type: ''
+                        data-entity-uuid: ''
+                        data-entity-substitution: ''
+                  field_target_blank:
+                    -
+                      value: false
+          field_title:
+            -
+              value: 'Linkbox - Tør du besøge dette link?'
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/52863d4a-b270-40c3-8015-76c24aacc50b.yml
+++ b/web/modules/custom/dpl_example_content/content/node/52863d4a-b270-40c3-8015-76c24aacc50b.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 52863d4a-b270-40c3-8015-76c24aacc50b
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Børnenes bogtips'
+  created:
+    -
+      value: 1746540475
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Børnenes bogtips | DPL CMS'
+  path:
+    -
+      alias: /kategori/boernenes-bogtips
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: 'Børnenes bogtips'
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/5a18531a-963e-481c-9070-4ea578cf62e8.yml
+++ b/web/modules/custom/dpl_example_content/content/node/5a18531a-963e-481c-9070-4ea578cf62e8.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 5a18531a-963e-481c-9070-4ea578cf62e8
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Dyr
+  created:
+    -
+      value: 1746540576
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Dyr | DPL CMS'
+  path:
+    -
+      alias: /kategori/dyr
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Dyr
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/5fc5a750-9c89-4417-8953-0a76ff227d45.yml
+++ b/web/modules/custom/dpl_example_content/content/node/5fc5a750-9c89-4417-8953-0a76ff227d45.yml
@@ -1,0 +1,155 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 5fc5a750-9c89-4417-8953-0a76ff227d45
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+    d219e4de-4984-487e-8e21-9f56c0a0335c: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Science fiction'
+  created:
+    -
+      value: 1746518087
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Science fiction | DPL CMS'
+  path:
+    -
+      alias: /kategori/science-fiction
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Sci-Fi
+  field_paragraphs:
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 810c4657-cb5f-418b-bd4b-9949de999f53
+          bundle: go_video
+          default_langcode: da
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1746518120
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_embed_video:
+            -
+              entity: d219e4de-4984-487e-8e21-9f56c0a0335c
+          field_go_video_title:
+            -
+              value: 'Video - Nyeste trailer til Star Wars landet'
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 68a1ddcb-dde8-4786-8703-132347c7c4e4
+          bundle: go_material_slider_automatic
+          default_langcode: da
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1746518206
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_cql_search:
+            -
+              value: "'star wars'"
+          field_slider_amount_of_materials:
+            -
+              value: 8
+          field_title:
+            -
+              value: 'Material Slider Automatic - Anbefalede Star Wars titler'
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: d6d394c2-4d49-43ad-a0d2-0e183dca5e5c
+          bundle: go_material_slider_manual
+          default_langcode: da
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1746518354
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_material_slider_work_ids:
+            -
+              value: 'work-of:870970-basis:51919165'
+              material_type: bog
+            -
+              value: 'work-of:870970-basis:29377545'
+              material_type: ''
+            -
+              value: 'work-of:870970-basis:50673103'
+              material_type: ''
+            -
+              value: 'work-of:870970-basis:50625656'
+              material_type: ''
+          field_title:
+            -
+              value: 'Material Slider Manuel - Bliv klogere på Star Wars universet'
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/7be854e6-b74e-4ad5-8d52-3fca8e9f85f9.yml
+++ b/web/modules/custom/dpl_example_content/content/node/7be854e6-b74e-4ad5-8d52-3fca8e9f85f9.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 7be854e6-b74e-4ad5-8d52-3fca8e9f85f9
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Venskab
+  created:
+    -
+      value: 1746540505
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Venskab | DPL CMS'
+  path:
+    -
+      alias: /kategori/venskab
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Venskab
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/8e69a8c1-1778-4578-b3e3-70d9d6bcbb2e.yml
+++ b/web/modules/custom/dpl_example_content/content/node/8e69a8c1-1778-4578-b3e3-70d9d6bcbb2e.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 8e69a8c1-1778-4578-b3e3-70d9d6bcbb2e
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Letlæsning
+  created:
+    -
+      value: 1746540585
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Letlæsning | DPL CMS'
+  path:
+    -
+      alias: /kategori/letlaesning
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Letlæsning
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/d226f87d-b2b1-480f-b54d-cd87d4571fff.yml
+++ b/web/modules/custom/dpl_example_content/content/node/d226f87d-b2b1-480f-b54d-cd87d4571fff.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: d226f87d-b2b1-480f-b54d-cd87d4571fff
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Serier
+  created:
+    -
+      value: 1746540630
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Serier | DPL CMS'
+  path:
+    -
+      alias: /kategori/serier
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Serier
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/d61c2e26-0ecc-4e2f-b0f0-540582902d30.yml
+++ b/web/modules/custom/dpl_example_content/content/node/d61c2e26-0ecc-4e2f-b0f0-540582902d30.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: d61c2e26-0ecc-4e2f-b0f0-540582902d30
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Fakta
+  created:
+    -
+      value: 1746540451
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Fakta | DPL CMS'
+  path:
+    -
+      alias: /kategori/fakta
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Fakta
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/d92cbb70-dafa-4fe9-9693-89b1242df846.yml
+++ b/web/modules/custom/dpl_example_content/content/node/d92cbb70-dafa-4fe9-9693-89b1242df846.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: d92cbb70-dafa-4fe9-9693-89b1242df846
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Overrask mig'
+  created:
+    -
+      value: 1746540620
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Overrask mig | DPL CMS'
+  path:
+    -
+      alias: /kategori/overrask-mig
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: 'Overrask mig'
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/d92feb2f-8e49-4680-9512-472df40a5e76.yml
+++ b/web/modules/custom/dpl_example_content/content/node/d92feb2f-8e49-4680-9512-472df40a5e76.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: d92feb2f-8e49-4680-9512-472df40a5e76
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Kærlighed
+  created:
+    -
+      value: 1746540357
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Kærlighed | DPL CMS'
+  path:
+    -
+      alias: /kategori/kaerlighed
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Kærlighed
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/f5e70db9-73d7-402e-a867-73712f8c5d63.yml
+++ b/web/modules/custom/dpl_example_content/content/node/f5e70db9-73d7-402e-a867-73712f8c5d63.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: f5e70db9-73d7-402e-a867-73712f8c5d63
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Unge
+  created:
+    -
+      value: 1746540566
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Unge | DPL CMS'
+  path:
+    -
+      alias: /kategori/unge
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Unge
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/fe2840b5-a0bd-435e-861b-9a3df5eedf22.yml
+++ b/web/modules/custom/dpl_example_content/content/node/fe2840b5-a0bd-435e-861b-9a3df5eedf22.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: fe2840b5-a0bd-435e-861b-9a3df5eedf22
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: Fantasy
+  created:
+    -
+      value: 1746540525
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Fantasy | DPL CMS'
+  path:
+    -
+      alias: /kategori/fantasy
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: Fantasy
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/content/node/ffda6a08-b27e-420f-9c14-e565b7c1da75.yml
+++ b/web/modules/custom/dpl_example_content/content/node/ffda6a08-b27e-420f-9c14-e565b7c1da75.yml
@@ -1,0 +1,59 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: ffda6a08-b27e-420f-9c14-e565b7c1da75
+  bundle: go_category
+  default_langcode: da
+  depends:
+    109347b3-c3df-4b2d-a8fb-d4e379c2cc50: media
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Sjove bøger'
+  created:
+    -
+      value: 1746540485
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  bnf_state:
+    -
+      value: 0
+  entity_clone_template_active:
+    -
+      value: false
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Sjove bøger | DPL CMS'
+  path:
+    -
+      alias: /kategori/sjove-boeger
+      langcode: und
+      pathauto: 1
+  field_category_menu_image:
+    -
+      entity: 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
+  field_category_menu_title:
+    -
+      value: 'Sjove bøger'
+  field_publication_date:
+    -
+      value: '2025-05-06'

--- a/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
+++ b/web/modules/custom/dpl_example_content/dpl_example_content.info.yml
@@ -34,6 +34,22 @@ default_content:
     - 5b67227c-adfb-46bd-8808-afc5494b24f9
     # GO Articles
     - 9010aabf-d87d-4d24-ada0-910090846f28
+    # GO Categories
+    - 37fcfc9e-5925-4fe5-987d-62b144045440
+    - 5fc5a750-9c89-4417-8953-0a76ff227d45
+    - d92feb2f-8e49-4680-9512-472df40a5e76
+    - d61c2e26-0ecc-4e2f-b0f0-540582902d30
+    - 52863d4a-b270-40c3-8015-76c24aacc50b
+    - ffda6a08-b27e-420f-9c14-e565b7c1da75
+    - 16f740f1-0040-40af-a59e-6925fc9bac0d
+    - 7be854e6-b74e-4ad5-8d52-3fca8e9f85f9
+    - fe2840b5-a0bd-435e-861b-9a3df5eedf22
+    - 0c18c225-af99-45d5-b6d5-73eb2dabbba1
+    - f5e70db9-73d7-402e-a867-73712f8c5d63
+    - 5a18531a-963e-481c-9070-4ea578cf62e8
+    - 8e69a8c1-1778-4578-b3e3-70d9d6bcbb2e
+    - d92cbb70-dafa-4fe9-9693-89b1242df846
+    - d226f87d-b2b1-480f-b54d-cd87d4571fff
   eventseries:
     # https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?type=design&node-id=7477-39713&mode=dev
     - c8177097-1438-493e-8177-e8ef968cc133
@@ -63,6 +79,7 @@ default_content:
     - ddd4f544-aff0-40d4-8c8e-651ca39e8db6
     - d219e4de-4984-487e-8e21-9f56c0a0335c
     - 06fbedf9-cbc7-4d70-b911-cbda63c4efca
+    - 109347b3-c3df-4b2d-a8fb-d4e379c2cc50
   file:
     - b0fea511-57df-4b49-b127-1c445beacfe7
     - f19a4a4c-80b0-4290-a098-4f2f5fc137a2


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-577

#### Description

Added 15 Go Category nodes as example content. Also included an image that we use as the Go Category menu image.

2 Go Categories also include a few paragraphs ("Gys" and "Science Fiction"), the rest of the nodes does not contain any paragraphs.

#### Screenshot of the result
![Screenshot 2025-05-06 at 16 53 18](https://github.com/user-attachments/assets/b23fc403-1f9c-4649-8392-1d2baa1f967c)
