### PR TITLE
BNF: Do *NOT* set BNF-imported nodes as entity templates. DDFSAL-174

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -334,7 +334,8 @@
                 "2708731: Allow redirect to edit form after cloning": "https://www.drupal.org/files/issues/2022-11-15/improve-workflow-of-cloned-entity-2708731-39.patch"
             },
             "drupal/entity_clone_template": {
-                "3424597: Fix error when creating entity of type without templates": "https://git.drupalcode.org/project/entity_clone_template/-/commit/ad4964dd51f7f5e814111fcb73e6e472eefccf5c.patch"
+                "3424597: Fix error when creating entity of type without templates": "https://git.drupalcode.org/project/entity_clone_template/-/commit/ad4964dd51f7f5e814111fcb73e6e472eefccf5c.patch",
+                "3530772: entity_clone_template_active should be FALSE by default": "https://git.drupalcode.org/project/entity_clone_template/-/commit/7cd2ee6541cd25b6370b304911d49a00c46c3a0.patch"
             },
             "drupal/entity_reference_revisions": {
                 "3039442: Circular dependencies in EntityReferenceRevisionsFieldItemList::hasAffectingChanges()": "https://www.drupal.org/files/issues/2023-11-20/entity_reference_revisions-fix_infinite_loop-3039442-8.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b656d525d2d1d4640c01fea1c38035f",
+    "content-hash": "9941a4433862c3bf6310ea4a86d355cb",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/web/modules/custom/bnf/bnf.install
+++ b/web/modules/custom/bnf/bnf.install
@@ -1,6 +1,8 @@
 <?php
 
+use Drupal\bnf\BnfStateEnum;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\node\Entity\Node;
 
 /**
  * Install bnf_source_changed field on nodes.
@@ -19,4 +21,45 @@ function bnf_update_10101(): string {
   $definition_manager->installFieldStorageDefinition('bnf_source_changed', 'node', 'node', $field);
 
   return 'node.bnf_source_changed installed.';
+}
+
+/**
+ * Find all BNF-imported nodes, and make sure they are not entity templates.
+ *
+ * Nodes imported from Delingstjenesten have mistakenly been automatically
+ * created as entity_clone_templates. That means they've been spamming the
+ * /node/add page.
+ *
+ * We've fixed the code so this doesn't happen for future imports, but this
+ * action also finds all existing, imported nodes, and sets template to FALSE.
+ */
+function bnf_update_10102(): string {
+  $target_states = [
+    BnfStateEnum::Imported->value,
+    BnfStateEnum::LocallyClaimed->value,
+  ];
+
+  $ids =
+    \Drupal::entityQuery('node')
+      ->condition(BnfStateEnum::FIELD_NAME, $target_states, 'IN')
+      ->condition('entity_clone_template_active', TRUE)
+      // As it is a migration action, we do not want any access checks.
+      ->accessCheck(FALSE)
+      ->execute();
+
+  $nodes = Node::loadMultiple($ids);
+  $updated_count = 0;
+
+  foreach ($nodes as $node) {
+    try {
+      $node->set('entity_clone_template_active', FALSE);
+      $node->save();
+      $updated_count++;
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('bnf')->error('Unable to disable entity_clone_template as part of bnf_update_10102: @error', ['@error' => $e->getMessage()]);
+    }
+  }
+
+  return "$updated_count imported BNF nodes updated.";
 }


### PR DESCRIPTION
When a node is BNF-imported, we do *NOT* want it to show up as a node template on the /node/add page. Apparantly, the entity_clone_template module assumes that no value must mean TRUE.

This commit also includes cleaning up the existing nodes that already have been imported, and has been set as templates. The client will be informed of this update.

https://reload.atlassian.net/browse/DDFSAL-174