### PR TITLE
DDFSAL-332 - add use absolute urls logic

### DIFF
--- a/config/sync/administerusersbyrole.settings.yml
+++ b/config/sync/administerusersbyrole.settings.yml
@@ -10,3 +10,4 @@ roles:
   bnf_graphql_client: unsafe
   go_graphql_client: unsafe
   bnf_pilot: unsafe
+  external_graphql_client: unsafe

--- a/config/sync/system.action.user_add_role_action.external_graphql_client.yml
+++ b/config/sync/system.action.user_add_role_action.external_graphql_client.yml
@@ -1,0 +1,14 @@
+uuid: b23663ec-afee-4d2f-b8dc-5e3213c5afbb
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.external_graphql_client
+  module:
+    - user
+id: user_add_role_action.external_graphql_client
+label: 'Add the External GraphQL Client role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: external_graphql_client

--- a/config/sync/system.action.user_remove_role_action.external_graphql_client.yml
+++ b/config/sync/system.action.user_remove_role_action.external_graphql_client.yml
@@ -1,0 +1,14 @@
+uuid: c1756787-0bdc-4474-8b1c-7fc8b08cefc7
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.external_graphql_client
+  module:
+    - user
+id: user_remove_role_action.external_graphql_client
+label: 'Remove the External GraphQL Client role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: external_graphql_client

--- a/config/sync/user.role.external_graphql_client.yml
+++ b/config/sync/user.role.external_graphql_client.yml
@@ -1,0 +1,9 @@
+uuid: f30639e3-4c54-44c9-8a76-9d503a318067
+langcode: en
+status: true
+dependencies: {  }
+id: external_graphql_client
+label: 'External GraphQL Client'
+weight: 13
+is_admin: null
+permissions: {  }

--- a/config/sync/user.role.external_graphql_client.yml
+++ b/config/sync/user.role.external_graphql_client.yml
@@ -1,9 +1,14 @@
 uuid: f30639e3-4c54-44c9-8a76-9d503a318067
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - dpl_go
+    - graphql
 id: external_graphql_client
 label: 'External GraphQL Client'
 weight: 13
 is_admin: null
-permissions: {  }
+permissions:
+  - 'execute graphql_compose_server arbitrary graphql requests'
+  - 'use absolute cms and go urls'

--- a/config/sync/user.role.go_graphql_client.yml
+++ b/config/sync/user.role.go_graphql_client.yml
@@ -16,7 +16,7 @@ is_admin: null
 permissions:
   - 'execute graphql_compose_server arbitrary graphql requests'
   - 'get dpl graphql cache tags'
-  - 'rewrite go urls'
+  - 'use absolute cms urls'
   - 'view any unpublished content'
   - 'view graphql_compose_preview entity'
   - 'view unpublished paragraphs'

--- a/docs/architecture/adr-015-go-cms-intersite-links.md
+++ b/docs/architecture/adr-015-go-cms-intersite-links.md
@@ -31,7 +31,7 @@ This is basically how the domain language negotiation plugin in Drupal
 core implements links between language versions, so the method should
 be fairly safe.
 
-What "site" we're on is determined by checking the `rewrite go urls`
+What "site" we're on is determined by checking the `use absolute cms urls`
 permission, which is only given to the `go_graphql_client` role which
 in turn is only given to the `go_graphql` user that's used for the Go
 GraphQL consumer.

--- a/web/modules/custom/dpl_go/dpl_go.permissions.yml
+++ b/web/modules/custom/dpl_go/dpl_go.permissions.yml
@@ -1,3 +1,7 @@
-rewrite go urls:
-  title: 'Get URLs rewritten for the Go frontend'
-  description: 'URLs is rewritten to be relative to the Go site, not the CMS site'
+use absolute cms urls:
+  title: 'Use absolute CMS URLs.'
+  description: 'CMS URLs on the Go site should be absolute'
+
+use absolute cms and go urls:
+  title: 'Use absolute URLs for both CMS and Go.'
+  description: 'Use absolute URLs for both Go and CMS content (for external services)'

