### PR TITLE
Add option to hide events from automatic lists. DDFSAL-257

### DIFF
--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventseries.default.field_automatic_list_hide
     - field.field.eventseries.default.field_branch
     - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_description
@@ -131,6 +132,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_automatic_list_hide:
+    type: boolean_checkbox
+    weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_branch:
     type: select2_entity_reference
     weight: 0
@@ -243,7 +251,7 @@ content:
     third_party_settings: {  }
   field_relevant_ticket_manager:
     type: boolean_checkbox
-    weight: 25
+    weight: 26
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.eventinstance.default.card.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.card.yml
@@ -72,6 +72,16 @@ content:
     third_party_settings: {  }
     weight: 53
     region: content
+  event_automatic_list_hide:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 53
+    region: content
   event_categories:
     type: entity_reference_label
     label: above

--- a/config/sync/core.entity_view_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.default.yml
@@ -210,6 +210,7 @@ content:
 hidden:
   body: true
   description: true
+  event_automatic_list_hide: true
   event_relevant_ticket_manager: true
   event_state: true
   event_ticket_capacity: true

--- a/config/sync/core.entity_view_display.eventinstance.default.list.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list.yml
@@ -80,6 +80,16 @@ content:
     third_party_settings: {  }
     weight: 53
     region: content
+  event_automatic_list_hide:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 53
+    region: content
   event_categories:
     type: entity_reference_label
     label: above

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser.yml
@@ -82,6 +82,16 @@ content:
     third_party_settings: {  }
     weight: 53
     region: content
+  event_automatic_list_hide:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 53
+    region: content
   event_categories:
     type: entity_reference_label
     label: visually_hidden

--- a/config/sync/core.entity_view_display.eventinstance.default.list_teaser_stacked_parent.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.list_teaser_stacked_parent.yml
@@ -82,6 +82,16 @@ content:
     third_party_settings: {  }
     weight: 53
     region: content
+  event_automatic_list_hide:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 53
+    region: content
   event_categories:
     type: entity_reference_label
     label: hidden

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_spot.yml
@@ -56,6 +56,16 @@ content:
     third_party_settings: {  }
     weight: 53
     region: content
+  event_automatic_list_hide:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 53
+    region: content
   event_relevant_ticket_manager:
     type: boolean
     label: visible

--- a/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.nav_teaser.yml
@@ -56,6 +56,16 @@ content:
     third_party_settings: {  }
     weight: 53
     region: content
+  event_automatic_list_hide:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 53
+    region: content
   event_relevant_ticket_manager:
     type: boolean
     label: visible

--- a/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
+++ b/config/sync/core.entity_view_display.eventinstance.default.stacked_event.yml
@@ -73,6 +73,16 @@ content:
     third_party_settings: {  }
     weight: 53
     region: content
+  event_automatic_list_hide:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 53
+    region: content
   event_link:
     type: link
     label: hidden

--- a/config/sync/core.entity_view_display.eventseries.default.card.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.card.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventseries.card
+    - field.field.eventseries.default.field_automatic_list_hide
     - field.field.eventseries.default.field_branch
     - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_description
@@ -71,6 +72,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_automatic_list_hide: true
   field_branch: true
   field_categories: true
   field_description: true

--- a/config/sync/core.entity_view_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.eventseries.default.field_automatic_list_hide
     - field.field.eventseries.default.field_branch
     - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_description
@@ -166,6 +167,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_automatic_list_hide: true
   field_event_all_day: true
   field_event_state: true
   field_relevant_ticket_manager: true

--- a/config/sync/core.entity_view_display.eventseries.default.list.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.list.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventseries.list
+    - field.field.eventseries.default.field_automatic_list_hide
     - field.field.eventseries.default.field_branch
     - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_description
@@ -45,6 +46,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_automatic_list_hide: true
   field_branch: true
   field_categories: true
   field_description: true

--- a/config/sync/core.entity_view_display.eventseries.default.list_teaser.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.list_teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventseries.list_teaser
+    - field.field.eventseries.default.field_automatic_list_hide
     - field.field.eventseries.default.field_branch
     - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_description
@@ -127,6 +128,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_automatic_list_hide: true
   field_event_all_day: true
   field_event_link: true
   field_event_paragraphs: true

--- a/config/sync/core.entity_view_display.eventseries.default.nav_spot.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.nav_spot.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventseries.nav_spot
+    - field.field.eventseries.default.field_automatic_list_hide
     - field.field.eventseries.default.field_branch
     - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_description
@@ -62,6 +63,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_automatic_list_hide: true
   field_branch: true
   field_categories: true
   field_description: true

--- a/config/sync/core.entity_view_display.eventseries.default.nav_teaser.yml
+++ b/config/sync/core.entity_view_display.eventseries.default.nav_teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.eventseries.nav_teaser
+    - field.field.eventseries.default.field_automatic_list_hide
     - field.field.eventseries.default.field_branch
     - field.field.eventseries.default.field_categories
     - field.field.eventseries.default.field_description
