### PR TITLE
DDFSAL-554 - Return original images in Event API

### DIFF
--- a/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
+++ b/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
@@ -368,7 +368,7 @@ class EventRestMapper {
    * Getting the main, original image.
    */
   private function getImage(): ?EventsGET200ResponseInnerImage {
-    $url = $this->getImageUrl('event_image', 'paragraph_wide');
+    $url = $this->getImageUrl('event_image', NULL);
 
     if (empty($url)) {
       return NULL;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-554


#### Test
https://varnish.pr-2968.dpl-cms.dplplat01.dpl.reload.dk/api/v1/events

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2968

#### Description
Problem

The Event API was applying the paragraph_wide image style (896x670px crop) to the main image field, but the API specification requires "the original, unaltered file" with preserved aspect ratio. This caused issues for libraries using images on info screens where they couldn't predict dimensions or aspect ratios.

Solution

Changed EventRestMapper::getImage() to return the original file instead of the cropped version by passing NULL as the image style parameter.

Before:
```
"image": {"url": ".../styles/paragraph_wide/public/.../image.jpg"}  // 896x670 (cropped)
```

After:

```
"image": {"url": ".../files/.../image.jpg"}  // Original size & aspect ratio
```


The teaserImage field continues to use the styled version as intended.