### PR TITLE
Update git-auto-commit-action to v6. DDFSAL-236

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -85,11 +85,10 @@ jobs:
 
       - name: Create branch
         id: create_branch
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v6
         with:
           branch: ${{ env.PR_BRANCH }}
           commit_message: "Insert new reference to dependency ${{ env.PACKAGE }}: ${{ env.BUILD_URL }}"
-          create_branch: true
         if: ${{ steps.manipulate_composer.outcome == 'success' }}
 
       - name: Create PR


### PR DESCRIPTION
V6 has removed the `create_branch` option, but apparantly it is not a problem as the `branch` option now works slightly differently.

https://github.com/stefanzweifel/git-auto-commit-action/pull/314
