### PR TITLE
Do not use Go node service in PR environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,17 +166,6 @@ services:
     environment:
       << : *default-environment
 
-  node:
-    image: ghcr.io/danskernesdigitalebibliotek/dpl-go-node:0.0.12
-    labels:
-      provenance: false
-      lagoon.type: node-persistent
-      lagoon.persistent: /app/.next
-      # The size of the persistent storage for this service
-      # is based on some documentation in Lagoon about hosting a node service:
-      # https://docs.lagoon.sh/docker-images/nodejs/#docker-composeyml-snippet
-      # We could revise in the future if we need more space.
-      lagoon.persistent.size: 2Gi
 volumes:
   projectroot:
     driver: local


### PR DESCRIPTION
Do not use Go node service in PR environments
Except from demo and playground which needs to have the service defined in docker-compose.yml

