### PR TITLE
Fix nid/vid mixup in new content producer

### DIFF
--- a/web/modules/custom/bnf/bnf_server/src/Plugin/GraphQL/DataProducer/NewContentProducer.php
+++ b/web/modules/custom/bnf/bnf_server/src/Plugin/GraphQL/DataProducer/NewContentProducer.php
@@ -88,7 +88,7 @@ class NewContentProducer extends DataProducerPluginBase implements ContainerFact
     $nids = $query->accessCheck()->execute();
 
     /** @var \Drupal\node\Entity\Node[] $nodes */
-    $nodes = $this->nodeStorage->loadMultiple(array_keys($nids));
+    $nodes = $this->nodeStorage->loadMultiple(array_values($nids));
 
     if ($nodes) {
       $result->uuids = array_map(fn ($node) => (string) $node->uuid(), $nodes);


### PR DESCRIPTION
#### Link to issue

DDFSAL-417 probably.

#### Description

EntityQuery returns an array of `vid => nid` mappings. This is, imho, counterintuitive. But the upshot of the mixup is that the NewContent producer was using `vid` where it should use `nid`, which obviously resulted in the wrong nodes being loaded.

The reason why we didn't discover this earlier is that without revisions, `vid` and `nid` is in sync. But something has done something on BNF, so now `nid` 514 has `vid` 510 (which doesn't make sense, but anyhoo).