### PR TITLE
Always set the `bnf_library_session` cache context

### DIFF
--- a/web/modules/custom/bnf/bnf_server/bnf_server.module
+++ b/web/modules/custom/bnf/bnf_server/bnf_server.module
@@ -27,6 +27,8 @@ function bnf_server_views_pre_build(ViewExecutable $view): void {
  * has logged in and has the callback cookie context.
  */
 function bnf_server_preprocess_page(array &$variables): void {
+  $variables['#cache']['contexts'][] = 'bnf_library_session';
+
   $session = \Drupal::request()->getSession();
 
   $site_url = $session->get(LoginController::CALLBACK_URL_KEY);
@@ -36,8 +38,6 @@ function bnf_server_preprocess_page(array &$variables): void {
   if (!$site_url || \Drupal::service('router.admin_context')->isAdminRoute()) {
     return;
   }
-
-  $variables['#cache']['contexts'][] = 'bnf_library_session';
 
   if ($site_name) {
     $variables['page']['content']['logged_notifier'] = [


### PR DESCRIPTION
#### Link to issue

DDFSAL-185

#### Description

The early return meant it wasn't set on anonymous pages, so it was ignored when the library was logged in.
