### PR TITLE
DDFBRA-591 - Set the display for GO content in the editorial_search view to list_teaser

### DIFF
--- a/config/sync/views.view.editorial_search.yml
+++ b/config/sync/views.view.editorial_search.yml
@@ -249,9 +249,14 @@ display:
         options:
           view_modes:
             'entity:eventseries':
+              ':default': list_teaser
               default: list_teaser
             'entity:node':
+              ':default': list_teaser
               article: list_teaser
+              go_article: list_teaser
+              go_category: list_teaser
+              go_page: list_teaser
               page: list_teaser
       query:
         type: search_api_query


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-591

#### Description

After adding Go content types to the `editorial_search` view, we still needed to chose which display to use. 
Other content types was using the display `list teaser`, so we are gonna do the same of Go Content.

With Go Content it still does not look that good, because currently we haven't set the up the fields normally used in the `list teaser` display. We will need to decide if this is something we want to do.

#### Screenshot of the result
The screenshot shows the difference between a normal FB-CMS article and the GO content.
![Screenshot 2025-05-09 at 03 02 51](https://github.com/user-attachments/assets/e4ae1ea1-e4e1-495b-a535-77b9439b109b)

