### PR TITLE
Implement a cache of node types in the path processor

### DIFF
--- a/web/modules/custom/dpl_go/dpl_go.services.yml
+++ b/web/modules/custom/dpl_go/dpl_go.services.yml
@@ -9,7 +9,14 @@ services:
 
   dpl_go.go_site:
     class: Drupal\dpl_go\GoSite
+    arguments:
+      $keyValueStore: '@dpl_go.node_type_storage'
   Drupal\dpl_go\GoSite: '@dpl_go.go_site'
+
+  dpl_go.node_type_storage:
+    class: Drupal\Core\KeyValueStore\KeyValueStoreInterface
+    factory: ['@keyvalue', 'get']
+    arguments: ['dpl_go_node_type']
 
   dpl_go.path_processor_outbound:
     class: Drupal\dpl_go\PathProcessor\OutboundPathProcessor

--- a/web/modules/custom/dpl_go/src/GoSite.php
+++ b/web/modules/custom/dpl_go/src/GoSite.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Drupal\dpl_go;
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\dpl_lagoon\Services\LagoonRouteResolver;
 use function Safe\parse_url;
 
@@ -14,10 +17,26 @@ use function Safe\parse_url;
  */
 class GoSite {
 
+  /**
+   * Node storage.
+   */
+  protected EntityStorageInterface $nodeStorage;
+
+  /**
+   * Static node type cache.
+   *
+   * @var array<int, array<string, bool>>
+   */
+  protected $typeCoche = [];
+
   public function __construct(
     protected LagoonRouteResolver $lagoonRouteResolver,
     protected AccountInterface $currentUser,
-  ) {}
+    EntityTypeManagerInterface $entityTypeManager,
+    protected StateInterface $state,
+  ) {
+    $this->nodeStorage = $entityTypeManager->getStorage('node');
+  }
 
   /**
    * Is the current request considered "the Go site".
@@ -87,6 +106,52 @@ class GoSite {
    */
   public function isGoNode(EntityInterface $node): bool {
     return str_starts_with($node->bundle(), 'go_');
+  }
+
+  /**
+   * Determine if the given nid is a Go node.
+   */
+  public function isGoNid(string $nid): ?bool {
+    // We store our cache of node types in chunks of 100 to limit the amount of
+    // state items and queries. And we use state instead of cache as a nodes
+    // type cannot be changed after creation anyway, and even CACHE_PERMANENT
+    // entries are cleared on cache rebuild.
+    $cache_num = floor(intval($nid) / 100);
+    $state_id = "dpl_go.node_type_cache_{$cache_num}";
+
+    // Use a static cache. This will drastically limit the amount of queries we
+    // need to do.
+    if (!isset($this->typeCoche[$cache_num])) {
+      $this->typeCoche[$cache_num] = $this->state->get($state_id, []);
+    }
+
+    if (isset($this->typeCoche[$cache_num][$nid])) {
+      return $this->typeCoche[$cache_num][$nid];
+    }
+
+    $this->typeCoche[$cache_num][$nid] = NULL;
+
+    $node = $this->nodeStorage->load($nid);
+
+    if ($node) {
+      $this->typeCoche[$cache_num][$nid] = $this->isGoNode($node);
+    }
+
+    // Add in fresh copy of saved state to guard against race conditions.
+    $this->typeCoche[$cache_num] += $this->state->get($state_id, []);
+
+    // While the types of existing nodes don't change, the non-existence of a
+    // node (signified by null values) might, so filter out the null values
+    // before saving so it'll not stick around to future requests.
+    $filtered = array_filter($this->typeCoche[$cache_num], fn ($val) => !is_null($val));
+    if (!empty($filtered)) {
+      $this->state->set($state_id, $filtered);
+    }
+    else {
+      $this->state->delete($state_id);
+    }
+
+    return $this->typeCoche[$cache_num][$nid];
   }
 
 }

