### PR TITLE
Include video thumbnails in GraphQL output. DDFSAL-180

### DIFF
--- a/web/modules/custom/bnf/graphql/bnf_extension.extension.graphqls
+++ b/web/modules/custom/bnf/graphql/bnf_extension.extension.graphqls
@@ -2,6 +2,14 @@ extend interface NodeInterface {
   url: String!
 }
 
+extend type MediaVideo {
+  thumbnail: String!
+}
+
+extend type MediaVideotool {
+  thumbnail: String!
+}
+
 # Ideally, we wouldn't want to manually create each content type here, but
 # there is no way around that, with how GraphQL works with interfaces.
 # If a new content type is added, a warning will show up in the GraphQL explorer

--- a/web/modules/custom/bnf/src/Plugin/GraphQL/SchemaExtension/BnfExtension.php
+++ b/web/modules/custom/bnf/src/Plugin/GraphQL/SchemaExtension/BnfExtension.php
@@ -36,6 +36,24 @@ class BnfExtension extends SdlSchemaExtensionPluginBase {
         ->map('entity', $builder->fromParent())
     ));
 
+    $registry->addFieldResolver('MediaVideo', 'thumbnail', $builder->compose(
+      $builder->produce('property_path')
+        ->map('type', $builder->fromValue('entity:media'))
+        ->map('value', $builder->fromParent())
+        ->map('path', $builder->fromValue('thumbnail.entity')),
+      $builder->produce('image_url')
+        ->map('entity', $builder->fromParent())
+    ));
+
+    $registry->addFieldResolver('MediaVideotool', 'thumbnail', $builder->compose(
+      $builder->produce('property_path')
+        ->map('type', $builder->fromValue('entity:media'))
+        ->map('value', $builder->fromParent())
+        ->map('path', $builder->fromValue('thumbnail.entity')),
+      $builder->produce('image_url')
+        ->map('entity', $builder->fromParent())
+    ));
+
   }
 
 }


### PR DESCRIPTION
Adds a custom extension, so MediaVideotool and MediaVideo also can expose their already-existing thumbnails.

<img width="1121" alt="Screenshot 2025-06-18 at 09 14 11" src="https://github.com/user-attachments/assets/9b282ecd-4c51-4a58-98e9-5f1af518ce0f" />
