### PR TITLE
BNF: Improve error handling when importing nodes

### DIFF
--- a/web/modules/custom/bnf/src/Services/BnfImporter.php
+++ b/web/modules/custom/bnf/src/Services/BnfImporter.php
@@ -74,9 +74,7 @@ class BnfImporter {
 
     try {
       $response = GetNode::execute($uuid);
-
-      $nodeData = $response->data?->node;
-
+      $nodeData = $response->errorFree()->data->node;
       if (!$nodeData) {
         throw new \RuntimeException('Could not fetch content.');
       }
@@ -114,9 +112,8 @@ class BnfImporter {
 
       $node->set('bnf_source_changed', $newSourceChanged);
 
-      $info = $response->data?->info;
-
-      if ($info?->name) {
+      $info = $response->errorFree()->data->info;
+      if ($info->name) {
         $node->set('bnf_source_name', $info->name);
       }
 


### PR DESCRIPTION
#### Description

Currently we do not check for GraphQL errors in the response when importing a node.

This leads to conditional code and generic error messages which can be hard to debug.

Add the `errorFree()` check to the result data retrieval to ensure that an exception is thrown if the result contains errors. This will bubble to our general exception handling for the importer which includes the exception message.

This also means we can remove a few conditionals.

#### Additional comments or questions

Note: I have not tested this in practice. It is purely based on code paths.

We could also consider adding the UUID to the logged message.