### PR TITLE
Set correct vocabulary for tags field on eventinstances. DDFSAL-111

### DIFF
--- a/config/sync/field.field.eventinstance.default.field_tags.yml
+++ b/config/sync/field.field.eventinstance.default.field_tags.yml
@@ -5,7 +5,7 @@ dependencies:
   config:
     - field.storage.eventinstance.field_tags
     - recurring_events.eventinstance_type.default
-    - taxonomy.vocabulary.categories
+    - taxonomy.vocabulary.tags
 id: eventinstance.default.field_tags
 field_name: field_tags
 entity_type: eventinstance
@@ -20,7 +20,7 @@ settings:
   handler: 'default:taxonomy_term'
   handler_settings:
     target_bundles:
-      categories: categories
+      tags: tags
     sort:
       field: name
       direction: asc


### PR DESCRIPTION
The "field_tags" on eventinstances was set to the categories vocabulary, which must be a mistake.
This commit sets it instead to "tags" vocabulary.
I've tested, and if any existing eventinstances already had data in the field, it is just removed (As expected), without incurring an error.
