### PR TITLE
Ddfsal 352 info box

### DIFF
--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -184,6 +184,36 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('opening_hours_url') ?? GeneralSettings::OPENING_HOURS_URL,
     ];
 
+    $form['search'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Search', [], ['context' => 'Library Agency Configuration']),
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $form['search']['search_infobox'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Search Info Box', [], ['context' => 'Library Agency Configuration']),
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $form['search']['search_infobox']['search_infobox_title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Title', [], ['context' => 'Library Agency Configuration']),
+      '#default_value' => $config->get('search_infobox_title') ?? GeneralSettings::SEARCH_INFOBOX_TITLE,
+      '#description' => $this->t('The title of the search info box.', [], ['context' => 'Library Agency Configuration']),
+    ];
+
+    $form['search']['search_infobox']['search_infobox_content'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Content', [], ['context' => 'Library Agency Configuration']),
+      '#format' => 'limited',
+      '#allowed_formats' => ['limited'],
+      '#default_value' => $config->get('search_infobox_content.value') ?? json_decode(GeneralSettings::SEARCH_INFOBOX_CONTENT, true)['value'],
+      '#description' => $this->t('The content of the search info box.', [], ['context' => 'Library Agency Configuration']),
+    ];
+
     $form['find_on_shelf'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Find on shelf', [], ['context' => 'Library Agency Configuration']),
@@ -339,6 +369,8 @@ class GeneralSettingsForm extends ConfigFormBase {
         'local' => $form_state->getValue('fbi_profile_local'),
         'global' => $form_state->getValue('fbi_profile_global'),
       ])
+      ->set('search_infobox_title', $form_state->getValue('search_infobox_title'))
+      ->set('search_infobox_content', $form_state->getValue('search_infobox_content'))
       ->save();
 
     $this->branchSettings->setExcludedAvailabilityBranches(array_filter($form_state->getValue('availability')));

--- a/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/dpl_library_agency/src/Form/GeneralSettingsForm.php
@@ -214,6 +214,13 @@ class GeneralSettingsForm extends ConfigFormBase {
       '#description' => $this->t('The content of the search info box.', [], ['context' => 'Library Agency Configuration']),
     ];
 
+    $form['search']['search_infobox']['search_infobox_button_text'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Button text', [], ['context' => 'Library Agency Configuration']),
+      '#default_value' => $config->get('search_infobox_button_text') ?? GeneralSettings::SEARCH_INFOBOX_BUTTON_TEXT,
+      '#description' => $this->t('The text of the button in the search info box.', [], ['context' => 'Library Agency Configuration']),
+    ];
+
     $form['find_on_shelf'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Find on shelf', [], ['context' => 'Library Agency Configuration']),
@@ -371,6 +378,7 @@ class GeneralSettingsForm extends ConfigFormBase {
       ])
       ->set('search_infobox_title', $form_state->getValue('search_infobox_title'))
       ->set('search_infobox_content', $form_state->getValue('search_infobox_content'))
+      ->set('search_infobox_button_text', $form_state->getValue('search_infobox_button_text'))
       ->save();
 
     $this->branchSettings->setExcludedAvailabilityBranches(array_filter($form_state->getValue('availability')));

--- a/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
@@ -23,6 +23,8 @@ class GeneralSettings extends DplReactConfigBase {
   const FBI_PROFILE = 'next';
   const OPENING_HOURS_URL = '/branches';
   const FIND_ON_SHELF_DISCLOSURES_DEFAULT_OPEN = FALSE;
+  const SEARCH_INFOBOX_TITLE = '';
+  const SEARCH_INFOBOX_CONTENT = '{"value":"","format":"limited"}';
 
   /**
    * Gets the configuration key for general settings.

--- a/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
+++ b/web/modules/custom/dpl_library_agency/src/GeneralSettings.php
@@ -25,6 +25,7 @@ class GeneralSettings extends DplReactConfigBase {
   const FIND_ON_SHELF_DISCLOSURES_DEFAULT_OPEN = FALSE;
   const SEARCH_INFOBOX_TITLE = '';
   const SEARCH_INFOBOX_CONTENT = '{"value":"","format":"limited"}';
+  const SEARCH_INFOBOX_BUTTON_TEXT = '';
 
   /**
    * Gets the configuration key for general settings.

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -120,6 +120,7 @@ class DplReactAppsController extends ControllerBase {
       'search-infobox-config' => json_encode([
         'title' => $this->generalSettings->loadConfig()->get('search_infobox_title'),
         'content' => $this->generalSettings->loadConfig()->get('search_infobox_content'),
+        'buttonText' => $this->generalSettings->loadConfig()->get('search_infobox_button_text'),
       ]),
       // Dynamic values, set through preprocess.
       'web-search-config' => json_encode([

--- a/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
+++ b/web/modules/custom/dpl_react_apps/src/Controller/DplReactAppsController.php
@@ -117,6 +117,10 @@ class DplReactAppsController extends ControllerBase {
       'blacklisted-availability-branches-config' => $this->buildBranchesListProp($this->branchSettings->getExcludedAvailabilityBranches()),
       'blacklisted-search-branches-config' => $this->buildBranchesListProp($this->branchSettings->getExcludedSearchBranches()),
       'branches-config' => $this->buildBranchesJsonProp($this->branchRepository->getBranches()),
+      'search-infobox-config' => json_encode([
+        'title' => $this->generalSettings->loadConfig()->get('search_infobox_title'),
+        'content' => $this->generalSettings->loadConfig()->get('search_infobox_content'),
+      ]),
       // Dynamic values, set through preprocess.
       'web-search-config' => json_encode([
         'hasWebSearchResults' => FALSE,


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-352

#### Description

This PR introduces a new component called CardListInfoBox.tsx. Which is shown in as the first element when users are loading additional search result. 

desktop:
<img width="1183" height="605" alt="Screenshot 2025-09-24 at 15 33 23" src="https://github.com/user-attachments/assets/5cb4d2ba-a7a4-4c8c-aaee-c30768df92ad" />

mobile:
<img width="474" height="572" alt="Screenshot 2025-09-24 at 20 39 22" src="https://github.com/user-attachments/assets/fb76facf-8431-4938-a046-87856ba9055d" />