### PR TITLE
DDFBRA-554 - Add preview for GO content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,6 +133,7 @@
         "drupal/gin_toolbar": "^1.0@RC",
         "drupal/graphql": "^4.9",
         "drupal/graphql_compose": "^2.2",
+        "drupal/graphql_compose_preview": "^1.1",
         "drupal/handy_cache_tags": "^1.4",
         "drupal/health_check": "^3.1",
         "drupal/honeypot": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f175feef7d1fe669bd7cb7785b95a4d7",
+    "content-hash": "4f6ae266383db0ab4addcd56da0baed7",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -5077,6 +5077,100 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/graphql_compose",
                 "issues": "https://www.drupal.org/project/issues/graphql_compose"
+            }
+        },
+        {
+            "name": "drupal/graphql_compose_preview",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/graphql_compose_preview.git",
+                "reference": "1.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/graphql_compose_preview-1.1.0.zip",
+                "reference": "1.1.0",
+                "shasum": "ca950c8deaf6259f2b523359e8edbd4da0f3fd3f"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11",
+                "drupal/graphql_compose": "^2.1",
+                "drupal/graphql_compose_routes": "*",
+                "drupal/token": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "drupal/token": "^1"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.1.0",
+                    "datestamp": "1745714549",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "almunnings",
+                    "homepage": "https://www.drupal.org/user/2251362"
+                },
+                {
+                    "name": "cedricl",
+                    "homepage": "https://www.drupal.org/user/3715087"
+                }
+            ],
+            "description": "Extended preview capabilities for GraphQL Compose.",
+            "homepage": "http://drupal.org/project/graphql_compose_preview",
+            "support": {
+                "source": "http://cgit.drupalcode.org/graphql_compose_preview",
+                "issues": "https://www.drupal.org/project/issues/graphql_compose_preview"
+            }
+        },
+        {
+            "name": "drupal/graphql_compose_routes",
+            "version": "2.3.0",
+            "require": {
+                "drupal/core": "^10.2 || ^11",
+                "drupal/graphql_compose": "*"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "2.3.0",
+                    "datestamp": "1739387377",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "almunnings",
+                    "homepage": "https://www.drupal.org/user/2251362"
+                },
+                {
+                    "name": "jmolivas",
+                    "homepage": "https://www.drupal.org/user/678770"
+                }
+            ],
+            "description": "Enable to load content by URL.",
+            "homepage": "https://www.drupal.org/project/graphql_compose",
+            "support": {
+                "source": "https://git.drupalcode.org/project/graphql_compose"
             }
         },
         {

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -22,6 +22,7 @@ ignored_config_entities:
     - dpl_reservations.settings
     - dpl_unilogin.settings
     - dpl_url_proxy.settings
+    - next.next_site.go
     - novel.settings
     - openid_connect.client.adgangsplatformen
     - system.site
@@ -45,6 +46,7 @@ ignored_config_entities:
     - dpl_reservations.settings
     - dpl_unilogin.settings
     - dpl_url_proxy.settings
+    - next.next_site.go
     - novel.settings
     - openid_connect.client.adgangsplatformen
     - system.site

--- a/config/sync/core.entity_view_display.node.article.card.yml
+++ b/config/sync/core.entity_view_display.node.article.card.yml
@@ -65,4 +65,5 @@ hidden:
   field_tags: true
   langcode: true
   links: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -106,4 +106,5 @@ hidden:
   field_canonical_url: true
   field_paragraphs: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.full.yml
+++ b/config/sync/core.entity_view_display.node.article.full.yml
@@ -77,4 +77,5 @@ hidden:
   field_teaser_image: true
   field_teaser_text: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.list_teaser.yml
@@ -99,4 +99,5 @@ hidden:
   field_paragraphs: true
   field_publication_date: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.article.nav_spot.yml
@@ -58,4 +58,5 @@ hidden:
   field_tags: true
   langcode: true
   links: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.nav_teaser.yml
@@ -43,4 +43,5 @@ hidden:
   field_teaser_text: true
   langcode: true
   links: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -41,4 +41,5 @@ hidden:
   field_teaser_image: true
   field_teaser_text: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.branch.card.yml
+++ b/config/sync/core.entity_view_display.node.branch.card.yml
@@ -31,4 +31,5 @@ hidden:
   field_phone: true
   field_promoted_on_lists: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.branch.default.yml
+++ b/config/sync/core.entity_view_display.node.branch.default.yml
@@ -70,4 +70,5 @@ content:
 hidden:
   field_promoted_on_lists: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.branch.full.yml
+++ b/config/sync/core.entity_view_display.node.branch.full.yml
@@ -40,4 +40,5 @@ hidden:
   field_phone: true
   field_promoted_on_lists: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.branch.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.branch.list_teaser.yml
@@ -71,4 +71,5 @@ content:
 hidden:
   field_promoted_on_lists: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.branch.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.branch.nav_spot.yml
@@ -31,4 +31,5 @@ hidden:
   field_phone: true
   field_promoted_on_lists: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.branch.teaser.yml
+++ b/config/sync/core.entity_view_display.node.branch.teaser.yml
@@ -31,4 +31,5 @@ hidden:
   field_phone: true
   field_promoted_on_lists: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.campaign.default.yml
+++ b/config/sync/core.entity_view_display.node.campaign.default.yml
@@ -73,4 +73,5 @@ content:
     region: content
 hidden:
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.campaign.teaser.yml
+++ b/config/sync/core.entity_view_display.node.campaign.teaser.yml
@@ -29,4 +29,5 @@ hidden:
   field_campaign_rules_logic: true
   field_campaign_text: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_article.card.yml
+++ b/config/sync/core.entity_view_display.node.go_article.card.yml
@@ -58,4 +58,5 @@ hidden:
   field_show_override_author: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_article.default.yml
+++ b/config/sync/core.entity_view_display.node.go_article.default.yml
@@ -89,4 +89,5 @@ hidden:
   field_paragraphs: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_article.full.yml
+++ b/config/sync/core.entity_view_display.node.go_article.full.yml
@@ -15,41 +15,30 @@ dependencies:
     - field.field.node.go_article.field_teaser_text
     - node.type.go_article
   module:
-    - entity_reference_revisions
+    - dpl_go
     - user
 id: node.go_article.full
 targetEntityType: node
 bundle: go_article
 mode: full
 content:
-  field_paragraphs:
-    type: entity_reference_revisions_entity_view
-    label: hidden
-    settings:
-      view_mode: default
-      link: ''
-    third_party_settings: {  }
-    weight: 1
-    region: content
-  field_subtitle:
-    type: basic_string
-    label: hidden
+  preview_token:
+    type: go_preview_token_iframe
+    label: above
     settings: {  }
     third_party_settings: {  }
     weight: 0
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 2
-    region: content
 hidden:
   field_go_article_image: true
   field_override_author: true
+  field_paragraphs: true
   field_publication_date: true
   field_show_override_author: true
+  field_subtitle: true
   field_tags: true
   field_teaser_image: true
   field_teaser_text: true
   langcode: true
+  links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_article.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.go_article.list_teaser.yml
@@ -74,4 +74,5 @@ hidden:
   field_publication_date: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_article.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.go_article.nav_spot.yml
@@ -58,4 +58,5 @@ hidden:
   field_show_override_author: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_article.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.node.go_article.nav_teaser.yml
@@ -43,4 +43,5 @@ hidden:
   field_teaser_image: true
   field_teaser_text: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.go_article.teaser.yml
@@ -37,4 +37,5 @@ hidden:
   field_teaser_image: true
   field_teaser_text: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_category.card.yml
+++ b/config/sync/core.entity_view_display.node.go_category.card.yml
@@ -33,4 +33,5 @@ hidden:
   field_publication_date: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_category.default.yml
+++ b/config/sync/core.entity_view_display.node.go_category.default.yml
@@ -56,4 +56,5 @@ hidden:
   field_paragraphs: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_category.full.yml
+++ b/config/sync/core.entity_view_display.node.go_category.full.yml
@@ -13,33 +13,28 @@ dependencies:
     - field.field.node.go_category.field_tags
     - node.type.go_category
   module:
-    - entity_reference_revisions
+    - dpl_go
     - user
 id: node.go_category.full
 targetEntityType: node
 bundle: go_category
 mode: full
 content:
-  field_paragraphs:
-    type: entity_reference_revisions_entity_view
-    label: hidden
-    settings:
-      view_mode: default
-      link: ''
-    third_party_settings: {  }
-    weight: 0
-    region: content
-  links:
+  preview_token:
+    type: go_preview_token_iframe
+    label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 0
     region: content
 hidden:
   field_category_menu_image: true
   field_category_menu_sound: true
   field_category_menu_title: true
   field_go_color: true
+  field_paragraphs: true
   field_publication_date: true
   field_tags: true
   langcode: true
+  links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_category.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.go_category.list_teaser.yml
@@ -33,4 +33,5 @@ hidden:
   field_publication_date: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_category.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.go_category.nav_spot.yml
@@ -33,4 +33,5 @@ hidden:
   field_publication_date: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_category.teaser.yml
+++ b/config/sync/core.entity_view_display.node.go_category.teaser.yml
@@ -33,4 +33,5 @@ hidden:
   field_publication_date: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_page.default.yml
+++ b/config/sync/core.entity_view_display.node.go_page.default.yml
@@ -33,4 +33,5 @@ hidden:
   field_paragraphs: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_page.full.yml
+++ b/config/sync/core.entity_view_display.node.go_page.full.yml
@@ -9,29 +9,24 @@ dependencies:
     - field.field.node.go_page.field_tags
     - node.type.go_page
   module:
-    - entity_reference_revisions
+    - dpl_go
     - user
 id: node.go_page.full
 targetEntityType: node
 bundle: go_page
 mode: full
 content:
-  field_paragraphs:
-    type: entity_reference_revisions_entity_view
-    label: hidden
-    settings:
-      view_mode: default
-      link: ''
+  preview_token:
+    type: go_preview_token_iframe
+    label: above
+    settings: {  }
     third_party_settings: {  }
     weight: 0
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
 hidden:
+  field_paragraphs: true
   field_publication_date: true
   field_tags: true
   langcode: true
+  links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_page.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.go_page.list_teaser.yml
@@ -25,4 +25,5 @@ hidden:
   field_publication_date: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.go_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.go_page.teaser.yml
@@ -25,4 +25,5 @@ hidden:
   field_publication_date: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.card.yml
+++ b/config/sync/core.entity_view_display.node.page.card.yml
@@ -62,4 +62,5 @@ hidden:
   field_publication_date: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -96,4 +96,5 @@ hidden:
   field_paragraphs: true
   field_subtitle: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.full.yml
+++ b/config/sync/core.entity_view_display.node.page.full.yml
@@ -76,4 +76,5 @@ hidden:
   field_teaser_image: true
   field_teaser_text: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.list_teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.list_teaser.yml
@@ -75,4 +75,5 @@ hidden:
   field_paragraphs: true
   field_publication_date: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.nav_spot.yml
+++ b/config/sync/core.entity_view_display.node.page.nav_spot.yml
@@ -62,4 +62,5 @@ hidden:
   field_publication_date: true
   field_tags: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.nav_teaser.yml
@@ -47,4 +47,5 @@ hidden:
   field_teaser_image: true
   field_teaser_text: true
   langcode: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -37,4 +37,5 @@ hidden:
   field_teaser_text: true
   langcode: true
   links: true
+  preview_token: true
   search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -109,6 +109,7 @@ module:
   gin_toolbar: 0
   graphql: 0
   graphql_compose: 0
+  graphql_compose_preview: 0
   graphql_compose_routes: 0
   graphql_compose_views: 0
   handy_cache_tags: 0

--- a/config/sync/user.role.go_graphql_client.yml
+++ b/config/sync/user.role.go_graphql_client.yml
@@ -4,7 +4,9 @@ status: true
 dependencies:
   module:
     - dpl_go
+    - dpl_graphql
     - graphql
+    - graphql_compose_preview
     - paragraphs
     - view_unpublished
 id: go_graphql_client
@@ -16,4 +18,5 @@ permissions:
   - 'get dpl graphql cache tags'
   - 'rewrite go urls'
   - 'view any unpublished content'
+  - 'view graphql_compose_preview entity'
   - 'view unpublished paragraphs'

--- a/web/modules/custom/dpl_go/dpl_go.info.yml
+++ b/web/modules/custom/dpl_go/dpl_go.info.yml
@@ -5,5 +5,6 @@ package: DPL
 core_version_requirement: ^10 || ^11
 dependencies:
   - graphql:graphql
+  - graphql_compose_preview:graphql_compose_preview
   - dpl_unilogin:dpl_unilogin
   - dpl_lagoon:dpl_lagoon

--- a/web/modules/custom/dpl_go/src/Plugin/Field/FieldFormatter/PreviewTokenIframeGoFormatter.php
+++ b/web/modules/custom/dpl_go/src/Plugin/Field/FieldFormatter/PreviewTokenIframeGoFormatter.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\dpl_go\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\Template\Attribute;
+use Drupal\Core\Utility\Token;
+use Drupal\dpl_go\GoSite;
+use Drupal\graphql_compose_preview\TokenHelper;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the 'preview_token_whatever' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "go_preview_token_iframe",
+ *   label = @Translation("GO token preview iframe"),
+ *   field_types = {
+ *     "preview_token",
+ *   },
+ * )
+ */
+class PreviewTokenIframeGoFormatter extends FormatterBase {
+
+  /**
+   * The GoSite service.
+   *
+   * @var \Drupal\dpl_go\GoSite
+   */
+  protected GoSite $goSite;
+
+  /**
+   * The token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */
+  protected Token $token;
+
+  /**
+   * The token helper service.
+   *
+   * @var \Drupal\graphql_compose_preview\TokenHelper
+   */
+  protected TokenHelper $tokenHelper;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+
+    $instance->token = $container->get('token');
+    $instance->tokenHelper = $container->get('graphql_compose_preview.token_helper');
+    $instance->goSite = $container->get('dpl_go.go_site');
+
+    return $instance;
+  }
+
+  /**
+   * Get the iframe URL.
+   *
+   * @return string
+   *   The iframe URL.
+   */
+  protected function getLinkUrl(): string {
+    return $this->goSite->getGoBaseUrl() . '/preview/' . '[node:preview:uuid]' . '?token=' . '[node:preview:token]';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $element = [];
+
+    $entity = $items->getEntity();
+    if (!$entity instanceof NodeInterface) {
+      return [];
+    }
+
+    $url = $this->tokenHelper->url($entity);
+    if (!$url) {
+      return [];
+    }
+
+    $access = $this->tokenHelper->access($entity);
+    $cache_metadata = new BubbleableMetadata();
+
+    $src = $this->token->replace(
+      $this->getLinkUrl(),
+      ['node' => $entity],
+      ['clear' => FALSE]
+    );
+
+    foreach ($items as $delta => $item) {
+      $element[$delta] = [
+        '#theme' => 'token_preview_iframe',
+        '#node' => $entity,
+        '#preview_token' => $item,
+        '#preview_token_url' => $url,
+        '#preview_token_access' => $access,
+        '#attributes' => new Attribute([
+          'src' => $src,
+          'class' => 'go-preview-iframe',
+          'width' => '100%',
+          'height' => '100%',
+          'style' => 'height: calc((100vh - 0px) - 121px);',
+          'allow' => 'fullscreen autoplay',
+          'allowtransparency' => $this->getSetting('transparency'),
+          'frameborder' => 0,
+        ]),
+      ];
+    }
+
+    $cache_metadata->addCacheableDependency($url);
+    $cache_metadata->applyTo($element);
+
+    return $element;
+  }
+
+}

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -151,6 +151,7 @@ function dpl_update_install(): string {
   $messages[] = dpl_update_update_10042();
   $messages[] = dpl_update_update_10043();
   $messages[] = dpl_update_update_10047();
+  $messages[] = dpl_update_update_10051();
 
   /*
    * dpl_update_update_10050 is not needed, when installing from scratch the
@@ -631,4 +632,11 @@ function dpl_update_update_10050(): string {
   }
 
   return "bnf_client not enabled, not enabling queue_ui";
+}
+
+/**
+ * Install graphql_compose_preview module.
+ */
+function dpl_update_update_10051(): string {
+  return _dpl_update_install_modules(['graphql_compose_preview']);
 }

--- a/web/themes/custom/novel/templates/layout/node.html.twig
+++ b/web/themes/custom/novel/templates/layout/node.html.twig
@@ -1,0 +1,89 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ *
+ * @see template_preprocess_node()
+ *
+ */
+#}
+<article{{ attributes }}>
+
+  {{ title_prefix }}
+  {% if label and not page %}
+    <h2{{ title_attributes }}>
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h2>
+  {% endif %}
+  {{ title_suffix }}
+
+  {% if not node.bundle starts with 'go_' %}
+    {% if display_submitted %}
+      <footer>
+        {{ author_picture }}
+        <div{{ author_attributes }}>
+          {{ 'Submitted by %author on %date'|t({'%author': author_name, '%date': date}) }}
+          {{ metadata }}
+        </div>
+      </footer>
+    {% endif %}
+  {% endif %}
+  <div{{ content_attributes }}>
+    {{ content }}
+  </div>
+
+</article>

--- a/web/themes/custom/novel/templates/layout/page--node--preview.html.twig
+++ b/web/themes/custom/novel/templates/layout/page--node--preview.html.twig
@@ -1,0 +1,94 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+{# Overflow hidden is necessary, to avoid the header breaking out on mobile. #}
+
+<div class="overflow-hidden">
+  {% if node.bundle starts with 'go_' %}
+    <main id="main-content" role="main">
+      {{ page.content }}
+    </main>
+  {% else %}
+
+    {% include '@novel/layout/header.html.twig'
+      with {
+      'header': page.header,
+      'search_header': search.header,
+      'patron_menu': patron.menu,
+      'logo': logo,
+      'opening_hours_url': opening_hours_url,
+      'opening_hours_sidebar_large': opening_hours_sidebar_large,
+      'opening_hours_sidebar_small': opening_hours_sidebar_small,
+    } only %}
+
+    {{ drupal_block('system_messages_block') }}
+
+    {{ breadcrumb }}
+
+    <main id="main-content" role="main">
+      {{ page.content }}
+
+      {% if related_children.items %}
+        {# @todo - this needs to be replaced by proper styling. #}
+        <div class="mt-64">
+          {% include '@novel/components/breadcrumb-children.html.twig'
+            with {
+            title: related_children.title,
+            show_subtitles: related_children.show_subtitles,
+            items: related_children.items,
+          } only %}
+        </div>
+      {% endif %}
+
+      {{ related_content }}
+    </main>
+
+    {% include '@novel/layout/footer.html.twig'
+      with {
+      'settings': footer_settings,
+      'logo': logo,
+    } only %}
+  {% endif %}
+</div>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-554

#### Description

The GO editors want to be able to preview GO content before publishing. Currently this is possible through Drupals core preview function. However, this preview shows how the GO content will look like, if it was rendered in FB-CMS, and therefore the preview is insufficient for the GO editors. 

With this PR, we add a way for the GO editors to preview GO content in FB-cms through an iFrame which shows the the content will be rendered in the GO frontend. 

This is done by:

1. Enabling the [GraphQL Compose - Preview ](https://www.drupal.org/project/graphql_compose_preview) module.
2. Adding the modules provided "Token Preview" field to the "Full Content" display of our GO content types.
3. Adding a custom fieldFormatter for the "Token Preview" field. Our custom fieldFormatter makes sure to define how the iFrame should be rendered as well as making sure that the iFrame src is being set to the current sites GO domain.
4. We have added 2 new twig templates which are being used to show the GO content without all of the usual FB-cms elements being shown (header, footer, author info etc.).

How it works:

1. The Token Preview fieldFormatter adds an iFrame with a src set to something like:
`https://dapple-cms.docker:3000/preview/9010aabf-d87d-4d24-ada0-910090846f28?token=h6717TOBIPg948MpPUTDBVoDu_RB-q4gnSAvxgwPzvWyAEF1XkjvUUOTobu4-AFQM8TiKQ2vRO61QlRFOhdrTQ`

2. The GO FE application then takes the UUID from the src and the token query param to make a preview GraphQL query.

3. The preview query returns the articles preview field values.

#### Screenshot of the result

Image showing how a preview of an GO article looks like in the FB-cms:

![Go preview](https://github.com/user-attachments/assets/d21c0bcb-2642-4e33-a31f-129bac1b587d)

#### Additional comments or questions

It is currently possible to change the preview "display" to one of the other display types added to GO content. However the preview will only work properly for the "full" display which is the default preview display. We have for now decided to keep it this way because of time constraint. 

This PR has a sister PR in dpl-go: https://github.com/danskernesdigitalebibliotek/dpl-go/pull/253

The above PR needs to be merged alongside this PR.