### PR TITLE
Breadcrumb and URL alias should respect local time. 

### DIFF
--- a/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.services.yml
+++ b/web/modules/custom/dpl_breadcrumb/dpl_breadcrumb.services.yml
@@ -1,17 +1,15 @@
+---
 services:
+  _defaults:
+    autowire: true
   dpl_breadcrumb.logger:
     parent: logger.channel_base
     arguments: ['dpl_breadcrumb']
   dpl_breadcrumb.breadcrumb_helper:
     class: Drupal\dpl_breadcrumb\Services\BreadcrumbHelper
     arguments:
-      [
-        '@entity_type.manager',
-        '@language_manager',
-        '@pathauto.alias_cleaner',
-        '@string_translation',
-        '@dpl_breadcrumb.logger',
-      ]
+      - '@dpl_breadcrumb.logger'
+      - '@pathauto.alias_cleaner'
   dpl_breadcrumb.redirect_structure_term:
     class: Drupal\dpl_breadcrumb\EventSubscriber\StructureTermRedirect
     arguments: ['@dpl_breadcrumb.breadcrumb_helper']

--- a/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
+++ b/web/modules/custom/dpl_breadcrumb/src/Services/BreadcrumbHelper.php
@@ -16,37 +16,11 @@ use Drupal\recurring_events\Entity\EventSeries;
 use Drupal\taxonomy\TermInterface;
 use Psr\Log\LoggerInterface;
 use Safe\DateTime;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Menu Helper service for DPL breadcrumb.
  */
 class BreadcrumbHelper {
-
-  /**
-   * The entity type interface.
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  /**
-   * The language manager.
-   */
-  protected LanguageManagerInterface $languageManager;
-
-  /**
-   * PathAuto alias cleaner.
-   */
-  protected AliasCleanerInterface $aliasCleaner;
-
-  /**
-   * Translation interface.
-   */
-  protected TranslationInterface $translation;
-
-  /**
-   * Custom logger service.
-   */
-  protected LoggerInterface $logger;
 
   /**
    * Should the current page also be shown in the breadcrumb?
@@ -67,30 +41,12 @@ class BreadcrumbHelper {
    * {@inheritdoc}
    */
   public function __construct(
-    EntityTypeManagerInterface $entity_type_manager,
-    LanguageManagerInterface $language_manager,
-    AliasCleanerInterface $alias_cleaner,
-    TranslationInterface $translation,
-    LoggerInterface $logger,
+    protected LoggerInterface $logger,
+    protected AliasCleanerInterface $aliasCleaner,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected LanguageManagerInterface $languageManager,
+    protected TranslationInterface $translation,
   ) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->languageManager = $language_manager;
-    $this->aliasCleaner = $alias_cleaner;
-    $this->translation = $translation;
-    $this->logger = $logger;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container): static {
-    return new static(
-      $container->get('entity_type.manager'),
-      $container->get('language.manager'),
-      $container->get('pathauto.alias_cleaner'),
-      $container->get('string_translation'),
-      $container->get('dpl_breadcrumb.logger'),
-    );
   }
 
   /**


### PR DESCRIPTION
# Update `BreadcrumbHelper` service, to use autowire.

This makes it much easier to maintain, if we wanna update it in the future.

# Breadcrumb and URL alias should respect local time.

If an editor has set an event to start at 00:00, the value saved in the database is in UTC time - e.g. 22:00 the day before.
The breadcrumbhelper creates the breadcrumb, and the URL alias, but due to a bug, it generates the string based on UTC.

This has not been noticed before, as we do not display the time as partof the string, but it is noticable when UTC actually is the day before as the 00:00 example.