### PR TITLE
Strip `www` prefix from cookie_domain

### DIFF
--- a/web/modules/custom/dpl_go/src/DplGoServiceProvider.php
+++ b/web/modules/custom/dpl_go/src/DplGoServiceProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\dpl_go;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+/**
+ * Ensures `www.` prefix is stripped from cookie_domain.
+ *
+ * On sites whose primary domain starts with `www`, Drupal sets the cookie
+ * domain to `.www.<site>` per default. This means that the cookie isn't shared
+ * with `www.go.<site>` and the login doesn't work. So we set it explicitly
+ * without the `.www` prefix.
+ */
+class DplGoServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container): void {
+    $parameter = 'session.storage.options';
+
+    if (!$container->getParameterBag()->has($parameter)) {
+      return;
+    }
+
+    /** @var array<string, string> $cookieSettings */
+    $cookieSettings = $container->getParameter($parameter);
+
+    // The cookie_domain shouldn't be set as this comes directly from the
+    // services.yml file, but for safety, use any configured value.
+    if (isset($cookieSettings['cookie_domain'])) {
+      $cookieDomain = $cookieSettings['cookie_domain'];
+    }
+    else {
+      // We can't use the service from `dpl_lagoon` for this, as obviously we
+      // can't use the container. Add the dot to mimic how Drupal generates it.
+      $cookieDomain = '.' . getenv('LAGOON_DOMAIN');
+    }
+
+    if (str_starts_with($cookieDomain, '.www.')) {
+      $cookieDomain = substr($cookieDomain, 4);
+    }
+
+    $cookieSettings['cookie_domain'] = $cookieDomain;
+
+    $container->setParameter($parameter, $cookieSettings);
+  }
+
+}

--- a/web/modules/custom/dpl_go/src/DplGoServiceProvider.php
+++ b/web/modules/custom/dpl_go/src/DplGoServiceProvider.php
@@ -12,8 +12,8 @@ use Drupal\Core\DependencyInjection\ServiceProviderBase;
  *
  * On sites whose primary domain starts with `www`, Drupal sets the cookie
  * domain to `.www.<site>` per default. This means that the cookie isn't shared
- * with `www.go.<site>` and the login doesn't work. So we set it explicitly
- * without the `.www` prefix.
+ * with `www.go.<site>` and the login doesn't work. In these cases we set it
+ * explicitly without the `.www` prefix.
  */
 class DplGoServiceProvider extends ServiceProviderBase {
 
@@ -49,9 +49,12 @@ class DplGoServiceProvider extends ServiceProviderBase {
       $cookieDomain = '.' . $domain;
     }
 
-    if (str_starts_with($cookieDomain, '.www.')) {
-      $cookieDomain = substr($cookieDomain, 4);
+    // If there's no www prefix, we don't need to do anything.
+    if (!str_starts_with($cookieDomain, '.www.')) {
+      return;
     }
+
+    $cookieDomain = substr($cookieDomain, 4);
 
     $cookieSettings['cookie_domain'] = $cookieDomain;
 

--- a/web/modules/custom/dpl_go/src/DplGoServiceProvider.php
+++ b/web/modules/custom/dpl_go/src/DplGoServiceProvider.php
@@ -37,8 +37,16 @@ class DplGoServiceProvider extends ServiceProviderBase {
     }
     else {
       // We can't use the service from `dpl_lagoon` for this, as obviously we
-      // can't use the container. Add the dot to mimic how Drupal generates it.
-      $cookieDomain = '.' . getenv('LAGOON_DOMAIN');
+      // can't use the container.
+      $domain = getenv('LAGOON_DOMAIN');
+
+      if (!$domain) {
+        // Without a domain, we can't do much.
+        return;
+      }
+
+      // Add the dot to mimic how Drupal generates it.
+      $cookieDomain = '.' . $domain;
     }
 
     if (str_starts_with($cookieDomain, '.www.')) {


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-725

#### Description

On sites whose primary domain starts with `www`, Drupal sets the cookie domain to `.www.<site>` per default. This means that the cookie isn't shared with `www.go.<site>` and the login doesn't work. So set it explicitly without the `.www` prefix.

PR set to "don't merge" as it should be applied as a hotfix (which involves creating a new branch first).