### PR TITLE
Fix `task ci:cypress:local`

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -10,6 +10,8 @@ services:
     environment:
       CYPRESS_INSTALL_BINARY: 0
       YARN_CACHE_FOLDER: '/app/.cache/yarn'
+      # Exclude npm/yarn registries from proxy to avoid tunneling issues
+      NO_PROXY: "registry.yarnpkg.com,registry.npmjs.org,npm.pkg.github.com"
 
   cypress:
     image: cypress/included:13.5.0


### PR DESCRIPTION
#### Link to issue


#### Description
Fixes issue where Cypress could not run locally due to errors downloading dependencies.


This pull request makes a small but important configuration update to the `docker-compose.ci.yml` file. The change sets the `NO_PROXY` environment variable to ensure that npm and yarn registry traffic bypasses any configured proxy, which helps avoid tunneling issues during CI builds.

* Configuration update:
  * Added `NO_PROXY` environment variable to the `services` section to exclude npm and yarn registries from proxying.