### PR TITLE
Do not clear cache after site install

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -49,10 +49,6 @@ tasks:
             # Otherwise install and let drush generate a password.
               drush si --existing-config -y
             fi
-
-            # Practice shows that the cache needs to be cleared to avoid
-            # configuration errors even after a site install.
-            drush cr
           fi
         service: cli
         shell: bash

--- a/dev-scripts/install-site.sh
+++ b/dev-scripts/install-site.sh
@@ -16,10 +16,6 @@ done
 # Install site.
 drush site-install --existing-config -y
 
-# Practice shows that the cache needs to be cleared to avoid configuration
-# errors even after a site install.
-drush cache:rebuild -y
-
 # Import translations.
 if [[ $SKIP_LANGUAGE_IMPORT == "true" ]]; then
   echo "Skipping language import due to SKIP_LANGUAGE_IMPORT environment variable"


### PR DESCRIPTION
#### Description

In 7ea6ccc4b604f9c7a4d8df7c65f8350608f47e8d we originally tried to introduce additional cache clearing after site install to address a problem regarding NoCorrespondingEntityClassException within the varnish_purge module.

This did not solve the problem and we have since in 6fe11bcbdc257becc955cb3bd9f9b7ee82a5dafa tried to handle it using a different approach which did not rely on cache clearing.

Now we sometime see an error "The "block" entity type does not exist." whem running this additional cache clear. This typically occurs when during task ci:reset.

Allowing this cache clear to fail by changing the code to drush cache:rebuild -y || true shows that this additional cache clearing may in fact not be necessary at all.

Consequently we remove it. This also reduces oddities within the project a bit.
