### PR TITLE
DDFSAL-270 - Add agency ID to work (material) React app

### DIFF
--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -300,6 +300,7 @@ class DplReactAppsController extends ControllerBase {
       'instant-loan-config' => $this->instantLoanSettings->getConfig(),
       'interest-periods-config' => json_encode($this->generalSettings->getInterestPeriodsConfig()),
       'find-on-shelf-disclosures-default-open-config' => (int) $this->generalSettings->getFindOnShelfDisclosuresDefaultOpen(),
+      'agency-id-config' => $this->config('openid_connect.client.adgangsplatformen')->get('agency_id'),
       'mapp-domain-config' => $this->config('dpl_mapp.settings')->get('domain'),
       'mapp-id-config' => $this->config('dpl_mapp.settings')->get('id'),
 

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -13,6 +13,7 @@ use Drupal\dpl_library_agency\BranchSettings;
 use Drupal\dpl_library_agency\FbiProfileType;
 use Drupal\dpl_library_agency\GeneralSettings;
 use Drupal\dpl_library_agency\ReservationSettings;
+use Drupal\dpl_login\Adgangsplatformen\Config;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -34,6 +35,7 @@ class DplReactAppsController extends ControllerBase {
     protected BranchRepositoryInterface $branchRepository,
     protected DplInstantLoanSettings $instantLoanSettings,
     protected GeneralSettings $generalSettings,
+    protected Config $adgangsplatformenConfig,
   ) {}
 
   /**
@@ -52,6 +54,7 @@ class DplReactAppsController extends ControllerBase {
       $container->get('dpl_library_agency.branch.repository'),
       $container->get('dpl_instant_loan.settings'),
       $container->get('dpl_library_agency.general_settings'),
+      $container->get('dpl_login.adgangsplatformen.config'),
     );
   }
 
@@ -300,7 +303,7 @@ class DplReactAppsController extends ControllerBase {
       'instant-loan-config' => $this->instantLoanSettings->getConfig(),
       'interest-periods-config' => json_encode($this->generalSettings->getInterestPeriodsConfig()),
       'find-on-shelf-disclosures-default-open-config' => (int) $this->generalSettings->getFindOnShelfDisclosuresDefaultOpen(),
-      'agency-id-config' => $this->config('openid_connect.client.adgangsplatformen')->get('agency_id'),
+      'agency-id-config' => $this->adgangsplatformenConfig->getAgencyId(),
       'mapp-domain-config' => $this->config('dpl_mapp.settings')->get('domain'),
       'mapp-id-config' => $this->config('dpl_mapp.settings')->get('id'),
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-270

#### Test
https://varnish.pr-2646.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2646



#### Description
This pull request adds agency ID to work (material) React app

This ensures users can access Infomedia articles if another municipality has granted access.



https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1991