### PR TITLE
BNF: Don't recreate entities if existing.

### DIFF
--- a/web/modules/custom/bnf/src/Plugin/Traits/EmbedVideoTrait.php
+++ b/web/modules/custom/bnf/src/Plugin/Traits/EmbedVideoTrait.php
@@ -56,7 +56,7 @@ trait EmbedVideoTrait {
 
     $properties = [
       'bundle' => 'video',
-      'name' => $video->name ?? '',
+      'name' => $video->name ?? 'Video',
       'field_media_oembed_video' => $video->mediaOembedVideo,
       'status' => TRUE,
     ];
@@ -81,7 +81,7 @@ trait EmbedVideoTrait {
 
     $properties = [
       'bundle' => 'videotool',
-      'name' => $video->name ?? '',
+      'name' => $video->name ?? 'Video',
       'field_media_videotool' => $video->mediaVideotool,
       'status' => TRUE,
     ];

--- a/web/modules/custom/bnf/src/Plugin/Traits/FileTrait.php
+++ b/web/modules/custom/bnf/src/Plugin/Traits/FileTrait.php
@@ -92,10 +92,13 @@ trait FileTrait {
       'field_media_file' => [
         'target_id' => $file->id(),
         'display' => TRUE,
-        'description' => $document->mediaFile->description ?? '',
       ],
       'name' => $document->mediaFile->name,
     ];
+
+    if (!empty($document->mediaFile->description)) {
+      $properties['field_media_file']['description'] = $document->mediaFile->description;
+    }
 
     // Look up existing media - if it exists, referer to that, otherwise create.
     $medias = $mediaStorage->loadByProperties($properties);

--- a/web/modules/custom/bnf/src/Plugin/Traits/ImageTrait.php
+++ b/web/modules/custom/bnf/src/Plugin/Traits/ImageTrait.php
@@ -42,12 +42,18 @@ trait ImageTrait {
       'bundle' => 'image',
       'name' => $image->name ?? $file->getFilename(),
       'status' => TRUE,
-      'field_byline' => $image->byline ?? '',
       'field_media_image' => [
         'target_id' => $file->id(),
-        'alt' => $alt ?? '',
       ],
     ];
+
+    if (!empty($image->byline)) {
+      $properties['field_byline'] = $image->byline;
+    }
+
+    if (!empty($alt)) {
+      $properties['field_media_image']['alt'] = $alt;
+    }
 
     // Look up existing media - if it exists, referer to that, otherwise create.
     $medias = $mediaStorage->loadByProperties($properties);


### PR DESCRIPTION
Apparantly, LoadByProperties doesn't like it when you pass along an empty string - and `NULL` is not allowed. Instead, we'll explictly set the values for lookup if they exist.
