### PR TITLE
Flip logic for which paragraphs are allowed on pages and articles.

### DIFF
--- a/config/sync/field.field.node.article.field_paragraphs.yml
+++ b/config/sync/field.field.node.article.field_paragraphs.yml
@@ -5,33 +5,18 @@ dependencies:
   config:
     - field.storage.node.field_paragraphs
     - node.type.article
-    - paragraphs.paragraphs_type.accordion
-    - paragraphs.paragraphs_type.banner
-    - paragraphs.paragraphs_type.breadcrumb_children
-    - paragraphs.paragraphs_type.card_grid_automatic
-    - paragraphs.paragraphs_type.card_grid_manual
-    - paragraphs.paragraphs_type.content_slider
-    - paragraphs.paragraphs_type.content_slider_automatic
-    - paragraphs.paragraphs_type.files
-    - paragraphs.paragraphs_type.filtered_event_list
-    - paragraphs.paragraphs_type.hero
-    - paragraphs.paragraphs_type.language_selector
-    - paragraphs.paragraphs_type.links
-    - paragraphs.paragraphs_type.manual_event_list
-    - paragraphs.paragraphs_type.material_grid_automatic
-    - paragraphs.paragraphs_type.material_grid_link_automatic
-    - paragraphs.paragraphs_type.material_grid_manual
-    - paragraphs.paragraphs_type.medias
-    - paragraphs.paragraphs_type.nav_grid_manual
-    - paragraphs.paragraphs_type.nav_spots_manual
-    - paragraphs.paragraphs_type.recommendation
-    - paragraphs.paragraphs_type.simple_links
-    - paragraphs.paragraphs_type.text_body
-    - paragraphs.paragraphs_type.user_registration_item
-    - paragraphs.paragraphs_type.user_registration_linklist
-    - paragraphs.paragraphs_type.user_registration_section
-    - paragraphs.paragraphs_type.video
-    - paragraphs.paragraphs_type.webform
+    - paragraphs.paragraphs_type.campaign_rule
+    - paragraphs.paragraphs_type.event_ticket_category
+    - paragraphs.paragraphs_type.go_images
+    - paragraphs.paragraphs_type.go_link
+    - paragraphs.paragraphs_type.go_linkbox
+    - paragraphs.paragraphs_type.go_material_slider_automatic
+    - paragraphs.paragraphs_type.go_material_slider_manual
+    - paragraphs.paragraphs_type.go_text_body
+    - paragraphs.paragraphs_type.go_video
+    - paragraphs.paragraphs_type.go_video_bundle_automatic
+    - paragraphs.paragraphs_type.go_video_bundle_manual
+    - paragraphs.paragraphs_type.opening_hours
   module:
     - entity_reference_revisions
 id: node.article.field_paragraphs
@@ -48,150 +33,135 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      text_body: text_body
-      links: links
-      medias: medias
-      accordion: accordion
-      card_grid_automatic: card_grid_automatic
-      card_grid_manual: card_grid_manual
-      content_slider: content_slider
-      files: files
-      hero: hero
-      language_selector: language_selector
-      material_grid_automatic: material_grid_automatic
-      material_grid_manual: material_grid_manual
-      banner: banner
-      nav_grid_manual: nav_grid_manual
-      breadcrumb_children: breadcrumb_children
-      nav_spots_manual: nav_spots_manual
-      recommendation: recommendation
-      user_registration_item: user_registration_item
-      content_slider_automatic: content_slider_automatic
-      user_registration_section: user_registration_section
-      video: video
-      filtered_event_list: filtered_event_list
-      manual_event_list: manual_event_list
-      simple_links: simple_links
-      material_grid_link_automatic: material_grid_link_automatic
-      user_registration_linklist: user_registration_linklist
-      webform: webform
-    negate: 0
+      campaign_rule: campaign_rule
+      event_ticket_category: event_ticket_category
+      opening_hours: opening_hours
+      go_linkbox: go_linkbox
+      go_material_slider_automatic: go_material_slider_automatic
+      go_material_slider_manual: go_material_slider_manual
+      go_video: go_video
+      go_video_bundle_automatic: go_video_bundle_automatic
+      go_link: go_link
+      go_video_bundle_manual: go_video_bundle_manual
+      go_images: go_images
+      go_text_body: go_text_body
+    negate: 1
     target_bundles_drag_drop:
       accordion:
         weight: 22
-        enabled: true
+        enabled: false
       banner:
         weight: 35
-        enabled: true
+        enabled: false
       breadcrumb_children:
         weight: 36
-        enabled: true
+        enabled: false
       campaign_rule:
         weight: 2
-        enabled: false
+        enabled: true
       card_grid_automatic:
         weight: 24
-        enabled: true
+        enabled: false
       card_grid_manual:
         weight: 25
-        enabled: true
+        enabled: false
       content_slider:
         weight: 26
-        enabled: true
+        enabled: false
       content_slider_automatic:
         weight: 41
-        enabled: true
+        enabled: false
       event_ticket_category:
         weight: 7
