### PR TITLE
DDFSAL-373 - Add validation for empty CQL search in material grid automatic paragraph

### DIFF
--- a/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/CqlSearchWidget.php
+++ b/web/modules/custom/dpl_fbi/src/Plugin/Field/FieldWidget/CqlSearchWidget.php
@@ -169,6 +169,7 @@ class CqlSearchWidget extends WidgetBase {
       '#title' => $this->t('Search filters', [], ['context' => 'dpl_fbi']),
       'cql' => [
         '#type' => 'textarea',
+        '#required' => TRUE,
         '#rows' => 3,
         '#title' => $fieldStorageDefinition->getPropertyDefinition('value')?->getLabel(),
         '#default_value' => $items[$delta]->value ?? '',

--- a/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
+++ b/web/modules/custom/dpl_paragraphs/dpl_paragraphs.module
@@ -277,10 +277,6 @@ function dpl_paragraphs_preprocess_paragraph__material_grid_automatic(array &$va
 
   $cql_search = $paragraph->get('field_cql_search')->getValue();
 
-  if (empty($cql_search[0]['value'])) {
-    return;
-  }
-
   $onshelf = !empty($cql_search[0]['onshelf']);
   $render['#data']['cql'] = $cql_search[0]['value'];
   $render['#data']['onshelf'] = $onshelf ? 'true' : 'false';


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-359
https://reload.atlassian.net/browse/DDFSAL-373

#### Test
https://varnish.pr-2732.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2732


#### Description
This pull request makes a small but important change to the `CqlSearchWidget` field widget by ensuring that the CQL search filter is required in the form.

* The `cql` textarea field in `CqlSearchWidget.php` is now marked as required, which enforces user input for this field in the form.


Fixes DDFSAL-359