### PR TITLE
Event API: Expose original image + tweak scaled. DDF-21

### DIFF
--- a/config/sync/image.style.event_api_scaled.yml
+++ b/config/sync/image.style.event_api_scaled.yml
@@ -1,0 +1,15 @@
+uuid: 0474a103-4e71-4ee0-99af-55354fe503fa
+langcode: en
+status: true
+dependencies: {  }
+name: event_api_scaled
+label: 'Event API scaled (1920x?)'
+effects:
+  e7d131d5-e6a9-42b5-ac48-078f6e3c0382:
+    uuid: e7d131d5-e6a9-42b5-ac48-078f6e3c0382
+    id: image_scale
+    weight: 1
+    data:
+      width: 1920
+      height: null
+      upscale: true

--- a/openapi.json
+++ b/openapi.json
@@ -932,7 +932,19 @@
                   },
                   "image": {
                     "type": "object",
-                    "description": "The main image for the event.",
+                    "description": "The main image for the event. (Scaled)",
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "An absolute URL for the image. This is a link to a scaled version of the original image - the width will always be 1920px, but height/aspect ratio will vary."
+                      }
+                    },
+                    "required": ["url"]
+                  },
+                  "originalImage": {
+                    "type": "object",
+                    "description": "The main image for the event. (Original source)",
                     "properties": {
                       "url": {
                         "type": "string",

--- a/packages/cms-api/.openapi-generator/FILES
+++ b/packages/cms-api/.openapi-generator/FILES
@@ -12,6 +12,7 @@ Model/EventsGET200ResponseInner.php
 Model/EventsGET200ResponseInnerAddress.php
 Model/EventsGET200ResponseInnerDateTime.php
 Model/EventsGET200ResponseInnerImage.php
+Model/EventsGET200ResponseInnerOriginalImage.php
 Model/EventsGET200ResponseInnerSeries.php
 Model/EventsGET200ResponseInnerTeaserImage.php
 Model/EventsGET200ResponseInnerTicketCategoriesInner.php

--- a/packages/cms-api/Model/EventsGET200ResponseInner.php
+++ b/packages/cms-api/Model/EventsGET200ResponseInner.php
@@ -127,6 +127,14 @@ class EventsGET200ResponseInner
     protected ?EventsGET200ResponseInnerImage $image = null;
 
     /**
+     * @var EventsGET200ResponseInnerOriginalImage|null
+     * @SerializedName("originalImage")
+     * @Assert\Type("DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerOriginalImage")
+     * @Type("DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerOriginalImage")
+     */
+    protected ?EventsGET200ResponseInnerOriginalImage $originalImage = null;
+
+    /**
      * @var EventsGET200ResponseInnerTeaserImage|null
      * @SerializedName("teaserImage")
      * @Assert\Type("DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerTeaserImage")
@@ -297,6 +305,7 @@ class EventsGET200ResponseInner
             $this->updatedAt = array_key_exists('updatedAt', $data) ? $data['updatedAt'] : $this->updatedAt;
             $this->ticketManagerRelevance = array_key_exists('ticketManagerRelevance', $data) ? $data['ticketManagerRelevance'] : $this->ticketManagerRelevance;
             $this->image = array_key_exists('image', $data) ? $data['image'] : $this->image;
+            $this->originalImage = array_key_exists('originalImage', $data) ? $data['originalImage'] : $this->originalImage;
             $this->teaserImage = array_key_exists('teaserImage', $data) ? $data['teaserImage'] : $this->teaserImage;
             $this->state = array_key_exists('state', $data) ? $data['state'] : $this->state;
             $this->allDay = array_key_exists('allDay', $data) ? $data['allDay'] : $this->allDay;
@@ -519,6 +528,32 @@ class EventsGET200ResponseInner
     public function setImage(?EventsGET200ResponseInnerImage $image = null): self
     {
         $this->image = $image;
+
+        return $this;
+    }
+
+    /**
+     * Gets originalImage.
+     *
+     * @return EventsGET200ResponseInnerOriginalImage|null
+     */
+    public function getOriginalImage(): ?EventsGET200ResponseInnerOriginalImage
+    {
+        return $this->originalImage;
+    }
+
+
+
+    /**
+     * Sets originalImage.
+     *
+     * @param EventsGET200ResponseInnerOriginalImage|null $originalImage
+     *
+     * @return $this
+     */
+    public function setOriginalImage(?EventsGET200ResponseInnerOriginalImage $originalImage = null): self
+    {
+        $this->originalImage = $originalImage;
 
         return $this;
     }

--- a/packages/cms-api/Model/EventsGET200ResponseInnerOriginalImage.php
+++ b/packages/cms-api/Model/EventsGET200ResponseInnerOriginalImage.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * EventsGET200ResponseInnerImage
+ * EventsGET200ResponseInnerOriginalImage
  *
  * PHP version 8.1.1
  *
@@ -35,18 +35,18 @@ use JMS\Serializer\Annotation\Accessor;
 use JMS\Serializer\Annotation\SerializedName;
 
 /**
- * Class representing the EventsGET200ResponseInnerImage model.
+ * Class representing the EventsGET200ResponseInnerOriginalImage model.
  *
- * The main image for the event. (Scaled)
+ * The main image for the event. (Original source)
  *
  * @package DanskernesDigitaleBibliotek\CMS\Api\Model
  * @author  OpenAPI Generator team
  */
 
-class EventsGET200ResponseInnerImage 
+class EventsGET200ResponseInnerOriginalImage 
 {
         /**
-     * An absolute URL for the image. This is a link to a scaled version of the original image - the width will always be 1920px, but height/aspect ratio will vary.
+     * An absolute URL for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event.
      *
      * @var string|null
      * @SerializedName("url")
@@ -82,7 +82,7 @@ class EventsGET200ResponseInnerImage
     /**
      * Sets url.
      *
-     * @param string|null $url  An absolute URL for the image. This is a link to a scaled version of the original image - the width will always be 1920px, but height/aspect ratio will vary.
+     * @param string|null $url  An absolute URL for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event.
      *
      * @return $this
      */

--- a/packages/cms-api/README.md
+++ b/packages/cms-api/README.md
@@ -157,6 +157,7 @@ Class | Method | HTTP request | Description
  - [EventsGET200ResponseInnerAddress](docs/Model/EventsGET200ResponseInnerAddress.md)
  - [EventsGET200ResponseInnerDateTime](docs/Model/EventsGET200ResponseInnerDateTime.md)
  - [EventsGET200ResponseInnerImage](docs/Model/EventsGET200ResponseInnerImage.md)
+ - [EventsGET200ResponseInnerOriginalImage](docs/Model/EventsGET200ResponseInnerOriginalImage.md)
  - [EventsGET200ResponseInnerSeries](docs/Model/EventsGET200ResponseInnerSeries.md)
  - [EventsGET200ResponseInnerTeaserImage](docs/Model/EventsGET200ResponseInnerTeaserImage.md)
  - [EventsGET200ResponseInnerTicketCategoriesInner](docs/Model/EventsGET200ResponseInnerTicketCategoriesInner.md)

--- a/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
+++ b/web/modules/custom/dpl_event/src/Plugin/rest/resource/v1/EventsResource.php
@@ -86,7 +86,19 @@ final class EventsResource extends EventResourceBase {
                   ],
                   'image' => [
                     'type' => 'object',
-                    'description' => 'The main image for the event.',
+                    'description' => 'The main image for the event. (Scaled)',
+                    'properties' => [
+                      'url' => [
+                        'type' => 'string',
+                        'format' => 'uri',
+                        'description' => 'An absolute URL for the image. This is a link to a scaled version of the original image - the width will always be 1920px, but height/aspect ratio will vary.',
+                      ],
+                    ],
+                    'required' => ['url'],
+                  ],
+                  'originalImage' => [
+                    'type' => 'object',
+                    'description' => 'The main image for the event. (Original source)',
                     'properties' => [
                       'url' => [
                         'type' => 'string',

--- a/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
+++ b/web/modules/custom/dpl_event/src/Services/EventRestMapper.php
@@ -7,6 +7,7 @@ use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInner;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerAddress;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerDateTime;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerImage;
+use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerOriginalImage;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerSeries;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerTeaserImage;
 use DanskernesDigitaleBibliotek\CMS\Api\Model\EventsGET200ResponseInnerTicketCategoriesInner;
@@ -58,6 +59,7 @@ class EventRestMapper {
       'body' => $this->event->getDescription(),
       'state' => $this->event->getState()?->value,
       'image' => $this->getImage(),
+      'originalImage' => $this->getOriginalImage(),
       'teaserImage' => $this->getTeaserImage(),
       'branches' => $this->getBranches(),
       'address' => $this->getAddress(),
@@ -372,16 +374,29 @@ class EventRestMapper {
   }
 
   /**
-   * Getting the main, original image.
+   * Getting the main image (scaled).
    */
   private function getImage(): ?EventsGET200ResponseInnerImage {
-    $url = $this->getImageUrl('event_image', 'paragraph_wide');
+    $url = $this->getImageUrl('event_image', 'event_api_scaled');
 
     if (empty($url)) {
       return NULL;
     }
 
     return new EventsGET200ResponseInnerImage(['url' => $url]);
+  }
+
+  /**
+   * Getting the main image (original).
+   */
+  private function getOriginalImage(): ?EventsGET200ResponseInnerOriginalImage {
+    $url = $this->getImageUrl('event_image');
+
+    if (empty($url)) {
+      return NULL;
+    }
+
+    return new EventsGET200ResponseInnerOriginalImage(['url' => $url]);
   }
 
   /**


### PR DESCRIPTION
- Updates the current "image" property, to return a 1920x?? size image. This matches the documentation, that mentions that it is what is expected.
I'm pretty sure it is a mistake that it was sent along as a locked aspect ratio until now.

- Exposes the original image as a specific property - we expose it as a seperate property, as we would prefer third parties to use the scaled version instead, as the original images can be *very* large.

