### PR TITLE
Event - show address fields by default. DDF-95

### DIFF
--- a/config/sync/core.entity_form_display.eventinstance.default.default.yml
+++ b/config/sync/core.entity_form_display.eventinstance.default.default.yml
@@ -336,7 +336,7 @@ content:
     region: content
     settings:
       size: 60
-      placeholder: ''
+      placeholder: 'E.g. a specific room such as “meeting room 1” or “4. floor”.'
     third_party_settings: {  }
   field_event_state:
     type: select2

--- a/config/sync/core.entity_form_display.eventseries.default.default.yml
+++ b/config/sync/core.entity_form_display.eventseries.default.default.yml
@@ -363,7 +363,7 @@ content:
     region: content
     settings:
       size: 60
-      placeholder: ''
+      placeholder: 'E.g. a specific room such as “meeting room 1” or “4. floor”.'
     third_party_settings: {  }
   field_event_state:
     type: select2

--- a/config/sync/field.field.eventinstance.default.field_event_address.yml
+++ b/config/sync/field.field.eventinstance.default.field_event_address.yml
@@ -15,7 +15,22 @@ label: Address
 description: 'Use this value to specific a different address than the event branch.'
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    langcode: en
+    country_code: DK
+    administrative_area: null
+    locality: ''
+    dependent_locality: null
+    postal_code: ''
+    sorting_code: null
+    address_line1: ''
+    address_line2: null
+    address_line3: ''
+    organization: null
+    given_name: null
+    additional_name: null
+    family_name: null
 default_value_callback: ''
 settings:
   available_countries:
@@ -33,12 +48,20 @@ settings:
       override: hidden
     organization:
       override: hidden
+    addressLine1:
+      override: optional
     addressLine2:
       override: hidden
+    addressLine3:
+      override: optional
+    postalCode:
+      override: optional
     sortingCode:
       override: hidden
     dependentLocality:
       override: hidden
+    locality:
+      override: optional
     administrativeArea:
       override: hidden
   fields: {  }

--- a/config/sync/field.field.eventseries.default.field_event_address.yml
+++ b/config/sync/field.field.eventseries.default.field_event_address.yml
@@ -15,7 +15,22 @@ label: Address
 description: 'Use this value to specific a different address than the event branch.'
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    langcode: en
+    country_code: DK
+    administrative_area: null
+    locality: ''
+    dependent_locality: null
+    postal_code: ''
+    sorting_code: null
+    address_line1: ''
+    address_line2: null
+    address_line3: ''
+    organization: null
+    given_name: null
+    additional_name: null
+    family_name: null
 default_value_callback: ''
 settings:
   available_countries:
@@ -33,12 +48,20 @@ settings:
       override: hidden
     organization:
       override: hidden
+    addressLine1:
+      override: optional
     addressLine2:
       override: hidden
+    addressLine3:
+      override: optional
+    postalCode:
+      override: optional
     sortingCode:
       override: hidden
     dependentLocality:
       override: hidden
+    locality:
+      override: optional
     administrativeArea:
       override: hidden
   fields: {  }

--- a/web/modules/custom/dpl_event/dpl_event.module
+++ b/web/modules/custom/dpl_event/dpl_event.module
@@ -76,7 +76,7 @@ function dpl_event_entity_presave(EntityInterface $entity): void {
     }
 
     if ($entity->hasField('field_event_address')) {
-      $entity->set('field_event_address', []);
+      $entity->set('field_event_address', ['country_code' => 'DK']);
     }
   }
 }


### PR DESCRIPTION
Update the event editing flow, so the address fields are always shown when relevant - but don't force the user to fill it out. We set the country to Denmark by default.

