### PR TITLE
Fix warnings when dpl_logging detects user change. DDFSAL-158

### DIFF
--- a/web/modules/custom/dpl_logging/dpl_logging.module
+++ b/web/modules/custom/dpl_logging/dpl_logging.module
@@ -89,8 +89,8 @@ function dpl_logging_user_presave(User $user): void {
       [
         '@label' => $label,
         '@key' => $key,
-        '@original_value' => $original_value[0]['value'],
-        '@value' => $value[0]['value'] ?? NULL,
+        '@original_value' => $original_value[0]['value'] ?? '(not set)',
+        '@value' => $value[0]['value'] ?? '(not set)',
       ],
       ['context' => 'DPL logging']
     )->render();


### PR DESCRIPTION
Sometimes values may be missing, either before or after. We should not display a warning, but rather show (not set) as part of the log.
