### PR TITLE
Fix getting images from DT to CMS

### DIFF
--- a/assets/sites.php
+++ b/assets/sites.php
@@ -7,11 +7,13 @@ $sites = [];
 // HTTP_HOST is not set when running PHPUnit tests, so check for existence
 // first.
 if (isset($_SERVER['HTTP_HOST'])) {
-  // Add in the host name to sites if it starts with `bnf-`. This way we don't
+  // Add in the host name to sites if it starts with `bnf`. This way we don't
   // have to worry about what TLD people use (docker or local), nor the composer
-  // project name (dpl-cms per default, but could be anything).
-  $host = $_SERVER['HTTP_HOST'];
-  if (preg_match('/^bnf-/', $host)) {
-    $sites[$host] = 'bnf';
+  // project name (dpl-cms per default, but could be anything). And we have to
+  // handle the port too, as we're using port 8080 in docker.
+  [$host, $port] = explode(':', $_SERVER['HTTP_HOST']);
+  $port ??= '80';
+  if (preg_match('/^bnf/', $host)) {
+    $sites[$port . '.' . $host] = 'bnf';
   }
 }


### PR DESCRIPTION
When doing GraphQL requests from CMS to DT, Drupal used the wrong site settings file due to `bnfnginx` not matching `bnf-`. Didn't have an influence on the returned data as it still used the right database service, but it had the effect that it thought that files was in `site/default/files`.

Fix the `sites.php` hackery to account for this.
