### PR TITLE
Rework cache clearing when installing sites

### DIFF
--- a/dev-scripts/install-site.sh
+++ b/dev-scripts/install-site.sh
@@ -25,12 +25,11 @@ else
   drush dpl_po:import-remote-config-po da https://danskernesdigitalebibliotek.github.io/dpl-cms/translations/da.config.po
 fi
 
-# Clear all caches to ensure we have a pristine setup.
-drush cache:rebuild -y
-drush cache:rebuild-external -y
-
 # Run deploy hooks.
 drush deploy -y
+
+# Clear external caches to ensure we have a pristine setup.
+drush cache:rebuild-external -y
 
 # Ensure site is reachable and warm any caches
 curl --silent --show-error --fail --output /dev/null http://varnish:8080/


### PR DESCRIPTION
#### Description

For whatever reason drush cache:rebuild fails with the error "The node entity type does not exist." when running drush ci:reset locally.

The situation seems to fix itself when running drush deploy. drush deploy internally also rebuilds the cache so there is little reason to do this explicitly.

Instead we only clear the external cache which requires a separate command. We do this after drush deploy for good measure.