-        enabled: false
+        enabled: true
       files:
         weight: 28
-        enabled: true
+        enabled: false
       filtered_event_list:
         weight: 44
-        enabled: true
+        enabled: false
       go_images:
         weight: 51
-        enabled: false
+        enabled: true
       go_link:
         weight: 50
-        enabled: false
+        enabled: true
       go_linkbox:
         weight: 45
-        enabled: false
+        enabled: true
       go_material_slider_automatic:
         weight: 46
-        enabled: false
+        enabled: true
       go_material_slider_manual:
         weight: 47
-        enabled: false
+        enabled: true
       go_text_body:
         weight: 54
-        enabled: false
+        enabled: true
       go_video:
         weight: 48
-        enabled: false
+        enabled: true
       go_video_bundle_automatic:
         weight: 49
-        enabled: false
+        enabled: true
       go_video_bundle_manual:
         weight: 50
-        enabled: false
+        enabled: true
       hero:
         weight: 29
-        enabled: true
+        enabled: false
       language_selector:
         weight: 30
-        enabled: true
+        enabled: false
       links:
         weight: 8
-        enabled: true
+        enabled: false
       manual_event_list:
         weight: 52
-        enabled: true
+        enabled: false
       material_grid_automatic:
         weight: 32
-        enabled: true
+        enabled: false
       material_grid_link_automatic:
         weight: 63
-        enabled: true
+        enabled: false
       material_grid_manual:
         weight: 33
-        enabled: true
+        enabled: false
       medias:
         weight: 9
-        enabled: true
+        enabled: false
       nav_grid_manual:
         weight: 35
-        enabled: true
+        enabled: false
       nav_spots_manual:
         weight: 36
-        enabled: true
+        enabled: false
       opening_hours:
         weight: 37
-        enabled: false
+        enabled: true
       recommendation:
         weight: 38
-        enabled: true
+        enabled: false
       simple_links:
         weight: 60
-        enabled: true
+        enabled: false
       text_body:
         weight: 4
-        enabled: true
+        enabled: false
       user_registration_item:
         weight: 40
-        enabled: true
+        enabled: false
       user_registration_linklist:
         weight: 63
-        enabled: true
+        enabled: false
       user_registration_section:
         weight: 41
-        enabled: true
+        enabled: false
       video:
         weight: 42
-        enabled: true
+        enabled: false
       webform:
         weight: 66
-        enabled: true
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/sync/field.field.node.page.field_paragraphs.yml
+++ b/config/sync/field.field.node.page.field_paragraphs.yml
@@ -5,33 +5,18 @@ dependencies:
   config:
     - field.storage.node.field_paragraphs
     - node.type.page
-    - paragraphs.paragraphs_type.accordion
-    - paragraphs.paragraphs_type.banner
-    - paragraphs.paragraphs_type.breadcrumb_children
-    - paragraphs.paragraphs_type.card_grid_automatic
-    - paragraphs.paragraphs_type.card_grid_manual
-    - paragraphs.paragraphs_type.content_slider
-    - paragraphs.paragraphs_type.content_slider_automatic
-    - paragraphs.paragraphs_type.files
-    - paragraphs.paragraphs_type.filtered_event_list
-    - paragraphs.paragraphs_type.hero
-    - paragraphs.paragraphs_type.language_selector
-    - paragraphs.paragraphs_type.links
-    - paragraphs.paragraphs_type.manual_event_list
-    - paragraphs.paragraphs_type.material_grid_automatic
-    - paragraphs.paragraphs_type.material_grid_link_automatic
-    - paragraphs.paragraphs_type.material_grid_manual
-    - paragraphs.paragraphs_type.medias
-    - paragraphs.paragraphs_type.nav_grid_manual
-    - paragraphs.paragraphs_type.nav_spots_manual
-    - paragraphs.paragraphs_type.recommendation
-    - paragraphs.paragraphs_type.simple_links
-    - paragraphs.paragraphs_type.text_body
-    - paragraphs.paragraphs_type.user_registration_item
-    - paragraphs.paragraphs_type.user_registration_linklist
-    - paragraphs.paragraphs_type.user_registration_section
-    - paragraphs.paragraphs_type.video
-    - paragraphs.paragraphs_type.webform
+    - paragraphs.paragraphs_type.campaign_rule
+    - paragraphs.paragraphs_type.event_ticket_category
+    - paragraphs.paragraphs_type.go_images
+    - paragraphs.paragraphs_type.go_link
+    - paragraphs.paragraphs_type.go_linkbox
+    - paragraphs.paragraphs_type.go_material_slider_automatic
+    - paragraphs.paragraphs_type.go_material_slider_manual
+    - paragraphs.paragraphs_type.go_text_body
+    - paragraphs.paragraphs_type.go_video
+    - paragraphs.paragraphs_type.go_video_bundle_automatic
+    - paragraphs.paragraphs_type.go_video_bundle_manual
+    - paragraphs.paragraphs_type.opening_hours
   module:
     - entity_reference_revisions
 id: node.page.field_paragraphs
