### PR TITLE
DDFBRA-644 -  Add missing user roles to never ignore list

### DIFF
--- a/config/sync/config_ignore_auto.settings.yml
+++ b/config/sync/config_ignore_auto.settings.yml
@@ -4,12 +4,15 @@ status: true
 whitelist_config_entities:
   - user.role.anonymous
   - user.role.authenticated
+  - user.role.administrator
   - user.role.local_administrator
-  - user.role.authenticated
   - user.role.editor
   - user.role.external_system
   - user.role.mediator
   - user.role.patron
+  - user.role.bnf_pilot
+  - user.role.bnf_graphql_client
+  - user.role.go_graphql_client
   - bnf_client.settings.yml
 direction_operations:
   - import_create

--- a/web/modules/custom/dpl_update/dpl_update.install
+++ b/web/modules/custom/dpl_update/dpl_update.install
@@ -9,12 +9,14 @@
  * config_ignore as library administrators can add their own modules.
  */
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\dpl_library_token\LibraryTokenHandler;
 use Drupal\dpl_login\Adgangsplatformen\Config;
 use Drupal\drupal_typed\DrupalTyped;
 use Drupal\locale\SourceString;
 use Drupal\locale\StringDatabaseStorage;
+use Drupal\user\Entity\User;
 
 /**
  * Helper function to install modules.
@@ -152,6 +154,7 @@ function dpl_update_install(): string {
   $messages[] = dpl_update_update_10043();
   $messages[] = dpl_update_update_10047();
   $messages[] = dpl_update_update_10051();
+  $messages[] = dpl_update_update_10052();
 
   /*
    * dpl_update_update_10050 is not needed, when installing from scratch the
@@ -547,7 +550,7 @@ function dpl_update_update_10044(): string {
  * Install BNF base module.
  *
  * Notice - this is ONLY the base module. The client and server modules get
- * enabled seperately.
+ * enabled separately.
  */
 function dpl_update_update_10045(): string {
   return _dpl_update_install_modules(['bnf']);
@@ -617,7 +620,7 @@ function dpl_update_update_10048(): string {
 }
 
 /**
- * Install drupal/nexxt modules for cache revalidation.
+ * Install drupal/next modules for cache revalidation.
  */
 function dpl_update_update_10049(): string {
   return _dpl_update_install_modules(['next', 'next_graphql']);
@@ -639,4 +642,50 @@ function dpl_update_update_10050(): string {
  */
 function dpl_update_update_10051(): string {
   return _dpl_update_install_modules(['graphql_compose_preview']);
+}
+
+/**
+ * Update passwords for the go_graphql and bnf_graphql users.
+ */
+function dpl_update_update_10052(): string {
+  $feedback = [];
+
+  $entity_type_manager = DrupalTyped::service(EntityTypeManagerInterface::class, 'entity_type.manager');
+
+  $users = $entity_type_manager->getStorage('user')->loadByProperties(['name' => 'bnf_graphql']);
+  $bnf_user = reset($users);
+
+  if ($bnf_user instanceof User) {
+
+    $go_password = getenv('BNF_GRAPHQL_CONSUMER_USER_PASSWORD');
+    if ($go_password) {
+      $bnf_user->setPassword($go_password);
+      $bnf_user->save();
+    }
+    else {
+      $feedback[] = 'Environment variable "BNF_GRAPHQL_CONSUMER_USER_PASSWORD" is not set.';
+    }
+  }
+  else {
+    $feedback[] = "No user found with the name 'bnf_graphql'.";
+  }
+
+  $users = $entity_type_manager->getStorage('user')->loadByProperties(['name' => 'go_graphql']);
+  $go_user = reset($users);
+
+  if ($go_user instanceof User) {
+    $go_password = getenv('NEXT_PUBLIC_GO_GRAPHQL_CONSUMER_USER_PASSWORD');
+    if ($go_password) {
+      $go_user->setPassword($go_password);
+      $go_user->save();
+    }
+    else {
+      $feedback[] = 'Environment variable "NEXT_PUBLIC_GO_GRAPHQL_CONSUMER_USER_PASSWORD" is not set.';
+    }
+  }
+  else {
+    $feedback[] = "No user found with the name 'go_graphql'.";
+  }
+
+  return implode("\n", $feedback);
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-644

#### Description

This PR makes sure to add the missing drupal roles to the "never ignore list" as we previously have been having issues with permissions on the library sites. This will make sure that whatever is set in configuration, will imported on deploys.

The following roles has been added:

```
user.role.administrator
user.role.bnf_pilot
user.role.bnf_graphql_client
user.role.go_graphql_client
```

Also removed a duplicate entry on the list `user.role.authenticated`.

#### Additional comments or questions

I have not added the `user.role.go_pilot` as this role is deprecated and will be removed in this PR <link is coming soon>
