### PR TITLE
DDFBRA-644-add-missing-user-roles-to-never-ignore-list-v2

### DIFF
--- a/config/sync/config_ignore_auto.settings.yml
+++ b/config/sync/config_ignore_auto.settings.yml
@@ -4,12 +4,15 @@ status: true
 whitelist_config_entities:
   - user.role.anonymous
   - user.role.authenticated
+  - user.role.administrator
   - user.role.local_administrator
-  - user.role.authenticated
   - user.role.editor
   - user.role.external_system
   - user.role.mediator
   - user.role.patron
+  - user.role.bnf_pilot
+  - user.role.bnf_graphql_client
+  - user.role.go_graphql_client
   - bnf_client.settings.yml
 direction_operations:
   - import_create


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-644

#### Description

This PR makes sure to add the missing drupal roles to the "never ignore list" as we previously have been having issues with permissions on the library sites. This will make sure that whatever is set in configuration, will imported on deploys.

The following roles has been added:

```
user.role.administrator
user.role.bnf_pilot
user.role.bnf_graphql_client
user.role.go_graphql_client
```

Also removed a duplicate entry on the list `user.role.authenticated`.

#### Additional comments or questions

I have not added the `user.role.go_editor` as this role is deprecated and will be removed in this PR <link is coming soon>
