### PR TITLE
DDFBRA-657 - Make search profile and FB-CMS URL available through GraphQL

### DIFF
--- a/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
+++ b/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
@@ -11,6 +11,12 @@ type GoLogoutUrls {
   adgangsplatformen: String
 }
 
+type SearchProfiles {
+  defaultProfile: String
+  searchProfile: String
+  materialProfile: String
+}
+
 type UniloginConfigurationPrivate {
   clientSecret: String
   webServiceUsername: String
@@ -30,6 +36,7 @@ type GoConfigurationPublic {
   libraryInfo: GoLibraryInfo
   loginUrls: GoLoginUrls
   logoutUrls: GoLogoutUrls
+  searchProfiles: SearchProfiles
   unilogin: UniloginConfigurationPublic
 }
 

--- a/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
+++ b/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
@@ -13,9 +13,9 @@ type GoLogoutUrls {
 }
 
 type SearchProfiles {
-  defaultProfile: String
-  searchProfile: String
-  materialProfile: String
+  default: String
+  local: String
+  global: String
 }
 
 type UniloginConfigurationPrivate {

--- a/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
+++ b/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
@@ -12,9 +12,22 @@ type GoLogoutUrls {
   adgangsplatformen: String
 }
 
+"""
+Various FBI profiles configured by the local library.
+"""
 type SearchProfiles {
+  """
+  This is meant to be a fallback profile if no other profile is specified.
+  But is not being used in the current implementation.
+  """
   default: String
+  """
+  This is the profile used for searching works in the library's catalog.
+  """
   local: String
+  """
+  This is the profile is using materials from other libraries as well.
+  """
   global: String
 }
 

--- a/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
+++ b/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
@@ -1,7 +1,7 @@
 
 type GoLibraryInfo {
   name: String
-  cmsUrl: String
+  cmsUrl: String!
 }
 
 type GoLoginUrls {

--- a/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
+++ b/web/modules/custom/dpl_go/graphql/dpl_go.base.graphqls
@@ -1,6 +1,7 @@
 
 type GoLibraryInfo {
   name: String
+  cmsUrl: String
 }
 
 type GoLoginUrls {

--- a/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/CmsUrlProducer.php
+++ b/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/CmsUrlProducer.php
@@ -51,6 +51,7 @@ class CmsUrlProducer extends DataProducerPluginBase implements ContainerFactoryP
    * Resolves the library name.
    */
   public function resolve(FieldContext $field_context): string {
+    /* @todo We should make this cacheable and add cache tags */
     $field_context->addCacheableDependency((new CacheableMetadata())->setCacheMaxAge(0));
     return $this->goSite->getCmsBaseUrl();
   }

--- a/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/CmsUrlProducer.php
+++ b/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/CmsUrlProducer.php
@@ -4,25 +4,24 @@ namespace Drupal\dpl_go\Plugin\GraphQL\DataProducer;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\dpl_library_agency\FbiProfileType;
-use Drupal\dpl_library_agency\GeneralSettings;
+use Drupal\dpl_go\GoSite;
 use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Resolves search profiles configuration for the library.
+ * Resolves the FB-CMS URL of the library.
  *
  * @DataProducer(
- *   id = "search_profiles_producer",
- *   name = "Library Search Profiles Producer",
- *   description = "Provides the library search profile configuration.",
+ *   id = "cms_url_producer",
+ *   name = "FB-CMS URL Producer",
+ *   description = "Provides the FB-CMS URL.",
  *   produces = @ContextDefinition("any",
  *     label = "Request Response"
  *   )
  * )
  */
-class SearchProfilesProducer extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+class CmsUrlProducer extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * {@inheritdoc}
@@ -31,7 +30,7 @@ class SearchProfilesProducer extends DataProducerPluginBase implements Container
     array $configuration,
     string $pluginId,
     mixed $pluginDefinition,
-    protected GeneralSettings $generalSettings,
+    protected GoSite $goSite,
   ) {
     parent::__construct($configuration, $pluginId, $pluginDefinition);
   }
@@ -44,23 +43,16 @@ class SearchProfilesProducer extends DataProducerPluginBase implements Container
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('dpl_library_agency.general_settings')
+      $container->get('dpl_go.go_site'),
     );
   }
 
   /**
-   * Resolves the Unilogin info.
-   *
-   * @return mixed[]
-   *   The Unilogin configuration.
+   * Resolves the library name.
    */
-  public function resolve(FieldContext $field_context): array {
+  public function resolve(FieldContext $field_context): string {
     $field_context->addCacheableDependency((new CacheableMetadata())->setCacheMaxAge(0));
-    return [
-      'defaultProfile' => $this->generalSettings->getFbiProfile(FbiProfileType::DEFAULT) ?: NULL,
-      'searchProfile' => $this->generalSettings->getFbiProfile(FbiProfileType::LOCAL) ?: NULL,
-      'materialProfile' => $this->generalSettings->getFbiProfile(FbiProfileType::GLOBAL) ?: NULL,
-    ];
+    return $this->goSite->getCmsBaseUrl();
   }
 
 }

--- a/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/SearchProfilesProducer.php
+++ b/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/SearchProfilesProducer.php
@@ -57,9 +57,9 @@ class SearchProfilesProducer extends DataProducerPluginBase implements Container
   public function resolve(FieldContext $field_context): array {
     $field_context->addCacheableDependency((new CacheableMetadata())->setCacheMaxAge(0));
     return [
-      'defaultProfile' => $this->generalSettings->getFbiProfile(FbiProfileType::DEFAULT) ?: NULL,
-      'searchProfile' => $this->generalSettings->getFbiProfile(FbiProfileType::LOCAL) ?: NULL,
-      'materialProfile' => $this->generalSettings->getFbiProfile(FbiProfileType::GLOBAL) ?: NULL,
+      'default' => $this->generalSettings->getFbiProfile(FbiProfileType::DEFAULT) ?: NULL,
+      'local' => $this->generalSettings->getFbiProfile(FbiProfileType::LOCAL) ?: NULL,
+      'global' => $this->generalSettings->getFbiProfile(FbiProfileType::GLOBAL) ?: NULL,
     ];
   }
 

--- a/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/SearchProfilesProducer.php
+++ b/web/modules/custom/dpl_go/src/Plugin/GraphQL/DataProducer/SearchProfilesProducer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\dpl_go\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\dpl_library_agency\FbiProfileType;
+use Drupal\dpl_library_agency\GeneralSettings;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Resolves search profiles configuration for the library.
+ *
+ * @DataProducer(
+ *   id = "search_profiles_producer",
+ *   name = "Library Search Profiles Producer",
+ *   description = "Provides the library search profile configuration.",
+ *   produces = @ContextDefinition("any",
+ *     label = "Request Response"
+ *   )
+ * )
+ */
+class SearchProfilesProducer extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    string $pluginId,
+    mixed $pluginDefinition,
+    protected GeneralSettings $generalSettings,
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('dpl_library_agency.general_settings')
+    );
+  }
+
+  /**
+   * Resolves the Unilogin info.
+   *
+   * @return mixed[]
+   *   The Unilogin configuration.
+   */
+  public function resolve(FieldContext $field_context): array {
+    $field_context->addCacheableDependency((new CacheableMetadata())->setCacheMaxAge(0));
+    return [
+      'defaultProfile' => $this->generalSettings->getFbiProfile(FbiProfileType::DEFAULT) ?: NULL,
+      'searchProfile' => $this->generalSettings->getFbiProfile(FbiProfileType::LOCAL) ?: NULL,
+      'materialProfile' => $this->generalSettings->getFbiProfile(FbiProfileType::GLOBAL) ?: NULL,
+    ];
+  }
+
+}

