### PR TITLE
Enable queue_ui on library sites

### DIFF
--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -152,6 +152,12 @@ function dpl_update_install(): string {
   $messages[] = dpl_update_update_10043();
   $messages[] = dpl_update_update_10047();
 
+  /*
+   * dpl_update_update_10050 is not needed, when installing from scratch the
+   * deploy hook that enables bnf_client is used, which properly installs
+   * dependencies.
+   */
+
   return implode('\r\n', $messages);
 }
 
@@ -614,4 +620,15 @@ function dpl_update_update_10048(): string {
  */
 function dpl_update_update_10049(): string {
   return _dpl_update_install_modules(['next', 'next_graphql']);
+}
+
+/**
+ * Enable queue_ui for bnf_client.
+ */
+function dpl_update_update_10050(): string {
+  if (\Drupal::moduleHandler()->moduleExists('bnf_client')) {
+    return _dpl_update_install_modules(['queue_ui']);
+  }
+
+  return "bnf_client not enabled, not enabling queue_ui";
 }


### PR DESCRIPTION
The bnf_client module added it as a dependency, but it was kinda forgotten because bnf_client isn't installed like other modules.

Use an update hook to enable queue_ui if if the bnf_client is enabled.

Ref [DDFSAL-127](https://reload.atlassian.net/browse/DDFSAL-127)


[DDFSAL-127]: https://reload.atlassian.net/browse/DDFSAL-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