### PR TITLE
DDFSAL-251 - Option to have ‘Find on shelf’ always expanded by default.

### DIFF
--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -184,6 +184,20 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('opening_hours_url') ?? GeneralSettings::OPENING_HOURS_URL,
     ];
 
+    $form['find_on_shelf'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Find on shelf', [], ['context' => 'Library Agency Configuration']),
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $form['find_on_shelf']['find_on_shelf_disclosures_default_open'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Default open find on shelf disclosures', [], ['context' => 'Library Agency Configuration']),
+      '#default_value' => $config->get('find_on_shelf_disclosures_default_open') ?? FALSE,
+      '#description' => $this->t('If checked, the find on shelf disclosures will be open by default', [], ['context' => 'Library Agency Configuration']),
+    ];
+
     $form['expiration_warning'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Expiration warning', [], ['context' => 'Library Agency Configuration']),
@@ -319,6 +333,7 @@ class GeneralSettingsForm extends ConfigFormBase {
       ->set('reservation_sms_notifications_enabled', $form_state->getValue('reservation_sms_notifications_enabled'))
       ->set('pause_reservation_info_url', $form_state->getValue('pause_reservation_info_url'))
       ->set('opening_hours_url', $form_state->getValue('opening_hours_url'))
+      ->set('find_on_shelf_disclosures_default_open', $form_state->getValue('find_on_shelf_disclosures_default_open'))
       ->set('fbi_profiles', [
         'default' => $form_state->getValue('fbi_profile_default'),
         'local' => $form_state->getValue('fbi_profile_local'),

--- a/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
@@ -22,6 +22,7 @@ class GeneralSettings extends DplReactConfigBase {
   // not expected to be changing often.
   const FBI_PROFILE = 'next';
   const OPENING_HOURS_URL = '/branches';
+  const FIND_ON_SHELF_DISCLOSURES_DEFAULT_OPEN = FALSE;
 
   /**
    * Gets the configuration key for general settings.
@@ -149,6 +150,17 @@ class GeneralSettings extends DplReactConfigBase {
     return [
       'allowRemoveReadyReservations' => $allow_remove_ready_reservations,
     ];
+  }
+
+  /**
+   * Get the default setting for find on shelf disclosures.
+   *
+   * @return bool
+   *   True if disclosures should be shown by default, false otherwise.
+   */
+  public function getFindOnShelfDisclosuresDefaultOpen(): bool {
+    return $this->loadConfig()->get('find_on_shelf_disclosures_default_open')
+      ?? self::FIND_ON_SHELF_DISCLOSURES_DEFAULT_OPEN;
   }
 
   /**

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -295,6 +295,7 @@ class DplReactAppsController extends ControllerBase {
       'sms-notifications-for-reservations-enabled-config' => (int) $this->reservationSettings->smsNotificationsIsEnabled(),
       'instant-loan-config' => $this->instantLoanSettings->getConfig(),
       'interest-periods-config' => json_encode($this->generalSettings->getInterestPeriodsConfig()),
+      'find-on-shelf-disclosures-default-open-config' => (int) $this->generalSettings->getFindOnShelfDisclosuresDefaultOpen(),
       'mapp-domain-config' => $this->config('dpl_mapp.settings')->get('domain'),
       'mapp-id-config' => $this->config('dpl_mapp.settings')->get('id'),
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-251
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1976

#### Description

This allows smaller libraries to configure all 'Find on Shelf' disclosures to be open by default.

#### AI
This pull request introduces a new configuration option to manage the default behavior of "find on shelf disclosures" in the library agency module. The changes include updates to the form, configuration constants, and controller logic to support this feature.

### Additions to "Find on Shelf Disclosures" Feature:

* **Form Updates**:
  - Added a new fieldset `find_on_shelf` in `GeneralSettingsForm` to configure the default behavior of "find on shelf disclosures." This includes a checkbox field `find_on_shelf_disclosures_default_open` with description and default value handling.
  - Updated the `submitForm` method to save the new configuration value `find_on_shelf_disclosures_default_open` into the system.

* **Configuration Constants**:
  - Added a new constant `FIND_ON_SHELF_DISCLOSURES_DEFAULT_OPEN` to `GeneralSettings`, representing the default value for the "find on shelf disclosures" feature.

* **Getter Method**:
  - Introduced `getFindOnShelfDisclosuresDefaultOpen` in `GeneralSettings` to retrieve the value of `find_on_shelf_disclosures_default_open` from the configuration, falling back to the constant if not set.

* **Controller Logic**:
  - Updated `DplReactAppsController` to pass the `find-on-shelf-disclosures-default-open-config` value to the frontend as part of the work method's response.