@@ -53,6 +54,7 @@ hidden:
   daily_recurring_date: true
   event_instances: true
   event_registration: true
+  field_automatic_list_hide: true
   field_branch: true
   field_categories: true
   field_description: true

--- a/config/sync/field.field.eventseries.default.field_automatic_list_hide.yml
+++ b/config/sync/field.field.eventseries.default.field_automatic_list_hide.yml
@@ -1,0 +1,21 @@
+uuid: 6a67f715-bfe9-4a09-9746-443eb95a8b10
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.eventseries.field_automatic_list_hide
+    - recurring_events.eventseries_type.default
+id: eventseries.default.field_automatic_list_hide
+field_name: field_automatic_list_hide
+entity_type: eventseries
+bundle: default
+label: 'Hide in automatic lists'
+description: "If chosen, this eventseries and it's instances will not show up in automatic lists across the site.<br><br />The event will still show up in lists where it is manually added, and in Google search results."
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.eventseries.field_automatic_list_hide.yml
+++ b/config/sync/field.storage.eventseries.field_automatic_list_hide.yml
@@ -1,0 +1,18 @@
+uuid: e0013bd5-6064-4a84-b959-035060c3808d
+langcode: en
+status: true
+dependencies:
+  module:
+    - recurring_events
+id: eventseries.field_automatic_list_hide
+field_name: field_automatic_list_hide
+entity_type: eventseries
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field_inheritance.field_inheritance.eventinstance_default_event_automatic_list_hide.yml
+++ b/config/sync/field_inheritance.field_inheritance.eventinstance_default_event_automatic_list_hide.yml
@@ -1,0 +1,14 @@
+uuid: 2b0d9764-82a6-4fca-8b5a-3db3ff359b08
+langcode: en
+status: true
+dependencies: {  }
+id: eventinstance_default_event_automatic_list_hide
+label: 'Event Hide in automatic lists'
+type: inherit
+sourceEntityType: eventseries
+sourceEntityBundle: default
+sourceField: field_automatic_list_hide
+destinationEntityType: eventinstance
+destinationEntityBundle: default
+destinationField: ''
+plugin: default_inheritance

--- a/config/sync/search_api.index.content_events.yml
+++ b/config/sync/search_api.index.content_events.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.eventseries.field_automatic_list_hide
     - field.storage.eventseries.field_description
     - field.storage.eventseries.field_event_place
     - field.storage.eventseries.field_teaser_text
@@ -29,6 +30,14 @@ field_settings:
       fields:
         - 'entity:eventseries/field_categories'
         - 'entity:node/field_categories'
+  field_automatic_list_hide:
+    label: 'Hide in automatic lists'
+    datasource_id: 'entity:eventseries'
+    property_path: field_automatic_list_hide
+    type: boolean
+    dependencies:
+      config:
+        - field.storage.eventseries.field_automatic_list_hide
   field_branch:
     label: Branch
     datasource_id: 'entity:node'

--- a/config/sync/search_api.index.events.yml
+++ b/config/sync/search_api.index.events.yml
@@ -36,6 +36,14 @@ field_settings:
     dependencies:
       module:
         - recurring_events
+  event_automatic_list_hide:
+    label: 'Event Hide in automatic lists'
+    datasource_id: 'entity:eventinstance'
+    property_path: event_automatic_list_hide
+    type: boolean
+    dependencies:
+      module:
+        - field_inheritance
   event_categories:
     label: 'Event categories'
     datasource_id: 'entity:eventinstance'
@@ -104,6 +112,7 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
 server: db_search

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -332,6 +332,44 @@ display:
           parse_mode: terms
           min_length: null
           fields: {  }
+        event_automatic_list_hide:
+          id: event_automatic_list_hide
+          table: search_api_index_events
+          field: event_automatic_list_hide
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
       row:
@@ -376,6 +414,7 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
+        - 'facets_filter:f'
         - 'languages:language_interface'
         - url
         - url.query_args

--- a/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
+++ b/web/modules/custom/dpl_related_content/src/Services/RelatedContent.php
@@ -432,6 +432,12 @@ class RelatedContent {
 
     $es_query = $this->entityTypeManager->getStorage('eventseries')->getQuery();
 
+    $group = $es_query->orConditionGroup()
+      ->condition('field_automatic_list_hide', FALSE)
+      ->notExists('field_automatic_list_hide');
+
+    $es_query->condition($group);
+
     $es_query->condition('status', TRUE);
     $es_query->accessCheck(TRUE);
 


### PR DESCRIPTION
Add a boolean field on `EventSeries`, that when checked, makes sure that the eventseries and it's instances do not show up in our various automatic lists.