@@ -48,150 +33,135 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      text_body: text_body
-      links: links
-      medias: medias
-      card_grid_automatic: card_grid_automatic
-      card_grid_manual: card_grid_manual
-      content_slider: content_slider
-      files: files
-      video: video
-      accordion: accordion
-      hero: hero
-      language_selector: language_selector
-      material_grid_automatic: material_grid_automatic
-      material_grid_manual: material_grid_manual
-      banner: banner
-      nav_grid_manual: nav_grid_manual
-      breadcrumb_children: breadcrumb_children
-      nav_spots_manual: nav_spots_manual
-      recommendation: recommendation
-      user_registration_item: user_registration_item
-      content_slider_automatic: content_slider_automatic
-      user_registration_section: user_registration_section
-      filtered_event_list: filtered_event_list
-      manual_event_list: manual_event_list
-      simple_links: simple_links
-      material_grid_link_automatic: material_grid_link_automatic
-      user_registration_linklist: user_registration_linklist
-      webform: webform
-    negate: 0
+      campaign_rule: campaign_rule
+      event_ticket_category: event_ticket_category
+      opening_hours: opening_hours
+      go_linkbox: go_linkbox
+      go_material_slider_automatic: go_material_slider_automatic
+      go_material_slider_manual: go_material_slider_manual
+      go_video: go_video
+      go_video_bundle_automatic: go_video_bundle_automatic
+      go_link: go_link
+      go_video_bundle_manual: go_video_bundle_manual
+      go_images: go_images
+      go_text_body: go_text_body
+    negate: 1
     target_bundles_drag_drop:
       accordion:
         weight: 22
-        enabled: true
+        enabled: false
       banner:
         weight: 35
-        enabled: true
+        enabled: false
       breadcrumb_children:
         weight: 36
-        enabled: true
+        enabled: false
       campaign_rule:
         weight: 2
-        enabled: false
+        enabled: true
       card_grid_automatic:
         weight: 12
-        enabled: true
+        enabled: false
       card_grid_manual:
         weight: 13
-        enabled: true
+        enabled: false
       content_slider:
         weight: 14
-        enabled: true
+        enabled: false
       content_slider_automatic:
         weight: 41
-        enabled: true
+        enabled: false
       event_ticket_category:
         weight: 7
-        enabled: false
+        enabled: true
       files:
         weight: 16
-        enabled: true
+        enabled: false
       filtered_event_list:
         weight: 44
-        enabled: true
+        enabled: false
       go_images:
         weight: 51
-        enabled: false
+        enabled: true
       go_link:
         weight: 50
-        enabled: false
+        enabled: true
       go_linkbox:
         weight: 45
-        enabled: false
+        enabled: true
       go_material_slider_automatic:
         weight: 46
-        enabled: false
+        enabled: true
       go_material_slider_manual:
         weight: 47
-        enabled: false
+        enabled: true
       go_text_body:
         weight: 54
-        enabled: false
+        enabled: true
       go_video:
         weight: 48
-        enabled: false
+        enabled: true
       go_video_bundle_automatic:
         weight: 49
-        enabled: false
+        enabled: true
       go_video_bundle_manual:
         weight: 50
-        enabled: false
+        enabled: true
       hero:
         weight: 29
-        enabled: true
+        enabled: false
       language_selector:
         weight: 30
-        enabled: true
+        enabled: false
       links:
         weight: 8
-        enabled: true
+        enabled: false
       manual_event_list:
         weight: 52
-        enabled: true
+        enabled: false
       material_grid_automatic:
         weight: 32
-        enabled: true
+        enabled: false
       material_grid_link_automatic:
         weight: 63
-        enabled: true
+        enabled: false
       material_grid_manual:
         weight: 33
-        enabled: true
+        enabled: false
       medias:
         weight: 9
-        enabled: true
+        enabled: false
       nav_grid_manual:
         weight: 35
-        enabled: true
+        enabled: false
       nav_spots_manual:
         weight: 36
-        enabled: true
+        enabled: false
       opening_hours:
         weight: 37
-        enabled: false
+        enabled: true
       recommendation:
         weight: 38
-        enabled: true
+        enabled: false
       simple_links:
         weight: 60
-        enabled: true
+        enabled: false
       text_body:
         weight: 4
-        enabled: true
+        enabled: false
       user_registration_item:
         weight: 40
-        enabled: true
+        enabled: false
       user_registration_linklist:
         weight: 63
-        enabled: true
+        enabled: false
       user_registration_section:
         weight: 41
-        enabled: true
+        enabled: false
       video:
         weight: 20
-        enabled: true
+        enabled: false
       webform:
         weight: 66
-        enabled: true
+        enabled: false
 field_type: entity_reference_revisions


### PR DESCRIPTION
This allows webmaster modules to create their own paragraphs for these pages, without having to touch the config export. We want to avoid webmaster modules affecting config-export when possible, to avoid them losing access to core updates.