--- a/web/modules/custom/dpl_go/src/Cache/Context/IsGoCacheContext.php
+++ b/web/modules/custom/dpl_go/src/Cache/Context/IsGoCacheContext.php
@@ -31,7 +31,11 @@ class IsGoCacheContext implements CacheContextInterface {
    * {@inheritdoc}
    */
   public function getContext(): string {
-    return $this->goSite->isGoSite() ? '1' : '0';
+    if ($this->goSite->useAbsoluteUrls()) {
+      return 'x';
+    }
+
+    return ($this->goSite->isGoSite() ? '1' : '0');
   }
 
   /**

--- a/web/modules/custom/dpl_go/src/GoSite.php
+++ b/web/modules/custom/dpl_go/src/GoSite.php
@@ -42,7 +42,7 @@ class GoSite {
    * Is the current request considered "the Go site".
    *
    * This is true when the current user is the Go GraphQL consumer user that the
-   * React front-end uses. Which is the only user given the "rewrite go urls"
+   * React front-end uses. Which is the only user given the "use absolute cms urls"
    * permission.
    */
   public function isGoSite(): bool {
@@ -50,7 +50,11 @@ class GoSite {
     // site when they visit the site as the redirect to the front page that's
     // implicit in `/` gets rewritten, so exclude them. Means that user 1 can't
     // use the Go site, but they shouldn't be able to log into it anyway.
-    return $this->currentUser->hasPermission('rewrite go urls') && $this->currentUser->id() != 1;
+    return $this->currentUser->hasPermission('use absolute cms urls') && $this->currentUser->id() != 1;
+  }
+
+  public function useAbsoluteUrls(): bool {
+    return $this->currentUser->hasPermission('use absolute cms and go urls') && $this->currentUser->id() != 1;
   }
 
   /**

--- a/web/modules/custom/dpl_go/src/GoSite.php
+++ b/web/modules/custom/dpl_go/src/GoSite.php
@@ -41,9 +41,9 @@ class GoSite {
   /**
    * Is the current request considered "the Go site".
    *
-   * This is true when the current user is the Go GraphQL consumer user that the
-   * React front-end uses. Which is the only user given the "use absolute cms urls"
-   * permission.
+   * This is true when the current user is the Go GraphQL consumer user that
+   * the React front-end uses. Which is the only user given the
+   * "use absolute cms urls" permission.
    */
   public function isGoSite(): bool {
     // User 1 gets all permissions, but then they'll get redirected to the Go
@@ -53,6 +53,12 @@ class GoSite {
     return $this->currentUser->hasPermission('use absolute cms urls') && $this->currentUser->id() != 1;
   }
 
+  /**
+   * Check if absolute URLs should be used for all content.
+   *
+   * This is for external services that need absolute URLs for both CMS and
+   * Go content, regardless of the normal XOR logic.
+   */
   public function useAbsoluteUrls(): bool {
     return $this->currentUser->hasPermission('use absolute cms and go urls') && $this->currentUser->id() != 1;
   }

--- a/web/modules/custom/dpl_go/src/PathProcessor/OutboundPathProcessor.php
+++ b/web/modules/custom/dpl_go/src/PathProcessor/OutboundPathProcessor.php
@@ -65,7 +65,7 @@ class OutboundPathProcessor implements OutboundPathProcessorInterface {
 
       $isGoNode = $this->goSite->isGoNid($pathParts[2]);
       if (!is_null($isGoNode)) {
-        if ($isGoNode xor $this->goSite->isGoSite()) {
+        if ($this->goSite->useAbsoluteUrls() || ($isGoNode xor $this->goSite->isGoSite())) {
           $options['absolute'] = TRUE;
           $options['base_url'] = $isGoNode ?
             $this->goSite->getGoBaseUrl() :

--- a/web/modules/custom/dpl_go/test/src/Unit/GoSiteTest.php
+++ b/web/modules/custom/dpl_go/test/src/Unit/GoSiteTest.php
@@ -117,13 +117,22 @@ class GoSiteTest extends UnitTestCase {
   public function testGoSiteDetection(): void {
     // Not user 1.
     $this->currentUser->id()->willReturn(12);
-    $this->currentUser->hasPermission('rewrite go urls')->willReturn(TRUE);
+    $this->currentUser->hasPermission('use absolute cms urls')->willReturn(TRUE);
 
     $this->assertTrue($this->goSite->isGoSite());
 
-    $this->currentUser->hasPermission('rewrite go urls')->willReturn(FALSE);
+    $this->currentUser->hasPermission('use absolute cms urls')->willReturn(FALSE);
 
     $this->assertFalse($this->goSite->isGoSite());
+
+    // Test useAbsoluteUrls method.
+    $this->currentUser->hasPermission('use absolute cms and go urls')->willReturn(TRUE);
+
+    $this->assertTrue($this->goSite->useAbsoluteUrls());
+
+    $this->currentUser->hasPermission('use absolute cms and go urls')->willReturn(FALSE);
+
+    $this->assertFalse($this->goSite->useAbsoluteUrls());
   }
 
   /**
@@ -134,7 +143,7 @@ class GoSiteTest extends UnitTestCase {
    */
   public function testSuperUserSiteDetection(): void {
     $this->currentUser->id()->willReturn(1);
-    $this->currentUser->hasPermission('rewrite go urls')->willReturn(TRUE);
+    $this->currentUser->hasPermission('use absolute cms urls')->willReturn(TRUE);
 
     $this->assertFalse($this->goSite->isGoSite());
   }

--- a/web/modules/custom/dpl_go/test/src/Unit/PathProcessor/OutboundPathProcessorTest.php
+++ b/web/modules/custom/dpl_go/test/src/Unit/PathProcessor/OutboundPathProcessorTest.php
@@ -81,6 +81,7 @@ class OutboundPathProcessorTest extends UnitTestCase {
     bool $isGo,
     ?string $expectedBaseUrl,
   ): void {
+    $this->goSite->useAbsoluteUrls()->willReturn(FALSE);
     $this->goSite->isGoSite()->willReturn($isGo);
     $this->goSite->isGoNid($nid)->willReturn($isGoNode);
     $this->goSite->getCmsBaseUrl()->willReturn('https://cms.site');
@@ -146,6 +147,51 @@ class OutboundPathProcessorTest extends UnitTestCase {
 
     $this->assertEquals("/node/{$nid}", $newPath);
     $this->assertArrayNotHasKey('base_url', $options);
+  }
+
+  /**
+   * Test that useAbsoluteUrls forces absolute URLs regardless of XOR logic.
+   * Simulates external users (API consumers) who have the 'use absolute cms and go urls'
+   * permission but are not considered 'Go site' users.
+   *
+   * @dataProvider absoluteUrlCases
+   */
+  public function testUseAbsoluteUrlsForcing(
+    string $nid,
+    bool $isGoNode,
+    string $expectedBaseUrl,
+  ): void {
+    $this->goSite->useAbsoluteUrls()->willReturn(TRUE);
+    $this->goSite->isGoSite()->willReturn(FALSE);
+    $this->goSite->isGoNid($nid)->willReturn($isGoNode);
+    $this->goSite->getCmsBaseUrl()->willReturn('https://cms.site');
+    $this->goSite->getGoBaseUrl()->willReturn('https://go.cms.site');
+
+    $options = [];
+    $newPath = $this->pathProcessor->processOutbound(
+      "/node/{$nid}",
+      $options,
+      new Request(),
+      new BubbleableMetadata(),
+    );
+
+    $this->assertEquals("/node/{$nid}", $newPath);
+    $this->assertArrayHasKey('base_url', $options);
+    $this->assertTrue($options['absolute']);
+    $this->assertEquals($expectedBaseUrl, $options['base_url']);
+  }
+
+  /**
+   * Test cases for testUseAbsoluteUrlsForcing.
+   *
+   * @return array<string, array<string|bool>>
+   *   Array of test cases.
+   */
+  public function absoluteUrlCases(): array {
+    return [
+      'Go node with external user having absolute URLs permission' => ['12', TRUE, 'https://go.cms.site'],
+      'CMS node with external user having absolute URLs permission' => ['12', FALSE, 'https://cms.site'],
+    ];
   }
 
 }

--- a/web/modules/custom/dpl_go/test/src/Unit/PathProcessor/OutboundPathProcessorTest.php
+++ b/web/modules/custom/dpl_go/test/src/Unit/PathProcessor/OutboundPathProcessorTest.php
@@ -151,8 +151,10 @@ class OutboundPathProcessorTest extends UnitTestCase {
 
   /**
    * Test that useAbsoluteUrls forces absolute URLs regardless of XOR logic.
-   * Simulates external users (API consumers) who have the 'use absolute cms and go urls'
-   * permission but are not considered 'Go site' users.
+   *
+   * Simulates external users (API consumers) who have the
+   * 'use absolute cms and go urls' permission but are not considered
+   * 'Go site' users.
    *
    * @dataProvider absoluteUrlCases
    */

--- a/web/modules/custom/dpl_update/dpl_update.deploy.php
+++ b/web/modules/custom/dpl_update/dpl_update.deploy.php
@@ -352,6 +352,19 @@ function dpl_update_deploy_fix_content_view(): string {
 }
 
 /**
+ * Update go_graphql_client role permissions for DDFSAL-332.
+ *
+ * Replace 'rewrite go urls' permission with 'use absolute cms urls'.
+ */
+function dpl_update_deploy_update_go_permissions_ddfsal_332(): string {
+  // Remove the old permission and add the new one.
+  _dpl_update_alter_permissions(['go_graphql_client'], ['rewrite go urls'], FALSE);
+  _dpl_update_alter_permissions(['go_graphql_client'], ['use absolute cms urls'], TRUE);
+
+  return 'Updated go_graphql_client role: removed "rewrite go urls", added "use absolute cms urls".';
+}
+
+/**
  * Find duplicate medias, and hide them in the media library.
  *
  * As part of a bug, all medias pulled from Delingstjenesten/BNF were duplicated


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-332

#### Description

This PR introduces enhanced URL handling functionality to support external GraphQL clients that require absolute URLs for both CMS and Go content. The implementation refactors existing permission structures and extends URL rewriting logic to accommodate different client types.

Key Changes

Permission System Refactoring:
•  Renamed `rewrite go urls` permission to `use absolute cms urls` for better clarity
•  Added new `use absolute cms and go urls` permission for external API consumers
•  Updated `go_graphql_client` role to use the renamed permission
•  Created new `external_graphql_client` role with broader URL permissions

URL Processing Enhancement:
•  Extended `GoSite` service with new `useAbsoluteUrls()` method to handle external client requirements
•  Modified `OutboundPathProcessor` to support absolute URLs for external clients, bypassing the normal XOR logic between CMS and Go content
•  Updated cache context to handle the new URL generation scenarios

User Role Management:
•  Added `external_graphql_client` role with permissions for both GraphQL access and absolute URL usage
•  Created corresponding user action configurations for role management


Testing & Documentation:
•  Added comprehensive unit tests covering the new `useAbsoluteUrls()` functionality
•  Updated existing tests to reflect permission name changes
•  Updated ADR documentation to reflect the new permission naming
•  Added deployment hook to migrate existing permissions

Technical Implementation

The solution maintains backward compatibility while introducing a new permission layer that allows external services to receive absolute URLs for all content types. This addresses scenarios where external API consumers need to reference both CMS and Go content with full URLs, regardless of the traditional site detection logic.


#### Proof of result

https://github.com/user-attachments/assets/1a6fbae0-c598-4882-8c67-32eea86a36aa


AND STILL WORKS FOR `go_graphql`
<img width="1840" height="1191" alt="Skærmbillede 2025-09-05 kl  10 51 43" src="https://github.com/user-attachments/assets/81a9a9e2-8802-438b-bf4e-e86c2c106d8b" />