--- a/web/modules/custom/dpl_go/src/Plugin/GraphQL/SchemaExtension/GoConfigurationExtension.php
+++ b/web/modules/custom/dpl_go/src/Plugin/GraphQL/SchemaExtension/GoConfigurationExtension.php
@@ -42,6 +42,10 @@ class GoConfigurationExtension extends SdlSchemaExtensionPluginBase {
       $builder->produce('library_name')
     );
 
+    $registry->addFieldResolver('GoLibraryInfo', 'cmsUrl',
+      $builder->produce('cms_url_producer')
+    );
+
     $registry->addFieldResolver('GoConfigurationPrivate', 'unilogin',
       $builder->produce('unilogin_private_producer')
     );

--- a/web/modules/custom/dpl_go/src/Plugin/GraphQL/SchemaExtension/GoConfigurationExtension.php
+++ b/web/modules/custom/dpl_go/src/Plugin/GraphQL/SchemaExtension/GoConfigurationExtension.php
@@ -49,6 +49,10 @@ class GoConfigurationExtension extends SdlSchemaExtensionPluginBase {
     $registry->addFieldResolver('GoConfigurationPublic', 'unilogin',
       $builder->produce('unilogin_public_producer')
     );
+
+    $registry->addFieldResolver('GoConfigurationPublic', 'searchProfiles',
+      $builder->produce('search_profiles_producer')
+    );
   }
 
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-657

#### Description

This PR make sure that the GO Frontend can now fetch the following configuration from FB-CMS backend:

Search Profiles: - VIP profiler
- Default - Standardprofil
- Local - Søgeprofil
- Global - Visningsprofil

The PR also adds the `cmsUrl` to the LibraryInfo type. This field fetches the absolute CMS Base URL of FB-CMS of the library.


#### Screenshot of the result

Example GraphQL query:

```graphql
query MyQuery {
  goConfiguration {
    public {
      searchProfiles {
        default
        local
        global
      }
      libraryInfo {
        name
        cmsUrl
      }
    }
  }
}
```

Example result:
```
{
  "data": {
    "goConfiguration": {
      "public": {
        "searchProfiles": {
          "default": "next",
          "local": "next",
          "global": "next"
        },
        "libraryInfo": {
          "name": "Eksempel Biblioteket",
          "cmsUrl": "https://dapple-cms.docker"
        }
      }
    }
  }
}
```

#### Additional comments or questions

This PR will have a sister PR in dpl-go:
<add PR link when available>