--- a/web/modules/custom/dpl_go/src/GoSite.php
+++ b/web/modules/custom/dpl_go/src/GoSite.php
@@ -7,8 +7,8 @@ namespace Drupal\dpl_go;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\State\StateInterface;
 use Drupal\dpl_lagoon\Services\LagoonRouteResolver;
 use function Safe\parse_url;
 
@@ -33,7 +33,7 @@ class GoSite {
     protected LagoonRouteResolver $lagoonRouteResolver,
     protected AccountInterface $currentUser,
     EntityTypeManagerInterface $entityTypeManager,
-    protected StateInterface $state,
+    protected KeyValueStoreInterface $keyValueStore,
   ) {
     $this->nodeStorage = $entityTypeManager->getStorage('node');
   }
@@ -113,16 +113,16 @@ class GoSite {
    */
   public function isGoNid(string $nid): ?bool {
     // We store our cache of node types in chunks of 100 to limit the amount of
-    // state items and queries. And we use state instead of cache as a nodes
-    // type cannot be changed after creation anyway, and even CACHE_PERMANENT
-    // entries are cleared on cache rebuild.
+    // key-value items and queries. And we use key-value instead of cache as a
+    // nodes type cannot be changed after creation anyway, and even
+    // CACHE_PERMANENT entries are cleared on cache rebuild.
     $cache_num = floor(intval($nid) / 100);
     $state_id = "dpl_go.node_type_cache_{$cache_num}";
 
     // Use a static cache. This will drastically limit the amount of queries we
     // need to do.
     if (!isset($this->typeCoche[$cache_num])) {
-      $this->typeCoche[$cache_num] = $this->state->get($state_id, []);
+      $this->typeCoche[$cache_num] = $this->keyValueStore->get($state_id, []);
     }
 
     if (isset($this->typeCoche[$cache_num][$nid])) {
@@ -138,17 +138,17 @@ class GoSite {
     }
 
     // Add in fresh copy of saved state to guard against race conditions.
-    $this->typeCoche[$cache_num] += $this->state->get($state_id, []);
+    $this->typeCoche[$cache_num] += $this->keyValueStore->get($state_id, []);
 
     // While the types of existing nodes don't change, the non-existence of a
     // node (signified by null values) might, so filter out the null values
     // before saving so it'll not stick around to future requests.
     $filtered = array_filter($this->typeCoche[$cache_num], fn ($val) => !is_null($val));
     if (!empty($filtered)) {
-      $this->state->set($state_id, $filtered);
+      $this->keyValueStore->set($state_id, $filtered);
     }
     else {
-      $this->state->delete($state_id);
+      $this->keyValueStore->delete($state_id);
     }
 
     return $this->typeCoche[$cache_num][$nid];

--- a/web/modules/custom/dpl_go/src/PathProcessor/OutboundPathProcessor.php
+++ b/web/modules/custom/dpl_go/src/PathProcessor/OutboundPathProcessor.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\dpl_go\PathProcessor;
 
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Routing\AdminContext;
@@ -21,17 +19,10 @@ use function Safe\preg_match;
  */
 class OutboundPathProcessor implements OutboundPathProcessorInterface {
 
-  /**
-   * Node storage.
-   */
-  protected EntityStorageInterface $nodeStorage;
-
   public function __construct(
     protected GoSite $goSite,
-    EntityTypeManagerInterface $entityTypeManager,
     protected AdminContext $adminContext,
   ) {
-    $this->nodeStorage = $entityTypeManager->getStorage('node');
   }
 
   /**
@@ -72,11 +63,8 @@ class OutboundPathProcessor implements OutboundPathProcessorInterface {
         $bubbleableMetadata->addCacheContexts(['dpl_is_go']);
       }
 
-      $node = $this->nodeStorage->load($pathParts[2]);
-
-      if ($node) {
-        $isGoNode = $this->goSite->isGoNode($node);
-
+      $isGoNode = $this->goSite->isGoNid($pathParts[2]);
+      if (!is_null($isGoNode)) {
         if ($isGoNode xor $this->goSite->isGoSite()) {
           $options['absolute'] = TRUE;
           $options['base_url'] = $isGoNode ?

--- a/web/modules/custom/dpl_go/test/src/Unit/PathProcessor/OutboundPathProcessorTest.php
+++ b/web/modules/custom/dpl_go/test/src/Unit/PathProcessor/OutboundPathProcessorTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\dpl_go\Unit\PathProcessor;
 
-use Drupal\Core\Entity\EntityBase;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Routing\AdminContext;
 use Drupal\dpl_go\GoSite;
@@ -28,13 +25,6 @@ class OutboundPathProcessorTest extends UnitTestCase {
   protected ObjectProphecy $goSite;
 
   /**
-   * Node storage mock.
-   *
-   * @var \Prophecy\Prophecy\ObjectProphecy<\Drupal\Core\Entity\EntityStorageInterface>
-   */
-  protected ObjectProphecy $nodeStorage;
-
-  /**
    * AdminContext mock.
    *
    * @var \Prophecy\Prophecy\ObjectProphecy<\Drupal\Core\Routing\AdminContext>
@@ -52,10 +42,6 @@ class OutboundPathProcessorTest extends UnitTestCase {
   public function setUp(): void {
     parent::setUp();
 
-    $this->nodeStorage = $this->prophesize(EntityStorageInterface::class);
-    $typeManager = $this->prophesize(EntityTypeManagerInterface::class);
-    $typeManager->getStorage('node')->willReturn($this->nodeStorage);
-
     $this->goSite = $this->prophesize(GoSite::class);
     $this->goSite->getGoBaseUrl();
 
@@ -64,7 +50,6 @@ class OutboundPathProcessorTest extends UnitTestCase {
 
     $this->pathProcessor = new OutboundPathProcessor(
       $this->goSite->reveal(),
-      $typeManager->reveal(),
       $this->adminContext->reveal(),
     );
   }
@@ -96,10 +81,8 @@ class OutboundPathProcessorTest extends UnitTestCase {
     bool $isGo,
     ?string $expectedBaseUrl,
   ): void {
-    $node = $this->prophesize(EntityBase::class);
-    $this->nodeStorage->load($nid)->willReturn($node);
     $this->goSite->isGoSite()->willReturn($isGo);
-    $this->goSite->isGoNode($node)->willReturn($isGoNode);
+    $this->goSite->isGoNid($nid)->willReturn($isGoNode);
     $this->goSite->getCmsBaseUrl()->willReturn('https://cms.site');
     $this->goSite->getGoBaseUrl()->willReturn('https://go.cms.site');
 
@@ -147,10 +130,8 @@ class OutboundPathProcessorTest extends UnitTestCase {
     bool $isGo,
     ?string $ignored,
   ): void {
-    $node = $this->prophesize(EntityBase::class);
-    $this->nodeStorage->load($nid)->willReturn($node);
     $this->goSite->isGoSite()->willReturn($isGo);
-    $this->goSite->isGoNode($node)->willReturn($isGoNode);
+    $this->goSite->isGoNid($nid)->willReturn($isGoNode);
     $this->goSite->getCmsBaseUrl()->willReturn('https://cms.site');
     $this->goSite->getGoBaseUrl()->willReturn('https://go.cms.site');
     $this->adminContext->isAdminRoute()->willReturn(TRUE);


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-112

#### Description

The consequence of path rewriting is that we have to load each linked node to check its type to determine whether we need to rewrite the URL.

In order to limit the number of entity loads we do, we implement a static cache to keep track of whether a nid is a go node or not. We save this cache to state (as even CACHE_PERMANENT cache items are flushed on cache rebuild) and do it in chunks of a hundred items to keep down the amount of queries when our cache is filled.
