### PR TITLE
Add availability-available-physical text key for physical materials

### DIFF
--- a/web/modules/custom/dpl_react_apps/dpl_react_apps.module
+++ b/web/modules/custom/dpl_react_apps/dpl_react_apps.module
@@ -65,6 +65,7 @@ function dpl_react_apps_texts(): array {
     'autosuggest-game-category' => t('Games', [], ['context' => 'Global']),
     'autosuggest-music-category' => t('Music', [], ['context' => 'Global']),
     'availability-available' => t('Available', [], ['context' => 'Global']),
+    'availability-available-physical' => t('At home', [], ['context' => 'Global']),
     'availability-unavailable' => t('Unavailable', [], ['context' => 'Global']),
     'by-author' => t('by', [], ['context' => 'Global']),
     'change-interest-period' => t('Change interest period', [], ['context' => 'Global']),

--- a/web/profiles/dpl_cms/translations/da.combined.po
+++ b/web/profiles/dpl_cms/translations/da.combined.po
@@ -251,6 +251,11 @@ msgctxt "Global"
 msgid "Available"
 msgstr "Tilgængelig"
 
+#: 
+msgctxt "Global"
+msgid "At home"
+msgstr "Hjemme"
+
 msgctxt "Global"
 msgid "Unavailable"
 msgstr "Udlånt"

--- a/web/profiles/dpl_cms/translations/da.po
+++ b/web/profiles/dpl_cms/translations/da.po
@@ -2022,6 +2022,10 @@ msgid "Available"
 msgstr "Tilgængelig"
 
 msgctxt "Global"
+msgid "At home"
+msgstr "Hjemme"
+
+msgctxt "Global"
 msgid "Unavailable"
 msgstr "Udlånt"
 


### PR DESCRIPTION
Adds new translation key for physical material availability label.



#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-488
