### PR TITLE
DDFSAL-325: Add UUID cache tags to nodes

### DIFF
--- a/web/modules/custom/dpl_graphql/dpl_graphql.services.yml
+++ b/web/modules/custom/dpl_graphql/dpl_graphql.services.yml
@@ -9,6 +9,7 @@ services:
     arguments:
       - '@current_user'
       - '@dpl_graphql.logger'
+      - '@entity_type.manager'
 
     tags:
       - { name: event_subscriber }

--- a/web/modules/custom/dpl_graphql/src/EventSubscriber/CacheableResponseSubscriber.php
+++ b/web/modules/custom/dpl_graphql/src/EventSubscriber/CacheableResponseSubscriber.php
@@ -3,11 +3,13 @@
 namespace Drupal\dpl_graphql\EventSubscriber;
 
 use Drupal\Core\Cache\CacheableJsonResponse;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use function Safe\preg_match;
 
 /**
  * Add cache tags headers on cacheable responses, for external caching systems.
@@ -20,6 +22,7 @@ class CacheableResponseSubscriber implements EventSubscriberInterface {
   public function __construct(
     protected AccountProxyInterface $currentUser,
     protected LoggerInterface $logger,
+    protected EntityTypeManagerInterface $entityTypeManager,
   ) {}
 
   /**
@@ -57,11 +60,61 @@ class CacheableResponseSubscriber implements EventSubscriberInterface {
     $response = $event->getResponse();
     if ($response instanceof CacheableJsonResponse) {
 
-      // Get the cache tags from the response and set them as a header.
+      // Get the cache tags from the response.
       $tags = $response->getCacheableMetadata()->getCacheTags();
-      sort($tags);
-      $response->headers->set('x-dpl-graphql-cache-tags', implode(' ', $tags));
+
+      // Add UUID-based cache tags for nodes.
+      $uuid_tags = $this->addUuidCacheTags($tags);
+      $all_tags = array_merge($tags, $uuid_tags);
+
+      sort($all_tags);
+      $response->headers->set('x-dpl-graphql-cache-tags', implode(' ', $all_tags));
     }
+  }
+
+  /**
+   * Add UUID-based cache tags for nodes found in existing cache tags.
+   *
+   * @param array<string> $tags
+   *   The existing cache tags.
+   *
+   * @return array<string>
+   *   Array of UUID-based cache tags.
+   */
+  protected function addUuidCacheTags(array $tags): array {
+    $uuid_tags = [];
+    $node_ids = [];
+
+    // Extract node IDs from existing cache tags.
+    foreach ($tags as $tag) {
+      // Look for node cache tags in the format 'node:123' or 'node_list'.
+      if (preg_match('/^node:(\d+)$/', $tag, $matches)) {
+        $node_ids[] = $matches[1];
+      }
+    }
+
+    // If we found node IDs, load the nodes and add UUID cache tags.
+    if (!empty($node_ids)) {
+      try {
+        $node_storage = $this->entityTypeManager->getStorage('node');
+        $nodes = $node_storage->loadMultiple($node_ids);
+
+        foreach ($nodes as $node) {
+          $uuid = $node->uuid();
+          if ($uuid) {
+            $uuid_tags[] = 'node_uuid:' . $uuid;
+          }
+        }
+      }
+      catch (\Exception $e) {
+        // Log the error but don't break the response.
+        $this->logger->error('Error loading nodes for UUID cache tags: @message', [
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    return $uuid_tags;
   }
 
 }


### PR DESCRIPTION


#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-325

#### Description
- Add UUID-based cache tags alongside existing node cache tags
- Extract node IDs from cache tags and load corresponding nodes
- Create node_uuid:uuid-string cache tags for better tracing
- Add EntityTypeManager dependency for node loading
- Improve code quality with proper type annotations and Safe\preg_match